### PR TITLE
Add automated Profile Update workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ SF_CLIENT_SECRET=
 # Optional: Salesforce org URL or full OAuth token endpoint. The production
 # default is https://login.salesforce.com/services/oauth2/token.
 SF_LOGIN_URL=
+
+# Non-secret Salesforce IDs required by the profile-updates command.
+CERTIFICATION_QUEUE_ID=00Gf2000005cagqEAA
+PRIMARY_RESPONDER_ID=005f200000A06i6AAB

--- a/README.md
+++ b/README.md
@@ -8,46 +8,85 @@ Clone the repository, then install the project and its dependencies:
 uv sync
 ```
 
-## Usage
+## Configuration
 
-Create a read-only snapshot via the CLI entrypoint:
-
-```bash
-uv run aisc_salesforce snapshot
-```
-
-Use the development environment settings explicitly:
-
-```bash
-uv run aisc_salesforce snapshot
-```
-
-Or run it as a Python module:
-
-```bash
-uv run python -m aisc_salesforce snapshot
-```
-
-## Environment Variables
-
-`.env.example` is the committed template. Copy it to `.env` for development:
+`.env.example` is the committed template. Copy it to `.env`:
 
 ```bash
 cp .env.example .env
 ```
 
-Add the existing Salesforce Connected App values for `SF_CLIENT_ID` and
-`SF_CLIENT_SECRET`. The application uses the client-credentials OAuth2 flow,
-matching the existing Salesforce gateway. It reads this local file
-automatically. `.env` and generated snapshot files are sensitive and are
-ignored by Git; never commit them.
+Set these values in `.env`:
 
-For a specific Salesforce org or sandbox, set `SF_LOGIN_URL` to either its base
-URL or its full token endpoint. For example:
+- `SF_CLIENT_ID` and `SF_CLIENT_SECRET`: credentials for the existing
+  Salesforce Connected App.
+- `CERTIFICATION_QUEUE_ID`: the Case owner used by `profile-updates`.
+- `PRIMARY_RESPONDER_ID`: the Case Primary Responder used by
+  `profile-updates`.
+- `SF_LOGIN_URL` (optional): an org URL or complete OAuth token URL. It
+  defaults to Salesforce's production login service.
+
+The application loads `.env` automatically. This file and generated snapshots
+are ignored by Git because they can contain sensitive data. Never commit
+`.env`.
+
+For a specific Salesforce org or sandbox, for example:
 
 ```bash
 SF_LOGIN_URL=https://aisc.my.salesforce.com/services/oauth2/token
 ```
+
+## Commands
+
+Create a read-only snapshot:
+
+```bash
+uv run aisc_salesforce snapshot
+```
+
+Process recent audit notes and New company profile submissions:
+
+```bash
+uv run aisc_salesforce profile-updates
+```
+
+Both commands are also available as a Python module:
+
+```bash
+uv run python -m aisc_salesforce profile-updates
+```
+
+`profile-updates` prints `created`, `reused`, `skipped`, and `failed` counts. A
+successful run returns exit code `0`; missing configuration or a Salesforce
+failure returns `1`.
+
+### Daily scheduling
+
+The command is non-interactive, so an external scheduler can run it once per
+day. For example, a Linux cron entry can change to the repository and run it at
+2:00 AM:
+
+```cron
+0 2 * * * cd /path/to/aisc-sf && uv run aisc_salesforce profile-updates
+```
+
+Windows Task Scheduler can run the same command with the repository as its
+working directory. Scheduling is deliberately kept outside this project.
+
+### Safe retries and duplicate prevention
+
+The automation checks Cases only on the relevant Account. It reuses the newest
+appropriate Expected or Received Case and checks the Case and Audit Chatter
+feeds for the exact automation message before posting. Therefore, rerunning
+after a partial failure fills in missing work without duplicating completed
+comments. New submission names are appended with ` / ` once.
+
+Audit Dates from 30 days ago through today are eligible. Blank explanations,
+`None`, and `N/A` are ignored. If adding a Profile Update name would make a
+Case Subject longer than Salesforce's 255-character limit, that record is
+reported as failed instead of silently truncating its identifier.
+
+## Snapshot schema
 
 The schema dictionary is stored at
 `src/aisc_salesforce/data/salesforce_schema_dictionary.csv` and controls the
@@ -62,11 +101,6 @@ Account, Contact, Case, `Cert_Audit__c`, and `Company_Profile_Change__c`, plus
 ```bash
 uv run aisc_salesforce snapshot --output-dir /secure/snapshot-location
 ```
-
-The command is ready for a future scheduler because it is non-interactive and
-uses exit codes. Choosing cron, Windows Task Scheduler, or GitHub Actions is a
-separate operational decision.
-
 
 ## Testing
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,42 @@
 # API Reference
 
-::: aisc_salesforce
+## Profile Update service
+
+::: aisc_salesforce.profile_updates
     options:
-      show_submodules: true
+      show_root_heading: true
+      members:
+        - AutomationCounts
+        - ProfileUpdateService
+        - build_submission_summary
+        - has_meaningful_explanation
+        - is_eligible_audit
+        - match_contact
+
+## Salesforce client
+
+::: aisc_salesforce.salesforce
+    options:
+      show_root_heading: true
+      members:
+        - SalesforceClient
+        - SalesforceError
+        - SalesforceSession
+        - get_credentials
+        - get_oauth_url
+        - request_access_token
+
+`SalesforceClient` supports paginated filtered queries, record creation,
+updates and retrieval, plus reading and posting record-feed Chatter messages.
+Chatter posts use the Connect REST API's
+[feed element format](https://developer.salesforce.com/docs/platform/connect-rest-api/guide/features_feeds_feed_elements.html)
+with the target record supplied as `subjectId`.
+
+## CLI
+
+::: aisc_salesforce.app
+    options:
+      show_root_heading: true
+      members:
+        - main
+        - get_profile_update_configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,8 @@ Welcome to the **aisc-salesforce** documentation.
 
 ## Overview
 
-aisc-salesforce is a Python application.
+aisc-salesforce creates read-only data snapshots and automates daily Profile
+Update Case work from certification audits and participant submissions.
 
 ## Quick Links
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,26 +8,69 @@ Clone the repository and install dependencies:
 uv sync
 ```
 
-## Running
+## Configuration
 
-Via the CLI entrypoint:
-
-```bash
-uv run aisc_salesforce                          # production defaults
-uv run --env-file .env aisc_salesforce          # dev settings
-```
-
-Or as a Python module:
+Copy the environment template and fill in the Salesforce values:
 
 ```bash
-uv run python -m aisc_salesforce
+cp .env.example .env
 ```
 
-## Environment Variables
+| Variable | Required | Description |
+|---|---:|---|
+| `SF_CLIENT_ID` | Yes | Salesforce Connected App client ID |
+| `SF_CLIENT_SECRET` | Yes | Salesforce Connected App secret |
+| `CERTIFICATION_QUEUE_ID` | For profile updates | Owner ID for Profile Update Cases |
+| `PRIMARY_RESPONDER_ID` | For profile updates | Primary Responder ID for Profile Update Cases |
+| `SF_LOGIN_URL` | No | Salesforce org URL or complete OAuth token URL |
 
-| Variable    | Default    | Description                          |
-|-------------|------------|--------------------------------------|
-| `LOG_LEVEL` | `INFO`     | Console log level (DEBUG, INFO, …)   |
-| `LOG_FILE`  | `app.log`  | Path to the log file                 |
+The CLI loads `.env` without replacing environment variables that are already
+set.
 
-Copy `.env.example` to `.env` for development defaults, then run with `uv run --env-file .env`.
+## Snapshot command
+
+```bash
+uv run aisc_salesforce snapshot
+uv run aisc_salesforce snapshot --output-dir /secure/snapshot-location
+```
+
+## Profile Update command
+
+Run one daily processing pass:
+
+```bash
+uv run aisc_salesforce profile-updates
+```
+
+The command evaluates eligible audits and submissions whose `Status__c` is
+`New`. It creates or reuses Account-scoped Profile Update Cases, matches a
+submission Contact by email when the match is unambiguous, and posts missing
+Chatter messages.
+
+Example output:
+
+```text
+Profile updates complete:
+created: 2
+reused: 1
+skipped: 4
+failed: 0
+```
+
+Exit code `0` means the run completed without failures. Exit code `1` means
+configuration, Salesforce communication, or one or more records failed.
+
+## Scheduling and retries
+
+Use cron, Windows Task Scheduler, or another external scheduler to call the
+command daily. For example:
+
+```cron
+0 2 * * * cd /path/to/aisc-sf && uv run aisc_salesforce profile-updates
+```
+
+Retries are safe: the service uses the Account, Case Subject, Profile Update
+name, and exact Chatter text to recognize completed work. If a run stops after
+one Chatter post, the next run posts only the missing message.
+
+The project does not install or manage a scheduler itself.

--- a/framework.md
+++ b/framework.md
@@ -1,0 +1,24 @@
+This is my potential framework for replicating my most repetitive, time-consuming tasks with human-assisted Python scripts
+
+# Scripts that will run overnight
+- Create and/or update Profile Update cases based on Audit comments and submitted Profile Update objects
+- Stage changes for needed data cleanup
+- various data snapshots
+# A TUI app that I will access in the morning that shares changes needing human input
+- A list of Accounts and contacts with unneccesary capitalization in their names
+- Applicants with no Certification Status
+- Multiple accounts with same email domain that aren't parented
+# Apps that I can access as needed to process batches of items, e.g. renewal certificates
+- profile updates waiting to be processed
+- new and renewal certificates waiting to be processed
+# Apps for large processes, e.g. board report
+- pull data from iMIS and Salesforce
+- create charts and documents
+# An app for handling ad hoc requests
+- create a linked and filtered pull of the relevant tables on open
+- turn natural language prompts into accurate queries
+- return tables or charts as needed
+# Someday/Maybe List
+- Access Dodge Construction Services data through API
+- replace Salesforce functionality with a standalone app; will need help with security
+- expand app to replace iMIS functionaltiy

--- a/scripts/serve_docs.py
+++ b/scripts/serve_docs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Serve MkDocs with output captured to mkdocs.log."""
+
 import subprocess
 import sys
 

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -1,4 +1,4 @@
-"""Command-line interface for manual Salesforce snapshots."""
+"""Command-line interface for Salesforce snapshots and daily automation."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 from .dictionary import DictionaryError, load_export_plan
+from .profile_updates import ProfileUpdateService
 from .salesforce import (
     SalesforceClient,
     SalesforceError,
@@ -21,7 +22,7 @@ from .snapshot import write_snapshot
 def main(argv: list[str] | None = None) -> int:
     """Run the CLI and return a shell-friendly status code."""
     parser = argparse.ArgumentParser(
-        description="Create a read-only Salesforce data snapshot."
+        description="Run AISC Salesforce data and workflow commands."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     snapshot_parser = subparsers.add_parser(
@@ -33,6 +34,10 @@ def main(argv: list[str] | None = None) -> int:
         default=Path("snapshots"),
         help="Directory to contain snapshot folders.",
     )
+    subparsers.add_parser(
+        "profile-updates",
+        help="Process recent audits and New profile update submissions.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -40,12 +45,20 @@ def main(argv: list[str] | None = None) -> int:
         except (DictionaryError, SalesforceError, OSError) as error:
             print(f"Snapshot failed: {error}", file=sys.stderr)
             return 1
+    if args.command == "profile-updates":
+        try:
+            return _run_profile_updates()
+        except (SalesforceError, OSError) as error:
+            print(f"Profile updates failed: {error}", file=sys.stderr)
+            return 1
     return 1
 
 
 def _run_snapshot(output_dir: Path) -> int:
     _load_dotenv(Path(".env"))
-    dictionary_path = Path(__file__).with_name("data") / "salesforce_schema_dictionary.csv"
+    dictionary_path = (
+        Path(__file__).with_name("data") / "salesforce_schema_dictionary.csv"
+    )
     plan = load_export_plan(dictionary_path)
     environment = dict(os.environ)
     credentials = get_credentials(environment)
@@ -62,6 +75,38 @@ def _run_snapshot(output_dir: Path) -> int:
     return 0
 
 
+def _run_profile_updates() -> int:
+    """Connect to Salesforce and run the profile update service once."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    queue_id, responder_id = get_profile_update_configuration(environment)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    service = ProfileUpdateService(SalesforceClient(auth), queue_id, responder_id)
+    counts = service.run()
+    print("Profile updates complete:")
+    print(f"created: {counts.created}")
+    print(f"reused: {counts.reused}")
+    print(f"skipped: {counts.skipped}")
+    print(f"failed: {counts.failed}")
+    for error in getattr(service, "errors", []):
+        print(error, file=sys.stderr)
+    return 1 if counts.failed else 0
+
+
+def get_profile_update_configuration(
+    environment: dict[str, str],
+) -> tuple[str, str]:
+    """Read the two Salesforce IDs required by profile update automation."""
+    names = ("CERTIFICATION_QUEUE_ID", "PRIMARY_RESPONDER_ID")
+    missing = [name for name in names if not environment.get(name, "").strip()]
+    if missing:
+        raise SalesforceError(
+            "Missing Profile Update configuration: " + ", ".join(missing)
+        )
+    return tuple(environment[name].strip() for name in names)
+
+
 def _load_dotenv(path: Path) -> None:
     """Load simple KEY=VALUE entries without overwriting real environment variables."""
     if not path.is_file():
@@ -71,6 +116,23 @@ def _load_dotenv(path: Path) -> None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, value = line.split("=", 1)
-        key, value = key.strip(), value.strip().strip("\"'")
+        key, value = key.strip(), _dotenv_value(value)
         if key:
             os.environ.setdefault(key, value)
+
+
+def _dotenv_value(value: str) -> str:
+    """Remove quotes and comments from one value read from a ``.env`` file."""
+    value = value.strip()
+    if not value:
+        return ""
+    if value[0] in {'"', "'"}:
+        quote = value[0]
+        for index, character in enumerate(value[1:], start=1):
+            if character == quote and value[index - 1] != "\\":
+                return value[1:index]
+        return value[1:]
+    for index, character in enumerate(value):
+        if character == "#" and index > 0 and value[index - 1].isspace():
+            return value[:index].rstrip()
+    return value

--- a/src/aisc_salesforce/profile_updates.py
+++ b/src/aisc_salesforce/profile_updates.py
@@ -1,0 +1,575 @@
+"""Business rules for turning profile updates into Salesforce Cases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from .salesforce import SalesforceClient, SalesforceError
+
+AUDIT_FIELDS = [
+    "Id",
+    "Name",
+    "Cert_Audit_Date__c",
+    "Company_Profile_Change_Form__c",
+    "Explanation_for_Profile_Change_Form__c",
+    "Cert_Account__c",
+    "Cert_Account__r.Name",
+    "Cert_Contact__c",
+]
+
+SUBMISSION_FIELDS = [
+    "Id",
+    "Name",
+    "CreatedDate",
+    "Status__c",
+    "Account__c",
+    "Account__r.Name",
+    "Email__c",
+    "Name__c",
+    "Phone__c",
+    "Certification_ID__c",
+    "Effective_Date__c",
+    "Type__c",
+    "Revised_Company_Name__c",
+    "Revised_Company_Owner__c",
+    "Revised_Facility_Street__c",
+    "Revised_Facility_City__c",
+    "Revised_Facility_State__c",
+    "Revised_Facility_Zip__c",
+    "Revised_Facility_Country__c",
+    "Did_the_Cert_contact_change__c",
+    "Did_the_executive_manager_change__c",
+    "Will_you_change_personnel__c",
+    "Will_QMS_or_documentation_change__c",
+    "Existing_equipment_moved_to_new_facility__c",
+    "Will_new_equipment_be_purchased__c",
+    "Will_old_equipment_be_removed__c",
+    "Will_software_change__c",
+    "AP_First_Name__c",
+    "AP_Last_Name__c",
+    "AP_Title__c",
+    "AP_Email__c",
+    "AP_Phone__c",
+    "Cert_First_Name__c",
+    "Cert_Last_Name__c",
+    "Cert_Title__c",
+    "Cert_Email__c",
+    "Cert_Phone__c",
+    "Principal_First_Name__c",
+    "Principal_Last_Name__c",
+    "Principal_Title__c",
+    "Principal_Email__c",
+    "Principal_Phone__c",
+    "Quality_First_Name__c",
+    "Quality_Last_Name__c",
+    "QC_Title__c",
+    "Quality_Email__c",
+    "Quality_Phone__c",
+    "NY_First_Name__c",
+    "NY_Last_Name__c",
+    "NY_Email__c",
+    "NY_Phone__c",
+    "Other_Personnel_Notes__c",
+    "Comments__c",
+]
+
+CASE_FIELDS = [
+    "Id",
+    "CaseNumber",
+    "Subject",
+    "Status",
+    "IsClosed",
+    "CreatedDate",
+    "AccountId",
+    "ContactId",
+    "Origin",
+    "Label_new__c",
+    "Sub_Label__c",
+    "Description",
+]
+
+SUMMARY_FIELDS = [
+    ("Name__c", "Submitted By"),
+    ("Email__c", "Submitter Email"),
+    ("Phone__c", "Submitter Phone"),
+    ("Certification_ID__c", "Certification ID"),
+    ("Effective_Date__c", "Effective Date"),
+    ("Type__c", "Type"),
+    ("Revised_Company_Name__c", "Revised Company Name"),
+    ("Revised_Company_Owner__c", "Revised Company Owner"),
+    ("Revised_Facility_Street__c", "Revised Facility Street"),
+    ("Revised_Facility_City__c", "Revised Facility City"),
+    ("Revised_Facility_State__c", "Revised Facility State"),
+    ("Revised_Facility_Zip__c", "Revised Facility ZIP"),
+    ("Revised_Facility_Country__c", "Revised Facility Country"),
+    ("Did_the_Cert_contact_change__c", "Certification Contact Changed"),
+    ("Did_the_executive_manager_change__c", "Executive Manager Changed"),
+    ("Will_you_change_personnel__c", "Personnel Will Change"),
+    ("Will_QMS_or_documentation_change__c", "QMS or Documentation Will Change"),
+    (
+        "Existing_equipment_moved_to_new_facility__c",
+        "Existing Equipment Moved to New Facility",
+    ),
+    ("Will_new_equipment_be_purchased__c", "New Equipment Will Be Purchased"),
+    ("Will_old_equipment_be_removed__c", "Old Equipment Will Be Removed"),
+    ("Will_software_change__c", "Software Will Change"),
+    ("AP_First_Name__c", "Accounting Contact First Name"),
+    ("AP_Last_Name__c", "Accounting Contact Last Name"),
+    ("AP_Title__c", "Accounting Contact Title"),
+    ("AP_Email__c", "Accounting Contact Email"),
+    ("AP_Phone__c", "Accounting Contact Phone"),
+    ("Cert_First_Name__c", "Certification Contact First Name"),
+    ("Cert_Last_Name__c", "Certification Contact Last Name"),
+    ("Cert_Title__c", "Certification Contact Title"),
+    ("Cert_Email__c", "Certification Contact Email"),
+    ("Cert_Phone__c", "Certification Contact Phone"),
+    ("Principal_First_Name__c", "Principal Contact First Name"),
+    ("Principal_Last_Name__c", "Principal Contact Last Name"),
+    ("Principal_Title__c", "Principal Contact Title"),
+    ("Principal_Email__c", "Principal Contact Email"),
+    ("Principal_Phone__c", "Principal Contact Phone"),
+    ("Quality_First_Name__c", "Quality Contact First Name"),
+    ("Quality_Last_Name__c", "Quality Contact Last Name"),
+    ("QC_Title__c", "Quality Contact Title"),
+    ("Quality_Email__c", "Quality Contact Email"),
+    ("Quality_Phone__c", "Quality Contact Phone"),
+    ("NY_First_Name__c", "New York Contact First Name"),
+    ("NY_Last_Name__c", "New York Contact Last Name"),
+    ("NY_Email__c", "New York Contact Email"),
+    ("NY_Phone__c", "New York Contact Phone"),
+    ("Other_Personnel_Notes__c", "Other Personnel Notes"),
+    ("Comments__c", "Comments"),
+]
+
+
+@dataclass
+class AutomationCounts:
+    """Outcome totals printed by the daily command."""
+
+    created: int = 0
+    reused: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+def has_meaningful_explanation(value: Any) -> bool:
+    """Return whether an audit explanation contains useful text."""
+    if not isinstance(value, str):
+        return False
+    return value.strip().casefold() not in {"", "none", "n/a"}
+
+
+def is_eligible_audit(record: dict[str, Any], today: date) -> bool:
+    """Apply the inclusive 30-day audit eligibility rules."""
+    audit_date = _salesforce_date(record.get("Cert_Audit_Date__c"))
+    if audit_date is None or not today - timedelta(days=30) <= audit_date <= today:
+        return False
+    return bool(record.get("Company_Profile_Change_Form__c")) and (
+        has_meaningful_explanation(record.get("Explanation_for_Profile_Change_Form__c"))
+    )
+
+
+def match_contact(
+    contacts: list[dict[str, Any]], email: str | None, account_id: str | None
+) -> str | None:
+    """Match email without case sensitivity, preferring one unambiguous Account match."""
+    if not isinstance(email, str) or not email.strip():
+        return None
+    normalized = email.strip().casefold()
+    matches = [
+        contact
+        for contact in contacts
+        if isinstance(contact.get("Email"), str)
+        and contact["Email"].strip().casefold() == normalized
+    ]
+    account_matches = [
+        contact for contact in matches if contact.get("AccountId") == account_id
+    ]
+    preferred = account_matches or matches
+    if len(preferred) != 1:
+        return None
+    return preferred[0].get("Id")
+
+
+def build_submission_summary(record: dict[str, Any]) -> str:
+    """Build stable, readable Chatter text from nonblank submission fields."""
+    name = _clean_text(record.get("Name")) or "(unnamed)"
+    lines = [f"Profile Update {name}", "", "Submission details:"]
+    for api_name, label in SUMMARY_FIELDS:
+        value = record.get(api_name)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            continue
+        if isinstance(value, bool):
+            display_value = "Yes" if value else "No"
+        else:
+            display_value = str(value).strip()
+        lines.append(f"{label}: {display_value}")
+    return "\n".join(lines)
+
+
+class ProfileUpdateService:
+    """Coordinate idempotent audit and submission processing."""
+
+    def __init__(
+        self,
+        client: SalesforceClient,
+        certification_queue_id: str,
+        primary_responder_id: str,
+        *,
+        today: date | None = None,
+    ):
+        self.client = client
+        self.certification_queue_id = certification_queue_id
+        self.primary_responder_id = primary_responder_id
+        self.today = today or date.today()
+        self.errors: list[str] = []
+        self._case_cache: dict[str, list[dict[str, Any]]] = {}
+        self._feed_cache: dict[str, list[str]] = {}
+
+    def run(self) -> AutomationCounts:
+        """Process eligible audits and New submissions and return outcome counts."""
+        self.errors.clear()
+        self._case_cache.clear()
+        self._feed_cache.clear()
+        start = self.today - timedelta(days=30)
+        audits = self.client.query_records(
+            "Cert_Audit__c",
+            AUDIT_FIELDS,
+            where=(
+                f"Cert_Audit_Date__c >= {start.isoformat()} AND "
+                f"Cert_Audit_Date__c <= {self.today.isoformat()} AND "
+                "Company_Profile_Change_Form__c = TRUE"
+            ),
+            order_by="Cert_Audit_Date__c ASC, Id ASC",
+        )
+        submissions = self.client.query_records(
+            "Company_Profile_Change__c",
+            SUBMISSION_FIELDS,
+            where="Status__c = 'New'",
+            order_by="CreatedDate ASC, Id ASC",
+        )
+
+        counts = AutomationCounts()
+        for record in audits:
+            if not is_eligible_audit(record, self.today):
+                counts.skipped += 1
+                continue
+            self._count_record(counts, self._process_audit, record)
+        for record in submissions:
+            self._count_record(counts, self._process_submission, record)
+        return counts
+
+    def _count_record(
+        self, counts: AutomationCounts, operation: Any, record: Any
+    ) -> None:
+        try:
+            outcome = operation(record)
+        except (SalesforceError, ValueError, KeyError, TypeError) as error:
+            counts.failed += 1
+            record_id = record.get("Id", "unknown")
+            self.errors.append(f"{record_id}: {error}")
+            return
+        setattr(counts, outcome, getattr(counts, outcome) + 1)
+
+    def _process_audit(self, audit: dict[str, Any]) -> str:
+        account_id = _required_text(audit, "Cert_Account__c", "Audit Account")
+        account_name = _relationship_name(audit, "Cert_Account__r")
+        audit_name = _required_text(audit, "Name", "Audit Name")
+        audit_date = _salesforce_date(audit.get("Cert_Audit_Date__c"))
+        if audit_date is None:
+            raise ValueError("Audit Date is missing or invalid.")
+        explanation = _required_text(
+            audit,
+            "Explanation_for_Profile_Change_Form__c",
+            "Audit explanation",
+        )
+        subject = (
+            f"{audit_date.isoformat()}: Profile Update Expected for {account_name} "
+            f"based on {audit_name}"
+        )
+        _check_subject_length(subject)
+        cases = self._profile_cases(account_id)
+
+        matching = self._newest(
+            case for case in cases if _clean_text(case.get("Subject")) == subject
+        )
+        if matching is not None:
+            worked = self._reconcile_audit_messages(
+                matching, audit, explanation, account_name
+            )
+            return "reused" if worked else "skipped"
+
+        received = self._newest(
+            case
+            for case in cases
+            if "profile update received" in _clean_text(case.get("Subject")).casefold()
+        )
+        if received is not None:
+            worked = False
+            if received.get("IsClosed"):
+                self.client.update_record(
+                    "Case",
+                    _required_text(received, "Id", "Case ID"),
+                    {"Status": "Pending"},
+                )
+                received["Status"] = "Pending"
+                received["IsClosed"] = False
+                worked = True
+            return (
+                "reused"
+                if self._reconcile_audit_messages(
+                    received, audit, explanation, account_name
+                )
+                or worked
+                else "skipped"
+            )
+
+        if any(_record_date(case.get("CreatedDate")) >= audit_date for case in cases):
+            return "skipped"
+
+        payload = self._case_payload(
+            subject=subject,
+            account_id=account_id,
+            contact_id=audit.get("Cert_Contact__c"),
+            origin="Web",
+            label="Auditing",
+        )
+        case_id = self.client.create_record("Case", payload)
+        created = self.client.get_record("Case", case_id, ["Id", "CaseNumber"])
+        created.update(payload)
+        created.setdefault("CreatedDate", datetime.now().isoformat())
+        created["IsClosed"] = False
+        cases.append(created)
+        self._reconcile_audit_messages(created, audit, explanation, account_name)
+        return "created"
+
+    def _reconcile_audit_messages(
+        self,
+        case: dict[str, Any],
+        audit: dict[str, Any],
+        explanation: str,
+        account_name: str,
+    ) -> bool:
+        case_id = _required_text(case, "Id", "Case ID")
+        case_number = case.get("CaseNumber")
+        if not case_number:
+            case_number = self.client.get_record("Case", case_id, ["CaseNumber"]).get(
+                "CaseNumber"
+            )
+        if not case_number:
+            raise SalesforceError(f"Case {case_id} does not have a CaseNumber.")
+        audit_message = (
+            "Profile Change need noted. A pending case "
+            f"({case_number}) has been made on the {account_name} account. -MB"
+        )
+        worked = self._post_if_missing(case_id, explanation)
+        return (
+            self._post_if_missing(
+                _required_text(audit, "Id", "Audit ID"), audit_message
+            )
+            or worked
+        )
+
+    def _process_submission(self, submission: dict[str, Any]) -> str:
+        account_id = _required_text(submission, "Account__c", "Submission Account")
+        account_name = _relationship_name(submission, "Account__r")
+        update_name = _required_text(submission, "Name", "Profile Update Name")
+        created_date = _salesforce_date(submission.get("CreatedDate"))
+        if created_date is None:
+            raise ValueError("Submission Created Date is missing or invalid.")
+        summary = build_submission_summary(submission)
+        cases = self._profile_cases(account_id)
+
+        same_name_cases = [
+            case
+            for case in cases
+            if _subject_has_name(case.get("Subject"), update_name)
+        ]
+        for case in sorted(same_name_cases, key=_case_sort_key, reverse=True):
+            case_id = _required_text(case, "Id", "Case ID")
+            if summary in self._feed_messages(case_id):
+                return "skipped"
+        if same_name_cases:
+            case_id = _required_text(
+                self._newest(iter(same_name_cases)) or {}, "Id", "Case ID"
+            )
+            self._post_if_missing(case_id, summary)
+            return "reused"
+
+        received = self._newest(
+            case
+            for case in cases
+            if "profile update received" in _clean_text(case.get("Subject")).casefold()
+        )
+        if received is not None:
+            case_id = _required_text(received, "Id", "Case ID")
+            old_subject = _required_text(received, "Subject", "Case Subject")
+            subject = f"{old_subject} / {update_name}"
+            _check_subject_length(subject)
+            self.client.update_record("Case", case_id, {"Subject": subject})
+            received["Subject"] = subject
+            self._post_if_missing(case_id, summary)
+            return "reused"
+
+        contact_id = self._submission_contact(submission, account_id)
+        subject = (
+            f"{created_date.isoformat()}: Profile Update Received for {account_name} "
+            f"- {update_name}"
+        )
+        _check_subject_length(subject)
+        payload = self._case_payload(
+            subject=subject,
+            account_id=account_id,
+            contact_id=contact_id,
+            origin="Participant Portal",
+            label="Participant Portal",
+        )
+        expected = self._newest(
+            case
+            for case in cases
+            if "profile update expected" in _clean_text(case.get("Subject")).casefold()
+        )
+        if expected is not None:
+            case_id = _required_text(expected, "Id", "Case ID")
+            self.client.update_record("Case", case_id, payload)
+            expected.update(payload)
+            self._post_if_missing(case_id, summary)
+            return "reused"
+
+        case_id = self.client.create_record("Case", payload)
+        cases.append(
+            {
+                "Id": case_id,
+                **payload,
+                "IsClosed": False,
+                "CreatedDate": datetime.now().isoformat(),
+            }
+        )
+        self._post_if_missing(case_id, summary)
+        return "created"
+
+    def _case_payload(
+        self,
+        *,
+        subject: str,
+        account_id: str,
+        contact_id: Any,
+        origin: str,
+        label: str,
+    ) -> dict[str, Any]:
+        return {
+            "Subject": subject,
+            "OwnerId": self.certification_queue_id,
+            "Primary_Responder__c": self.primary_responder_id,
+            "ContactId": contact_id,
+            "AccountId": account_id,
+            "Status": "Pending",
+            "Origin": origin,
+            "Label_new__c": label,
+            "Sub_Label__c": "Profile Change",
+            "Description": "",
+        }
+
+    def _profile_cases(self, account_id: str) -> list[dict[str, Any]]:
+        if account_id not in self._case_cache:
+            escaped_id = escape_soql_string(account_id)
+            records = self.client.query_records(
+                "Case",
+                CASE_FIELDS,
+                where=(
+                    f"AccountId = '{escaped_id}' AND Subject LIKE '%Profile Update%'"
+                ),
+                order_by="CreatedDate DESC, Id DESC",
+            )
+            self._case_cache[account_id] = records
+        return self._case_cache[account_id]
+
+    def _submission_contact(
+        self, submission: dict[str, Any], account_id: str
+    ) -> str | None:
+        email = _clean_text(submission.get("Email__c"))
+        if not email:
+            return None
+        contacts = self.client.query_records(
+            "Contact",
+            ["Id", "AccountId", "Email"],
+            where=f"Email = '{escape_soql_string(email)}'",
+            order_by="Id ASC",
+        )
+        return match_contact(contacts, email, account_id)
+
+    def _feed_messages(self, record_id: str) -> list[str]:
+        if record_id not in self._feed_cache:
+            self._feed_cache[record_id] = self.client.get_feed_messages(record_id)
+        return self._feed_cache[record_id]
+
+    def _post_if_missing(self, record_id: str, message: str) -> bool:
+        feed = self._feed_messages(record_id)
+        if message in feed:
+            return False
+        self.client.post_feed_message(record_id, message)
+        feed.append(message)
+        return True
+
+    @staticmethod
+    def _newest(records: Any) -> dict[str, Any] | None:
+        return max(records, key=_case_sort_key, default=None)
+
+
+def escape_soql_string(value: str) -> str:
+    """Escape slash and quote characters in a SOQL string literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _subject_has_name(subject: Any, update_name: str) -> bool:
+    text = _clean_text(subject)
+    if " - " not in text:
+        return False
+    names = [name.strip().casefold() for name in text.rsplit(" - ", 1)[1].split("/")]
+    return update_name.strip().casefold() in names
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _required_text(record: dict[str, Any], key: str, label: str) -> str:
+    value = _clean_text(record.get(key))
+    if not value:
+        raise ValueError(f"{label} is missing.")
+    return value
+
+
+def _relationship_name(record: dict[str, Any], key: str) -> str:
+    relationship = record.get(key)
+    if not isinstance(relationship, dict):
+        raise ValueError("Account Name is missing.")
+    return _required_text(relationship, "Name", "Account Name")
+
+
+def _salesforce_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value if not isinstance(value, datetime) else value.date()
+    if not isinstance(value, str) or len(value) < 10:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _record_date(value: Any) -> date:
+    return _salesforce_date(value) or date.min
+
+
+def _case_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (_clean_text(record.get("CreatedDate")), _clean_text(record.get("Id")))
+
+
+def _check_subject_length(subject: str) -> None:
+    if len(subject) > 255:
+        raise ValueError(
+            f"Case Subject is {len(subject)} characters; Salesforce allows 255."
+        )

--- a/src/aisc_salesforce/salesforce.py
+++ b/src/aisc_salesforce/salesforce.py
@@ -1,4 +1,4 @@
-"""Read-only Salesforce OAuth2 and SOQL helpers."""
+"""Salesforce OAuth2, SOQL, record, and Chatter helpers."""
 
 from __future__ import annotations
 
@@ -89,7 +89,7 @@ def request_access_token(
 
 
 class SalesforceClient:
-    """A client that performs only SOQL GET requests."""
+    """A small Salesforce REST client used by the application services."""
 
     def __init__(
         self, auth: SalesforceSession, session: requests.Session | Any = requests
@@ -102,43 +102,186 @@ class SalesforceClient:
         self, object_name: str, fields: list[ExportField]
     ) -> list[dict[str, Any]]:
         """Return all rows for an object, following Salesforce pagination links."""
-        field_names = ", ".join(field.api_name for field in fields)
+        return self.query_records(object_name, [field.api_name for field in fields])
+
+    def query_records(
+        self,
+        object_name: str,
+        fields: list[str],
+        *,
+        where: str | None = None,
+        order_by: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query selected fields, optionally filtering and sorting the records."""
+        field_names = ", ".join(fields)
+        soql = f"SELECT {field_names} FROM {object_name}"
+        if where:
+            soql += f" WHERE {where}"
+        if order_by:
+            soql += f" ORDER BY {order_by}"
         url = f"{self.auth.instance_url}/services/data/{API_VERSION}/query"
-        params: dict[str, str] | None = {
-            "q": f"SELECT {field_names} FROM {object_name}"
-        }
+        params: dict[str, str] | None = {"q": soql}
         records: list[dict[str, Any]] = []
         while url:
-            try:
-                response = self.session.get(
-                    url, headers=self.headers, params=params, timeout=30
-                )
-            except requests.RequestException as error:
-                raise SalesforceError(
-                    f"Could not query {object_name}: {error}"
-                ) from error
-            if not response.ok:
-                raise SalesforceError(
-                    f"Salesforce query failed for {object_name}: {_response_details(response)}"
-                )
+            response = self._request(
+                "get",
+                url,
+                action=f"query {object_name}",
+                params=params,
+            )
             try:
                 payload = response.json()
                 records.extend(payload.get("records", []))
                 done = payload["done"]
-            except (ValueError, KeyError, TypeError) as error:
+            except (ValueError, KeyError, TypeError, AttributeError) as error:
                 raise SalesforceError(
                     f"Invalid Salesforce query response for {object_name}."
                 ) from error
             next_url = payload.get("nextRecordsUrl")
-            url = (
-                f"{self.auth.instance_url}{next_url}" if not done and next_url else None
-            )
+            url = self._absolute_url(next_url) if not done and next_url else None
             if not done and not next_url:
                 raise SalesforceError(
                     f"Salesforce query for {object_name} ended without a next page."
                 )
             params = None
         return records
+
+    def create_record(self, object_name: str, values: dict[str, Any]) -> str:
+        """Create one Salesforce record and return its new record ID."""
+        url = (
+            f"{self.auth.instance_url}/services/data/{API_VERSION}"
+            f"/sobjects/{object_name}"
+        )
+        response = self._request(
+            "post", url, action=f"create {object_name}", json=values
+        )
+        try:
+            record_id = response.json()["id"]
+        except (ValueError, KeyError, TypeError) as error:
+            raise SalesforceError(
+                f"Salesforce create response for {object_name} was incomplete."
+            ) from error
+        return record_id
+
+    def update_record(
+        self, object_name: str, record_id: str, values: dict[str, Any]
+    ) -> None:
+        """Update fields on one Salesforce record."""
+        url = (
+            f"{self.auth.instance_url}/services/data/{API_VERSION}"
+            f"/sobjects/{object_name}/{record_id}"
+        )
+        self._request(
+            "patch", url, action=f"update {object_name} {record_id}", json=values
+        )
+
+    def get_record(
+        self, object_name: str, record_id: str, fields: list[str]
+    ) -> dict[str, Any]:
+        """Retrieve selected fields from one Salesforce record."""
+        url = (
+            f"{self.auth.instance_url}/services/data/{API_VERSION}"
+            f"/sobjects/{object_name}/{record_id}"
+        )
+        response = self._request(
+            "get",
+            url,
+            action=f"retrieve {object_name} {record_id}",
+            params={"fields": ",".join(fields)},
+        )
+        try:
+            payload = response.json()
+        except ValueError as error:
+            raise SalesforceError(
+                f"Invalid Salesforce response for {object_name} {record_id}."
+            ) from error
+        if not isinstance(payload, dict):
+            raise SalesforceError(
+                f"Invalid Salesforce response for {object_name} {record_id}."
+            )
+        return payload
+
+    def get_feed_messages(self, record_id: str) -> list[str]:
+        """Return text from every Chatter element in a record feed."""
+        url: str | None = (
+            f"{self.auth.instance_url}/services/data/{API_VERSION}/connect/"
+            f"communities/internal/chatter/feeds/record/{record_id}/feed-elements"
+        )
+        messages: list[str] = []
+        while url:
+            response = self._request(
+                "get", url, action=f"read Chatter feed for {record_id}"
+            )
+            try:
+                payload = response.json()
+                elements = payload.get("elements", [])
+                for element in elements:
+                    segments = element.get("body", {}).get("messageSegments", [])
+                    message = "".join(
+                        segment.get("text", "")
+                        for segment in segments
+                        if segment.get("type") == "Text"
+                    )
+                    messages.append(message)
+                next_page = payload.get("nextPageUrl")
+            except (ValueError, AttributeError, TypeError) as error:
+                raise SalesforceError(
+                    f"Invalid Chatter feed response for {record_id}."
+                ) from error
+            url = self._absolute_url(next_page) if next_page else None
+        return messages
+
+    def post_feed_message(self, record_id: str, message: str) -> None:
+        """Post a plain-text Chatter message to a record's feed."""
+        url = (
+            f"{self.auth.instance_url}/services/data/{API_VERSION}/connect/"
+            "communities/internal/chatter/feed-elements"
+        )
+        payload = {
+            "body": {"messageSegments": [{"type": "Text", "text": message}]},
+            "feedElementType": "FeedItem",
+            "subjectId": record_id,
+        }
+        self._request(
+            "post",
+            url,
+            action=f"post Chatter message to {record_id}",
+            json=payload,
+        )
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        action: str,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        headers = self.headers
+        if json is not None:
+            headers = {**headers, "Content-Type": "application/json"}
+        kwargs: dict[str, Any] = {"headers": headers, "timeout": 30}
+        if params is not None:
+            kwargs["params"] = params
+        if json is not None:
+            kwargs["json"] = json
+        try:
+            response = getattr(self.session, method)(url, **kwargs)
+        except requests.RequestException as error:
+            raise SalesforceError(f"Could not {action}: {error}") from error
+        if not response.ok:
+            raise SalesforceError(
+                f"Salesforce failed to {action}: {_response_details(response)}"
+            )
+        return response
+
+    def _absolute_url(self, url: str) -> str:
+        if not isinstance(url, str):
+            raise SalesforceError("Salesforce pagination URL was invalid.")
+        if url.startswith("https://"):
+            return url
+        return f"{self.auth.instance_url}{url}"
 
 
 def _response_details(response: Any) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from aisc_salesforce import app
 from aisc_salesforce.dictionary import ExportField
+from aisc_salesforce.profile_updates import AutomationCounts
 
 
 def test_cli_success_uses_custom_output_dir(monkeypatch, tmp_path, capsys):
@@ -41,3 +42,87 @@ def test_cli_configuration_failure_is_nonzero(monkeypatch, capsys):
     )
     assert app.main(["snapshot"]) == 1
     assert "SF_CLIENT_SECRET" in capsys.readouterr().err
+
+
+def test_dotenv_removes_inline_comments_but_preserves_hashes(monkeypatch, tmp_path):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(
+        "QUEUE_ID = 00G123  # Queue ID\n"
+        "SECRET=abc#part\n"
+        'LOGIN_URL="https://example.com/#fragment" # Login URL\n',
+        encoding="utf-8",
+    )
+    for name in ("QUEUE_ID", "SECRET", "LOGIN_URL"):
+        monkeypatch.delenv(name, raising=False)
+
+    app._load_dotenv(dotenv)
+
+    assert app.os.environ["QUEUE_ID"] == "00G123"
+    assert app.os.environ["SECRET"] == "abc#part"
+    assert app.os.environ["LOGIN_URL"] == "https://example.com/#fragment"
+
+
+def test_profile_updates_cli_prints_counts_and_succeeds(monkeypatch, capsys):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app, "get_credentials", lambda env: {"ok": "yes"})
+    monkeypatch.setattr(app, "get_oauth_url", lambda env: "https://example/token")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: object()
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: object())
+    monkeypatch.setenv("CERTIFICATION_QUEUE_ID", "queue")
+    monkeypatch.setenv("PRIMARY_RESPONDER_ID", "responder")
+
+    class Service:
+        def __init__(self, client, queue_id, responder_id):
+            assert queue_id == "queue"
+            assert responder_id == "responder"
+
+        def run(self):
+            return AutomationCounts(created=2, reused=3, skipped=4)
+
+    monkeypatch.setattr(app, "ProfileUpdateService", Service)
+
+    assert app.main(["profile-updates"]) == 0
+    output = capsys.readouterr().out
+    assert "created: 2" in output
+    assert "reused: 3" in output
+    assert "skipped: 4" in output
+    assert "failed: 0" in output
+
+
+def test_profile_updates_cli_requires_both_ids(monkeypatch, capsys):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.delenv("CERTIFICATION_QUEUE_ID", raising=False)
+    monkeypatch.delenv("PRIMARY_RESPONDER_ID", raising=False)
+
+    assert app.main(["profile-updates"]) == 1
+    error = capsys.readouterr().err
+    assert "CERTIFICATION_QUEUE_ID" in error
+    assert "PRIMARY_RESPONDER_ID" in error
+
+
+def test_profile_updates_cli_is_nonzero_when_records_fail(monkeypatch, capsys):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app, "get_credentials", lambda env: {"ok": "yes"})
+    monkeypatch.setattr(app, "get_oauth_url", lambda env: "https://example/token")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: object()
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: object())
+    monkeypatch.setenv("CERTIFICATION_QUEUE_ID", "queue")
+    monkeypatch.setenv("PRIMARY_RESPONDER_ID", "responder")
+
+    class Service:
+        errors = ["audit-1: feed unavailable"]
+
+        def __init__(self, client, queue_id, responder_id):
+            pass
+
+        def run(self):
+            return AutomationCounts(failed=1)
+
+    monkeypatch.setattr(app, "ProfileUpdateService", Service)
+
+    assert app.main(["profile-updates"]) == 1
+    assert "audit-1: feed unavailable" in capsys.readouterr().err

--- a/tests/test_profile_updates.py
+++ b/tests/test_profile_updates.py
@@ -1,0 +1,406 @@
+from datetime import date
+
+import pytest
+
+from aisc_salesforce.profile_updates import (
+    AUDIT_FIELDS,
+    SUBMISSION_FIELDS,
+    ProfileUpdateService,
+    build_submission_summary,
+    has_meaningful_explanation,
+    is_eligible_audit,
+    match_contact,
+)
+from aisc_salesforce.salesforce import SalesforceError
+
+TODAY = date(2026, 7, 16)
+
+
+def audit(**changes):
+    record = {
+        "Id": "audit-1",
+        "Name": "A-100",
+        "Cert_Audit_Date__c": "2026-07-01",
+        "Company_Profile_Change_Form__c": True,
+        "Explanation_for_Profile_Change_Form__c": "The company moved.",
+        "Cert_Account__c": "account-1",
+        "Cert_Account__r": {"Name": "Acme Steel"},
+        "Cert_Contact__c": "contact-cert",
+    }
+    record.update(changes)
+    return record
+
+
+def submission(**changes):
+    record = {
+        "Id": "submission-1",
+        "Name": "PU-100",
+        "CreatedDate": "2026-07-15T14:30:00.000+0000",
+        "Status__c": "New",
+        "Account__c": "account-1",
+        "Account__r": {"Name": "Acme Steel"},
+        "Email__c": "submitter@example.com",
+        "Revised_Company_Name__c": "Acme Steel LLC",
+        "Comments__c": "New legal name",
+    }
+    record.update(changes)
+    return record
+
+
+class FakeClient:
+    def __init__(self, *, audits=None, submissions=None, cases=None, contacts=None):
+        self.audits = audits or []
+        self.submissions = submissions or []
+        self.cases = cases or {}
+        self.contacts = contacts or []
+        self.feeds = {}
+        self.created = []
+        self.updated = []
+        self.posted = []
+        self.queries = []
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where, order_by))
+        if object_name == "Cert_Audit__c":
+            return self.audits
+        if object_name == "Company_Profile_Change__c":
+            return self.submissions
+        if object_name == "Case":
+            account_id = where.split("AccountId = '", 1)[1].split("'", 1)[0]
+            return list(self.cases.get(account_id, []))
+        if object_name == "Contact":
+            return list(self.contacts)
+        raise AssertionError(object_name)
+
+    def create_record(self, object_name, payload):
+        record_id = f"case-created-{len(self.created) + 1}"
+        self.created.append((object_name, payload))
+        return record_id
+
+    def update_record(self, object_name, record_id, payload):
+        self.updated.append((object_name, record_id, payload))
+
+    def get_record(self, object_name, record_id, fields):
+        return {"Id": record_id, "CaseNumber": "00012345"}
+
+    def get_feed_messages(self, record_id):
+        return list(self.feeds.get(record_id, []))
+
+    def post_feed_message(self, record_id, message):
+        self.posted.append((record_id, message))
+        self.feeds.setdefault(record_id, []).append(message)
+
+
+def service(client):
+    return ProfileUpdateService(client, "queue-id", "responder-id", today=TODAY)
+
+
+@pytest.mark.parametrize("value", [None, "", "  ", "None", " none ", "N/A", " n/a "])
+def test_explanation_must_be_meaningful(value):
+    assert not has_meaningful_explanation(value)
+
+
+def test_audit_window_is_inclusive_and_excludes_future_dates():
+    assert is_eligible_audit(audit(Cert_Audit_Date__c="2026-06-16"), TODAY)
+    assert is_eligible_audit(audit(Cert_Audit_Date__c="2026-07-16"), TODAY)
+    assert not is_eligible_audit(audit(Cert_Audit_Date__c="2026-06-15"), TODAY)
+    assert not is_eligible_audit(audit(Cert_Audit_Date__c="2026-07-17"), TODAY)
+    assert not is_eligible_audit(
+        audit(Explanation_for_Profile_Change_Form__c="N/A"), TODAY
+    )
+
+
+def test_audit_creates_expected_case_and_posts_exact_messages():
+    client = FakeClient(audits=[audit()])
+
+    counts = service(client).run()
+
+    assert counts.created == 1
+    assert client.created == [
+        (
+            "Case",
+            {
+                "Subject": (
+                    "2026-07-01: Profile Update Expected for Acme Steel based on A-100"
+                ),
+                "OwnerId": "queue-id",
+                "Primary_Responder__c": "responder-id",
+                "ContactId": "contact-cert",
+                "AccountId": "account-1",
+                "Status": "Pending",
+                "Origin": "Web",
+                "Label_new__c": "Auditing",
+                "Sub_Label__c": "Profile Change",
+                "Description": "",
+            },
+        )
+    ]
+    assert client.posted == [
+        ("case-created-1", "The company moved."),
+        (
+            "audit-1",
+            "Profile Change need noted. A pending case (00012345) has been made "
+            "on the Acme Steel account. -MB",
+        ),
+    ]
+
+
+def test_case_duplicate_checks_are_scoped_to_the_audit_account():
+    other_case = {
+        "Id": "other-case",
+        "Subject": "2026-07-01: Profile Update Expected elsewhere",
+        "CreatedDate": "2026-07-02T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"other-account": [other_case]})
+
+    counts = service(client).run()
+
+    assert counts.created == 1
+    case_query = next(query for query in client.queries if query[0] == "Case")
+    assert "AccountId = 'account-1'" in case_query[2]
+
+
+def test_audit_reuses_received_case_and_reopens_only_when_closed():
+    received = {
+        "Id": "received-1",
+        "CaseNumber": "0042",
+        "Subject": "2026-06-01: Profile Update Received for Acme - PU-1",
+        "Status": "Closed",
+        "IsClosed": True,
+        "CreatedDate": "2026-06-01T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"account-1": [received]})
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert client.updated == [("Case", "received-1", {"Status": "Pending"})]
+    assert client.posted[0] == ("received-1", "The company moved.")
+
+
+def test_audit_preserves_open_received_status_and_skips_newer_other_case():
+    open_received = {
+        "Id": "received-open",
+        "CaseNumber": "0043",
+        "Subject": "Profile Update Received for Acme - PU-1",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-06-01T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"account-1": [open_received]})
+
+    service(client).run()
+
+    assert not client.updated
+
+    other_profile_case = {
+        "Id": "other-profile",
+        "Subject": "Manual Profile Update follow-up",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"account-1": [other_profile_case]})
+
+    counts = service(client).run()
+
+    assert counts.skipped == 1
+    assert not client.created
+
+
+def test_partial_audit_retry_posts_only_missing_message():
+    subject = "2026-07-01: Profile Update Expected for Acme Steel based on A-100"
+    existing = {
+        "Id": "case-existing",
+        "CaseNumber": "0042",
+        "Subject": subject,
+        "Status": "Pending",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"account-1": [existing]})
+    client.feeds["case-existing"] = ["The company moved."]
+
+    service(client).run()
+
+    assert client.posted == [
+        (
+            "audit-1",
+            "Profile Change need noted. A pending case (0042) has been made on "
+            "the Acme Steel account. -MB",
+        )
+    ]
+
+
+def test_new_submission_converts_newest_expected_case():
+    expected = {
+        "Id": "expected-newest",
+        "Subject": "Profile Update Expected for Acme",
+        "Status": "Pending",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-10T00:00:00.000+0000",
+    }
+    older = {
+        **expected,
+        "Id": "expected-older",
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    contacts = [
+        {"Id": "contact-1", "AccountId": "account-1", "Email": "SUBMITTER@example.com"}
+    ]
+    client = FakeClient(
+        submissions=[submission()],
+        cases={"account-1": [older, expected]},
+        contacts=contacts,
+    )
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert client.updated == [
+        (
+            "Case",
+            "expected-newest",
+            {
+                "Subject": "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+                "OwnerId": "queue-id",
+                "Primary_Responder__c": "responder-id",
+                "ContactId": "contact-1",
+                "AccountId": "account-1",
+                "Status": "Pending",
+                "Origin": "Participant Portal",
+                "Label_new__c": "Participant Portal",
+                "Sub_Label__c": "Profile Change",
+                "Description": "",
+            },
+        )
+    ]
+
+
+def test_new_submission_creates_received_case_with_exact_payload():
+    client = FakeClient(submissions=[submission()], contacts=[])
+
+    counts = service(client).run()
+
+    assert counts.created == 1
+    assert client.created == [
+        (
+            "Case",
+            {
+                "Subject": "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+                "OwnerId": "queue-id",
+                "Primary_Responder__c": "responder-id",
+                "ContactId": None,
+                "AccountId": "account-1",
+                "Status": "Pending",
+                "Origin": "Participant Portal",
+                "Label_new__c": "Participant Portal",
+                "Sub_Label__c": "Profile Change",
+                "Description": "",
+            },
+        )
+    ]
+    assert client.posted == [("case-created-1", build_submission_summary(submission()))]
+
+
+def test_submission_reuses_received_case_and_appends_name_once():
+    received = {
+        "Id": "received-1",
+        "Subject": "2026-07-01: Profile Update Received for Acme Steel - PU-099",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    client = FakeClient(submissions=[submission()], cases={"account-1": [received]})
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert not any(query[0] == "Contact" for query in client.queries)
+    assert client.updated == [
+        (
+            "Case",
+            "received-1",
+            {
+                "Subject": (
+                    "2026-07-01: Profile Update Received for Acme Steel - PU-099 / PU-100"
+                )
+            },
+        )
+    ]
+    assert "PU-100" in client.posted[0][1]
+
+    client.updated.clear()
+    client.posted.clear()
+    client.feeds["received-1"] = [build_submission_summary(submission())]
+    received["Subject"] += " / PU-100"
+    retry_counts = service(client).run()
+    assert retry_counts.skipped == 1
+    assert not client.updated
+    assert not client.posted
+
+
+def test_contact_matching_prefers_account_and_rejects_ambiguity():
+    contacts = [
+        {"Id": "other", "AccountId": "account-2", "Email": "person@example.com"},
+        {"Id": "preferred", "AccountId": "account-1", "Email": "PERSON@example.com"},
+    ]
+    assert match_contact(contacts, "person@EXAMPLE.com", "account-1") == "preferred"
+    assert (
+        match_contact(
+            contacts + [{**contacts[1], "Id": "duplicate"}],
+            "person@example.com",
+            "account-1",
+        )
+        is None
+    )
+
+
+def test_summary_is_deterministic_readable_and_omits_blank_fields():
+    text = build_submission_summary(
+        submission(Phone__c="", Effective_Date__c=None, Type__c="Address change")
+    )
+    assert text.startswith("Profile Update PU-100\n\nSubmission details:")
+    assert "Revised Company Name: Acme Steel LLC" in text
+    assert "Comments: New legal name" in text
+    assert "Type: Address change" in text
+    assert "Phone" not in text
+    assert "Effective Date" not in text
+
+
+def test_submission_subject_over_255_characters_fails_without_truncation():
+    client = FakeClient(submissions=[submission(Name="X" * 230)])
+
+    counts = service(client).run()
+
+    assert counts.failed == 1
+    assert not client.created
+
+
+def test_one_record_failure_does_not_prevent_later_records_and_is_retryable():
+    class FailingOnceClient(FakeClient):
+        def post_feed_message(self, record_id, message):
+            if record_id == "audit-1":
+                raise SalesforceError("temporary feed error")
+            super().post_feed_message(record_id, message)
+
+    client = FailingOnceClient(
+        audits=[audit(), audit(Id="audit-2", Cert_Account__c="account-2")]
+    )
+
+    counts = service(client).run()
+
+    assert counts.created == 1
+    assert counts.failed == 1
+    assert len(client.created) == 2
+
+
+def test_service_queries_only_recent_audits_and_new_submissions():
+    client = FakeClient()
+    service(client).run()
+    audit_query, submission_query = client.queries[:2]
+    assert audit_query[1] == AUDIT_FIELDS
+    assert "Cert_Audit_Date__c >= 2026-06-16" in audit_query[2]
+    assert "Cert_Audit_Date__c <= 2026-07-16" in audit_query[2]
+    assert submission_query[1] == SUBMISSION_FIELDS
+    assert submission_query[2] == "Status__c = 'New'"

--- a/tests/test_salesforce.py
+++ b/tests/test_salesforce.py
@@ -34,6 +34,10 @@ class Session:
         self.calls.append(("get", args, kwargs))
         return self.responses.pop(0)
 
+    def patch(self, *args, **kwargs):
+        self.calls.append(("patch", args, kwargs))
+        return self.responses.pop(0)
+
 
 def credentials():
     return {
@@ -128,3 +132,123 @@ def test_query_failure_names_object():
     )
     with pytest.raises(SalesforceError, match="Account.*bad field"):
         client.query_all("Account", [ExportField("Nope", "nope")])
+
+
+def test_filtered_query_supports_sorting_and_pagination():
+    session = Session(
+        [
+            Response(
+                {
+                    "done": False,
+                    "records": [{"Id": "one"}],
+                    "nextRecordsUrl": "/next-page",
+                }
+            ),
+            Response({"done": True, "records": [{"Id": "two"}]}),
+        ]
+    )
+    client = SalesforceClient(SalesforceSession("https://example", "token"), session)
+
+    records = client.query_records(
+        "Case",
+        ["Id", "Subject"],
+        where="AccountId = 'account'",
+        order_by="CreatedDate DESC",
+    )
+
+    assert records == [{"Id": "one"}, {"Id": "two"}]
+    assert session.calls[0][2]["params"]["q"] == (
+        "SELECT Id, Subject FROM Case WHERE AccountId = 'account' "
+        "ORDER BY CreatedDate DESC"
+    )
+    assert session.calls[1][1][0] == "https://example/next-page"
+
+
+def test_record_create_update_and_retrieve_use_salesforce_rest_api():
+    session = Session(
+        [
+            Response({"id": "500-created", "success": True}),
+            Response({}, ok=True),
+            Response({"Id": "500-created", "CaseNumber": "1234"}),
+        ]
+    )
+    client = SalesforceClient(SalesforceSession("https://example", "token"), session)
+
+    assert client.create_record("Case", {"Subject": "Test"}) == "500-created"
+    client.update_record("Case", "500-created", {"Status": "Pending"})
+    record = client.get_record("Case", "500-created", ["Id", "CaseNumber"])
+
+    assert record["CaseNumber"] == "1234"
+    assert session.calls[0] == (
+        "post",
+        ("https://example/services/data/v60.0/sobjects/Case",),
+        {
+            "headers": {
+                "Authorization": "Bearer token",
+                "Content-Type": "application/json",
+            },
+            "json": {"Subject": "Test"},
+            "timeout": 30,
+        },
+    )
+    assert session.calls[1][0] == "patch"
+    assert session.calls[2][2]["params"] == {"fields": "Id,CaseNumber"}
+
+
+def test_feed_messages_follow_pages_and_post_with_subject_id():
+    session = Session(
+        [
+            Response(
+                {
+                    "elements": [
+                        {
+                            "body": {
+                                "messageSegments": [{"type": "Text", "text": "First"}]
+                            }
+                        }
+                    ],
+                    "nextPageUrl": "/feed-next",
+                }
+            ),
+            Response(
+                {
+                    "elements": [
+                        {
+                            "body": {
+                                "messageSegments": [{"type": "Text", "text": "Second"}]
+                            }
+                        }
+                    ]
+                }
+            ),
+            Response({"id": "feed-item"}),
+        ]
+    )
+    client = SalesforceClient(SalesforceSession("https://example", "token"), session)
+
+    assert client.get_feed_messages("500-case") == ["First", "Second"]
+    client.post_feed_message("500-case", "A message")
+
+    assert session.calls[1][1][0] == "https://example/feed-next"
+    assert session.calls[2][2]["json"] == {
+        "body": {"messageSegments": [{"type": "Text", "text": "A message"}]},
+        "feedElementType": "FeedItem",
+        "subjectId": "500-case",
+    }
+
+
+def test_write_and_feed_http_errors_are_wrapped():
+    client = SalesforceClient(
+        SalesforceSession("https://example", "token"),
+        Session([Response([{"message": "not allowed"}], ok=False)]),
+    )
+
+    with pytest.raises(SalesforceError, match="create Case.*not allowed"):
+        client.create_record("Case", {"Subject": "Test"})
+
+    feed_client = SalesforceClient(
+        SalesforceSession("https://example", "token"),
+        Session([Response("server broke", ok=False, text="server broke")]),
+    )
+    with pytest.raises(SalesforceError, match="post Chatter.*server broke"):
+        feed_client.post_feed_message("500-case", "Test")


### PR DESCRIPTION
## Summary
- add the `profile-updates` CLI command for daily Salesforce automation
- create or reuse Account-scoped Profile Update Cases and post idempotent Chatter messages
- add Salesforce record, query, and feed helpers with documentation and tests

Tests: `uv run pytest` (44 passed)

Closes #1