### PR TITLE
Add read-only profile update staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ activemq-data/
 .env.*
 !.env.example
 snapshots/
+staged_profile_updates/
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ Process recent audit notes and New company profile submissions:
 uv run aisc_salesforce profile-updates
 ```
 
-Both commands are also available as a Python module:
+Stage New company profile submissions in a read-only CSV:
+
+```bash
+uv run aisc_salesforce stage-profile-updates
+```
+
+All commands are also available as a Python module:
 
 ```bash
 uv run python -m aisc_salesforce profile-updates
@@ -59,6 +65,44 @@ uv run python -m aisc_salesforce profile-updates
 `profile-updates` prints `created`, `reused`, `skipped`, and `failed` counts. A
 successful run returns exit code `0`; missing configuration or a Salesforce
 failure returns `1`.
+
+### Profile Update staging
+
+`stage-profile-updates` reads every submission whose `Status__c` is `New`. It
+does not create or update any Salesforce records. The default output is:
+
+```text
+staged_profile_updates/YYYY-MM-DDTHH-MM-SSZ/profile_updates.csv
+```
+
+Choose a different parent directory when needed:
+
+```bash
+uv run aisc_salesforce stage-profile-updates \
+  --output-dir /secure/staged-profile-updates
+```
+
+Submissions are grouped by Account ID and the submitter email after trimming
+and case-insensitive comparison. Later nonblank values replace earlier values.
+Different emails stay separate, and every blank-email submission stays
+separate and receives a warning. Each CSV row preserves all source submission
+IDs and names as JSON arrays.
+
+The CSV has shared submission and Account columns, Key Data columns, and
+prefixed role columns for `certification_`, `principal_`, `accounting_`,
+`quality_`, and `new_york_`. Role columns preserve submitted values and record
+the proposed resolution action, Contact ID, resolution source, source
+submission/role, and any role-specific warning. New York does not have a title
+column.
+
+Before processing a staged row, inspect both `has_warnings` and `warnings`.
+`warnings` is newline-separated and identifies ambiguous contacts, incomplete
+Accounts, missing role lookups, partial addresses that could not be filled, and
+other cases needing human review.
+
+Each run creates an independent timestamped directory. The CSV is first written
+inside a temporary directory and is published only after the complete write
+succeeds, so a failed run cannot leave a partial snapshot.
 
 ### Daily scheduling
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,19 @@ Chatter posts use the Connect REST API's
 [feed element format](https://developer.salesforce.com/docs/platform/connect-rest-api/guide/features_feeds_feed_elements.html)
 with the target record supplied as `subjectId`.
 
+## Profile Update staging service
+
+::: aisc_salesforce.stage_profile_updates
+    options:
+      show_root_heading: true
+      members:
+        - StagingResult
+        - ProfileUpdateStagingService
+        - write_staged_profile_updates
+
+`ProfileUpdateStagingService` only reads Salesforce data. The writer publishes
+the resulting rows atomically in a timestamped directory.
+
 ## CLI
 
 ::: aisc_salesforce.app

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,9 @@ Welcome to the **aisc-salesforce** documentation.
 
 ## Overview
 
-aisc-salesforce creates read-only data snapshots and automates daily Profile
-Update Case work from certification audits and participant submissions.
+aisc-salesforce creates read-only data snapshots, stages submitted Profile
+Updates for human review, and automates daily Profile Update Case work from
+certification audits and participant submissions.
 
 ## Quick Links
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,3 +74,95 @@ name, and exact Chatter text to recognize completed work. If a run stops after
 one Chatter post, the next run posts only the missing message.
 
 The project does not install or manage a scheduler itself.
+
+## Stage Profile Updates command
+
+Create a read-only CSV of every New profile-change submission:
+
+```bash
+uv run aisc_salesforce stage-profile-updates
+uv run aisc_salesforce stage-profile-updates \
+  --output-dir /secure/staged-profile-updates
+```
+
+The default file location is:
+
+```text
+staged_profile_updates/YYYY-MM-DDTHH-MM-SSZ/profile_updates.csv
+```
+
+If two runs finish during the same UTC second, the later directory receives a
+numeric suffix such as `-01`. Every run is independent and repeatable. The
+command only queries Salesforce; it never creates or updates a record.
+
+Example output:
+
+```text
+Staged profile updates complete: staged_profile_updates/2026-07-17T12-30-00Z/profile_updates.csv
+staged rows: 7
+warnings: 2
+```
+
+The warning count is the number of newline-separated warnings across all rows.
+Exit code `0` means Salesforce was queried and the complete CSV was published.
+Exit code `1` means configuration, Salesforce communication, or file writing
+failed. A failed write leaves no partially published snapshot.
+
+### Merge rules
+
+Rows are grouped by Account ID plus a trimmed, case-insensitive submitter email.
+Submissions with different Account IDs or emails stay separate. Each submission
+with a blank email also stays separate and receives a warning.
+
+Within a group, submissions are ordered by `CreatedDate` and `Id`. Later
+nonblank values replace earlier values, while blank later values do not erase
+earlier information. Source submission IDs and names are retained as JSON
+arrays.
+
+When at least one revised address component is present, the output contains all
+five components. Missing submitted components are filled from the Account
+billing address where possible.
+
+### CSV contract
+
+Each row contains these groups of columns:
+
+| Group | Columns |
+|---|---|
+| Source and dates | `source_submission_ids`, `source_submission_names`, `earliest_submission_date`, `latest_submission_date` |
+| Account and submitter | `account_id`, `account_name`, `certification_id`, `submitter_name`, `submitter_email`, `submitter_phone` |
+| Notes and review | `comments`, `personnel_notes`, `has_warnings`, `warnings` |
+| Key Data | `effective_date`, revised company name/owner, five revised address columns, and `key_answers` |
+| Contact roles | Columns prefixed with `certification_`, `principal_`, `accounting_`, `quality_`, and `new_york_` |
+
+`key_answers` contains eight labeled lines when a group has Key Data. Each role
+contains its submitted name, title, email, and phone fields, followed by:
+
+- `resolution_action`
+- `salesforce_contact_id`
+- `resolution_source`
+- `source_submission_id`
+- `source_role`
+- `warning`
+
+New York has no submitted title field. Completely blank roles have completely
+blank role columns.
+
+Resolution actions are `update_contact` for an exact match or a title/phone
+update, `change_email` for a new email applied to the Account's current role
+contact, and `use_submitted_contact` when another submitted role is the first
+exact match. Resolution sources show whether the match came from another
+submitted role, an Account Contact, a sibling Account Contact, or the Account's
+current role lookup.
+
+Contact text is compared after trimming and case folding. The resolver does not
+guess nicknames. Name searches stop at the first tier containing candidates:
+other submitted roles, the current Account's Contacts, then Contacts belonging
+to sibling Accounts with the same Parent. Multiple candidates at that first
+tier are reported as ambiguous.
+
+!!! warning
+
+    A future processor must inspect `has_warnings` and `warnings` before acting
+    on a row. The `warnings` field is readable, newline-separated text; role
+    warnings are also copied into the matching prefixed `warning` column.

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -17,6 +17,10 @@ from .salesforce import (
     request_access_token,
 )
 from .snapshot import write_snapshot
+from .stage_profile_updates import (
+    ProfileUpdateStagingService,
+    write_staged_profile_updates,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -38,6 +42,16 @@ def main(argv: list[str] | None = None) -> int:
         "profile-updates",
         help="Process recent audits and New profile update submissions.",
     )
+    stage_parser = subparsers.add_parser(
+        "stage-profile-updates",
+        help="Stage New profile update submissions in a read-only CSV snapshot.",
+    )
+    stage_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("staged_profile_updates"),
+        help="Directory to contain staged profile update folders.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -50,6 +64,12 @@ def main(argv: list[str] | None = None) -> int:
             return _run_profile_updates()
         except (SalesforceError, OSError) as error:
             print(f"Profile updates failed: {error}", file=sys.stderr)
+            return 1
+    if args.command == "stage-profile-updates":
+        try:
+            return _run_stage_profile_updates(args.output_dir)
+        except (SalesforceError, OSError) as error:
+            print(f"Stage profile updates failed: {error}", file=sys.stderr)
             return 1
     return 1
 
@@ -92,6 +112,20 @@ def _run_profile_updates() -> int:
     for error in getattr(service, "errors", []):
         print(error, file=sys.stderr)
     return 1 if counts.failed else 0
+
+
+def _run_stage_profile_updates(output_dir: Path) -> int:
+    """Connect to Salesforce and publish one read-only staging snapshot."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    result = ProfileUpdateStagingService(SalesforceClient(auth)).stage()
+    snapshot_path = write_staged_profile_updates(result.rows, output_dir)
+    print(f"Staged profile updates complete: {snapshot_path / 'profile_updates.csv'}")
+    print(f"staged rows: {len(result.rows)}")
+    print(f"warnings: {result.warning_count}")
+    return 0
 
 
 def get_profile_update_configuration(

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -1,0 +1,800 @@
+"""Build read-only CSV staging snapshots for New profile update submissions."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .profile_updates import SUBMISSION_FIELDS, escape_soql_string
+from .salesforce import SalesforceClient
+
+ACCOUNT_FIELDS = [
+    "Id",
+    "Name",
+    "Certification_ID__c",
+    "BillingStreet",
+    "BillingCity",
+    "BillingState",
+    "BillingPostalCode",
+    "BillingCountry",
+    "ParentId",
+    "Cert_Certification_Contact__c",
+    "Cert_Principal_Contact__c",
+    "Cert_Accounting_Contact__c",
+    "Cert_Marketing_Contact__c",
+    "Cert_Safety_Contact__c",
+]
+
+CONTACT_FIELDS = [
+    "Id",
+    "AccountId",
+    "FirstName",
+    "LastName",
+    "Title",
+    "Email",
+    "Phone",
+]
+
+KEY_ANSWER_FIELDS = [
+    ("Did_the_Cert_contact_change__c", "Certification contact changed"),
+    ("Did_the_executive_manager_change__c", "Executive manager changed"),
+    ("Will_you_change_personnel__c", "Personnel will change"),
+    ("Will_QMS_or_documentation_change__c", "QMS or documentation will change"),
+    (
+        "Existing_equipment_moved_to_new_facility__c",
+        "Existing equipment moved to new facility",
+    ),
+    ("Will_new_equipment_be_purchased__c", "New equipment will be purchased"),
+    ("Will_old_equipment_be_removed__c", "Old equipment will be removed"),
+    ("Will_software_change__c", "Software will change"),
+]
+
+ADDRESS_FIELDS = [
+    ("revised_facility_street", "Revised_Facility_Street__c", "BillingStreet"),
+    ("revised_facility_city", "Revised_Facility_City__c", "BillingCity"),
+    ("revised_facility_state", "Revised_Facility_State__c", "BillingState"),
+    ("revised_facility_zip", "Revised_Facility_Zip__c", "BillingPostalCode"),
+    ("revised_facility_country", "Revised_Facility_Country__c", "BillingCountry"),
+]
+
+
+@dataclass(frozen=True)
+class RoleDefinition:
+    """Map one submitted role to its fields and current Account lookup."""
+
+    prefix: str
+    label: str
+    first_name_field: str
+    last_name_field: str
+    title_field: str | None
+    email_field: str
+    phone_field: str
+    account_lookup: str
+
+    @property
+    def submitted_fields(self) -> list[tuple[str, str]]:
+        """Return pairs of CSV suffixes and Salesforce submission fields."""
+        fields = [
+            ("first_name", self.first_name_field),
+            ("last_name", self.last_name_field),
+        ]
+        if self.title_field is not None:
+            fields.append(("title", self.title_field))
+        fields.extend(
+            [
+                ("email", self.email_field),
+                ("phone", self.phone_field),
+            ]
+        )
+        return fields
+
+
+ROLE_DEFINITIONS = [
+    RoleDefinition(
+        "certification",
+        "Certification",
+        "Cert_First_Name__c",
+        "Cert_Last_Name__c",
+        "Cert_Title__c",
+        "Cert_Email__c",
+        "Cert_Phone__c",
+        "Cert_Certification_Contact__c",
+    ),
+    RoleDefinition(
+        "principal",
+        "Principal",
+        "Principal_First_Name__c",
+        "Principal_Last_Name__c",
+        "Principal_Title__c",
+        "Principal_Email__c",
+        "Principal_Phone__c",
+        "Cert_Principal_Contact__c",
+    ),
+    RoleDefinition(
+        "accounting",
+        "Accounting",
+        "AP_First_Name__c",
+        "AP_Last_Name__c",
+        "AP_Title__c",
+        "AP_Email__c",
+        "AP_Phone__c",
+        "Cert_Accounting_Contact__c",
+    ),
+    RoleDefinition(
+        "quality",
+        "Quality",
+        "Quality_First_Name__c",
+        "Quality_Last_Name__c",
+        "QC_Title__c",
+        "Quality_Email__c",
+        "Quality_Phone__c",
+        "Cert_Marketing_Contact__c",
+    ),
+    RoleDefinition(
+        "new_york",
+        "New York",
+        "NY_First_Name__c",
+        "NY_Last_Name__c",
+        None,
+        "NY_Email__c",
+        "NY_Phone__c",
+        "Cert_Safety_Contact__c",
+    ),
+]
+
+SHARED_COLUMNS = [
+    "source_submission_ids",
+    "source_submission_names",
+    "earliest_submission_date",
+    "latest_submission_date",
+    "account_id",
+    "account_name",
+    "certification_id",
+    "submitter_name",
+    "submitter_email",
+    "submitter_phone",
+    "comments",
+    "personnel_notes",
+    "has_warnings",
+    "warnings",
+]
+
+KEY_COLUMNS = [
+    "effective_date",
+    "revised_company_name",
+    "revised_company_owner",
+    "revised_facility_street",
+    "revised_facility_city",
+    "revised_facility_state",
+    "revised_facility_zip",
+    "revised_facility_country",
+    "key_answers",
+]
+
+ROLE_RESOLUTION_SUFFIXES = [
+    "resolution_action",
+    "salesforce_contact_id",
+    "resolution_source",
+    "source_submission_id",
+    "source_role",
+    "warning",
+]
+
+
+def _role_columns(role: RoleDefinition) -> list[str]:
+    submitted = [f"{role.prefix}_{suffix}" for suffix, _ in role.submitted_fields]
+    resolution = [f"{role.prefix}_{suffix}" for suffix in ROLE_RESOLUTION_SUFFIXES]
+    return submitted + resolution
+
+
+CSV_COLUMNS = [
+    *SHARED_COLUMNS,
+    *KEY_COLUMNS,
+    *(column for role in ROLE_DEFINITIONS for column in _role_columns(role)),
+]
+
+
+@dataclass
+class StagingResult:
+    """Rows and warning totals produced by one read-only staging pass."""
+
+    rows: list[dict[str, str]]
+    warning_count: int
+
+
+@dataclass
+class MergedRole:
+    """A role's latest nonblank submitted values and their source."""
+
+    definition: RoleDefinition
+    values: dict[str, str]
+    source_submission_id: str = ""
+
+
+class ProfileUpdateStagingService:
+    """Query and merge New profile updates without writing to Salesforce."""
+
+    def __init__(self, client: SalesforceClient):
+        self.client = client
+
+    def stage(self) -> StagingResult:
+        """Return deterministic CSV-ready rows for all New submissions."""
+        submissions = self.client.query_records(
+            "Company_Profile_Change__c",
+            SUBMISSION_FIELDS,
+            where="Status__c = 'New'",
+            order_by="CreatedDate ASC, Id ASC",
+        )
+        submissions = sorted(submissions, key=_submission_sort_key)
+
+        requested_account_ids = _unique_text_values(
+            record.get("Account__c") for record in submissions
+        )
+        accounts = self._query_accounts("Id", requested_account_ids)
+        accounts_by_id = {
+            account_id: record
+            for record in accounts
+            if (account_id := _clean_text(record.get("Id")))
+        }
+
+        parent_ids = _unique_text_values(
+            account.get("ParentId") for account in accounts
+        )
+        siblings = self._query_accounts("ParentId", parent_ids)
+        all_accounts_by_id = dict(accounts_by_id)
+        for sibling in siblings:
+            sibling_id = _clean_text(sibling.get("Id"))
+            if sibling_id:
+                all_accounts_by_id.setdefault(sibling_id, sibling)
+
+        contacts = self._query_contacts(list(all_accounts_by_id.values()))
+        grouped = _group_submissions(submissions)
+        rows = [
+            self._build_row(
+                records,
+                accounts_by_id,
+                all_accounts_by_id,
+                contacts,
+            )
+            for records in grouped
+        ]
+        rows.sort(
+            key=lambda row: (
+                row["earliest_submission_date"],
+                row["account_id"],
+                row["source_submission_ids"],
+            )
+        )
+        warning_count = sum(
+            len(row["warnings"].splitlines()) for row in rows if row["warnings"]
+        )
+        return StagingResult(rows, warning_count)
+
+    def _query_accounts(
+        self, field_name: str, values: list[str]
+    ) -> list[dict[str, Any]]:
+        if not values:
+            return []
+        return self.client.query_records(
+            "Account",
+            ACCOUNT_FIELDS,
+            where=_where_in(field_name, values),
+            order_by="Id ASC",
+        )
+
+    def _query_contacts(self, accounts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        account_ids = _unique_text_values(account.get("Id") for account in accounts)
+        lookup_ids = _unique_text_values(
+            account.get(role.account_lookup)
+            for account in accounts
+            for role in ROLE_DEFINITIONS
+        )
+        clauses = []
+        if account_ids:
+            clauses.append(_where_in("AccountId", account_ids))
+        if lookup_ids:
+            clauses.append(_where_in("Id", lookup_ids))
+        if not clauses:
+            return []
+        where = clauses[0] if len(clauses) == 1 else f"({' OR '.join(clauses)})"
+        return self.client.query_records(
+            "Contact",
+            CONTACT_FIELDS,
+            where=where,
+            order_by="AccountId ASC, Id ASC",
+        )
+
+    def _build_row(
+        self,
+        records: list[dict[str, Any]],
+        accounts_by_id: dict[str, dict[str, Any]],
+        all_accounts_by_id: dict[str, dict[str, Any]],
+        contacts: list[dict[str, Any]],
+    ) -> dict[str, str]:
+        row = {column: "" for column in CSV_COLUMNS}
+        merged = _merge_records(records)
+        warnings: list[str] = []
+
+        account_id = _clean_text(merged.get("Account__c"))
+        account = accounts_by_id.get(account_id)
+        row.update(
+            {
+                "source_submission_ids": json.dumps(
+                    [_clean_text(record.get("Id")) for record in records],
+                    ensure_ascii=False,
+                ),
+                "source_submission_names": json.dumps(
+                    [_clean_text(record.get("Name")) for record in records],
+                    ensure_ascii=False,
+                ),
+                "earliest_submission_date": _clean_text(records[0].get("CreatedDate")),
+                "latest_submission_date": _clean_text(records[-1].get("CreatedDate")),
+                "account_id": account_id,
+                "account_name": _account_name(account, merged),
+                "certification_id": _first_nonblank(
+                    account.get("Certification_ID__c") if account else None,
+                    merged.get("Certification_ID__c"),
+                ),
+                "submitter_name": _clean_text(merged.get("Name__c")),
+                "submitter_email": _clean_text(merged.get("Email__c")),
+                "submitter_phone": _clean_text(merged.get("Phone__c")),
+                "comments": _display_value(merged.get("Comments__c")),
+                "personnel_notes": _display_value(
+                    merged.get("Other_Personnel_Notes__c")
+                ),
+                "effective_date": _display_value(merged.get("Effective_Date__c")),
+                "revised_company_name": _display_value(
+                    merged.get("Revised_Company_Name__c")
+                ),
+                "revised_company_owner": _display_value(
+                    merged.get("Revised_Company_Owner__c")
+                ),
+            }
+        )
+
+        if not row["submitter_email"]:
+            warnings.append("Submission group has a blank submitter email.")
+        if not account_id:
+            warnings.append("Submission does not contain an Account ID.")
+        elif account is None:
+            warnings.append(f"Account {account_id} could not be retrieved.")
+        else:
+            if not _clean_text(account.get("Name")):
+                warnings.append(f"Account {account_id} has no Account Name.")
+            if not row["certification_id"]:
+                warnings.append(f"Account {account_id} has no Certification ID.")
+
+        for record in records:
+            if not _clean_text(record.get("CreatedDate")):
+                source_id = _clean_text(record.get("Id")) or "(unknown)"
+                warnings.append(f"Submission {source_id} has no CreatedDate.")
+
+        self._populate_address(row, merged, account, warnings)
+        self._populate_key_answers(row, merged)
+
+        merged_roles = _merge_roles(records)
+        for merged_role in merged_roles:
+            self._populate_role(
+                row,
+                merged_role,
+                merged_roles,
+                account,
+                all_accounts_by_id,
+                contacts,
+                warnings,
+            )
+
+        row["has_warnings"] = "true" if warnings else "false"
+        row["warnings"] = "\n".join(warnings)
+        return row
+
+    @staticmethod
+    def _populate_address(
+        row: dict[str, str],
+        merged: dict[str, Any],
+        account: dict[str, Any] | None,
+        warnings: list[str],
+    ) -> None:
+        supplied = any(
+            _has_value(merged.get(api_name)) for _, api_name, _ in ADDRESS_FIELDS
+        )
+        if not supplied:
+            return
+        for csv_name, api_name, billing_name in ADDRESS_FIELDS:
+            value = _display_value(merged.get(api_name))
+            if not value and account is not None:
+                value = _display_value(account.get(billing_name))
+            row[csv_name] = value
+            if not value:
+                readable = csv_name.removeprefix("revised_facility_").replace("_", " ")
+                warnings.append(
+                    f"Revised address {readable} is blank and could not be "
+                    "filled from the Account billing address."
+                )
+
+    @staticmethod
+    def _populate_key_answers(row: dict[str, str], merged: dict[str, Any]) -> None:
+        key_fields = [
+            "Effective_Date__c",
+            "Revised_Company_Name__c",
+            "Revised_Company_Owner__c",
+            *(api_name for _, api_name, _ in ADDRESS_FIELDS),
+            *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
+        ]
+        is_key_data = _normalized(merged.get("Type__c")) == "key data"
+        if not is_key_data and not any(
+            _has_value(merged.get(api_name)) for api_name in key_fields
+        ):
+            return
+        row["key_answers"] = "\n".join(
+            f"{label}: {_display_value(merged.get(api_name))}"
+            for api_name, label in KEY_ANSWER_FIELDS
+        )
+
+    @staticmethod
+    def _populate_role(
+        row: dict[str, str],
+        role: MergedRole,
+        all_roles: list[MergedRole],
+        account: dict[str, Any] | None,
+        all_accounts_by_id: dict[str, dict[str, Any]],
+        contacts: list[dict[str, Any]],
+        warnings: list[str],
+    ) -> None:
+        prefix = role.definition.prefix
+        if not role.values:
+            return
+        for suffix, _ in role.definition.submitted_fields:
+            row[f"{prefix}_{suffix}"] = role.values.get(suffix, "")
+
+        resolution, warning = _resolve_role(
+            role,
+            all_roles,
+            account,
+            all_accounts_by_id,
+            contacts,
+        )
+        for suffix in ROLE_RESOLUTION_SUFFIXES:
+            if suffix == "warning":
+                continue
+            row[f"{prefix}_{suffix}"] = resolution.get(suffix, "")
+        row[f"{prefix}_warning"] = warning
+        if warning:
+            warnings.append(f"{role.definition.label} role: {warning}")
+
+
+def _group_submissions(
+    submissions: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for index, record in enumerate(submissions):
+        account_id = _clean_text(record.get("Account__c"))
+        email = _normalized(record.get("Email__c"))
+        record_id = _clean_text(record.get("Id")) or str(index)
+        account_key = account_id or f"blank-account:{record_id}"
+        email_key = email or f"blank-email:{record_id}"
+        groups.setdefault((account_key, email_key), []).append(record)
+    return list(groups.values())
+
+
+def _merge_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for record in records:
+        for key, value in record.items():
+            if _has_value(value):
+                merged[key] = value
+    return merged
+
+
+def _merge_roles(records: list[dict[str, Any]]) -> list[MergedRole]:
+    roles: list[MergedRole] = []
+    for definition in ROLE_DEFINITIONS:
+        values: dict[str, str] = {}
+        source_submission_id = ""
+        for record in records:
+            supplied_here = False
+            for suffix, api_name in definition.submitted_fields:
+                if _has_value(record.get(api_name)):
+                    values[suffix] = _display_value(record.get(api_name))
+                    supplied_here = True
+            if supplied_here:
+                source_submission_id = _clean_text(record.get("Id"))
+        roles.append(MergedRole(definition, values, source_submission_id))
+    return roles
+
+
+def _resolve_role(
+    role: MergedRole,
+    all_roles: list[MergedRole],
+    account: dict[str, Any] | None,
+    all_accounts_by_id: dict[str, dict[str, Any]],
+    contacts: list[dict[str, Any]],
+) -> tuple[dict[str, str], str]:
+    values = role.values
+    first_name = values.get("first_name", "")
+    last_name = values.get("last_name", "")
+    email = values.get("email", "")
+    title = values.get("title", "")
+    phone = values.get("phone", "")
+
+    submitted_candidates = [
+        candidate
+        for candidate in all_roles
+        if candidate.definition.prefix != role.definition.prefix and candidate.values
+    ]
+    account_id = _clean_text(account.get("Id")) if account else ""
+    parent_id = _clean_text(account.get("ParentId")) if account else ""
+    sibling_ids = {
+        candidate_id
+        for candidate_id, candidate in all_accounts_by_id.items()
+        if candidate_id != account_id
+        and parent_id
+        and _clean_text(candidate.get("ParentId")) == parent_id
+    }
+    account_contacts = [
+        contact
+        for contact in contacts
+        if _clean_text(contact.get("AccountId")) == account_id
+    ]
+    sibling_contacts = [
+        contact
+        for contact in contacts
+        if _clean_text(contact.get("AccountId")) in sibling_ids
+    ]
+
+    if first_name:
+        tiers = [
+            (
+                "submitted_role",
+                _matching_submitted_names(submitted_candidates, first_name, last_name),
+            ),
+            (
+                "account_contact",
+                _matching_contact_names(account_contacts, first_name, last_name),
+            ),
+            (
+                "sibling_contact",
+                _matching_contact_names(sibling_contacts, first_name, last_name),
+            ),
+        ]
+        return _first_tier_resolution(tiers)
+
+    if last_name:
+        return {}, "Last-name-only input cannot be resolved safely."
+
+    if email:
+        tiers = [
+            (
+                "submitted_role",
+                [
+                    candidate
+                    for candidate in submitted_candidates
+                    if _normalized(candidate.values.get("email")) == _normalized(email)
+                ],
+            ),
+            (
+                "account_contact",
+                [
+                    contact
+                    for contact in account_contacts
+                    if _normalized(contact.get("Email")) == _normalized(email)
+                ],
+            ),
+            (
+                "sibling_contact",
+                [
+                    contact
+                    for contact in sibling_contacts
+                    if _normalized(contact.get("Email")) == _normalized(email)
+                ],
+            ),
+        ]
+        resolution, warning = _first_tier_resolution(tiers, no_match_is_warning=False)
+        if resolution or warning:
+            return resolution, warning
+        return _existing_role_resolution(
+            account,
+            role.definition,
+            action="change_email",
+            missing_message="Email does not match a known contact",
+        )
+
+    if title or phone:
+        return _existing_role_resolution(
+            account,
+            role.definition,
+            action="update_contact",
+            missing_message="Partial contact update",
+        )
+
+    return {}, "Submitted role fields could not be resolved."
+
+
+def _matching_submitted_names(
+    candidates: list[MergedRole], first_name: str, last_name: str
+) -> list[MergedRole]:
+    return [
+        candidate
+        for candidate in candidates
+        if _normalized(candidate.values.get("first_name")) == _normalized(first_name)
+        and (
+            not last_name
+            or _normalized(candidate.values.get("last_name")) == _normalized(last_name)
+        )
+    ]
+
+
+def _matching_contact_names(
+    contacts: list[dict[str, Any]], first_name: str, last_name: str
+) -> list[dict[str, Any]]:
+    return [
+        contact
+        for contact in contacts
+        if _normalized(contact.get("FirstName")) == _normalized(first_name)
+        and (
+            not last_name
+            or _normalized(contact.get("LastName")) == _normalized(last_name)
+        )
+    ]
+
+
+def _first_tier_resolution(
+    tiers: list[tuple[str, list[Any]]], *, no_match_is_warning: bool = True
+) -> tuple[dict[str, str], str]:
+    for source, candidates in tiers:
+        if not candidates:
+            continue
+        if len(candidates) > 1:
+            return (
+                {},
+                f"Resolution is ambiguous: {len(candidates)} matches in "
+                f"{source.replace('_', ' ')}.",
+            )
+        candidate = candidates[0]
+        if isinstance(candidate, MergedRole):
+            return (
+                {
+                    "resolution_action": "use_submitted_contact",
+                    "resolution_source": source,
+                    "source_submission_id": candidate.source_submission_id,
+                    "source_role": candidate.definition.prefix,
+                },
+                "",
+            )
+        return (
+            {
+                "resolution_action": "update_contact",
+                "salesforce_contact_id": _clean_text(candidate.get("Id")),
+                "resolution_source": source,
+            },
+            "",
+        )
+    if no_match_is_warning:
+        return {}, "No exact contact match was found."
+    return {}, ""
+
+
+def _existing_role_resolution(
+    account: dict[str, Any] | None,
+    definition: RoleDefinition,
+    *,
+    action: str,
+    missing_message: str,
+) -> tuple[dict[str, str], str]:
+    contact_id = _clean_text(account.get(definition.account_lookup)) if account else ""
+    if not contact_id:
+        return (
+            {},
+            f"{missing_message}, and the Account has no existing "
+            f"{definition.label} role contact.",
+        )
+    return (
+        {
+            "resolution_action": action,
+            "salesforce_contact_id": contact_id,
+            "resolution_source": "account_role_lookup",
+        },
+        "",
+    )
+
+
+def write_staged_profile_updates(
+    rows: list[dict[str, str]],
+    output_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> Path:
+    """Atomically publish one timestamped ``profile_updates.csv`` snapshot."""
+    timestamp = (now or datetime.now(UTC)).astimezone(UTC)
+    folder_name = timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_path = _available_snapshot_path(output_dir, folder_name)
+    temporary_path = output_dir / f".{folder_name}-{uuid4().hex}.tmp"
+    try:
+        temporary_path.mkdir()
+        _write_profile_updates_csv(
+            temporary_path / "profile_updates.csv",
+            rows,
+        )
+        os.replace(temporary_path, final_path)
+    except Exception:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+    return final_path
+
+
+def _write_profile_updates_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as output:
+        writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _available_snapshot_path(output_dir: Path, folder_name: str) -> Path:
+    candidate = output_dir / folder_name
+    number = 1
+    while candidate.exists():
+        candidate = output_dir / f"{folder_name}-{number:02d}"
+        number += 1
+    return candidate
+
+
+def _submission_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        _clean_text(record.get("CreatedDate")),
+        _clean_text(record.get("Id")),
+    )
+
+
+def _where_in(field_name: str, values: list[str]) -> str:
+    quoted = ", ".join(f"'{escape_soql_string(value)}'" for value in sorted(values))
+    return f"{field_name} IN ({quoted})"
+
+
+def _unique_text_values(values: Any) -> list[str]:
+    return sorted({_clean_text(value) for value in values if _clean_text(value)})
+
+
+def _account_name(account: dict[str, Any] | None, merged: dict[str, Any]) -> str:
+    if account is not None and _clean_text(account.get("Name")):
+        return _clean_text(account.get("Name"))
+    relationship = merged.get("Account__r")
+    if isinstance(relationship, dict):
+        return _clean_text(relationship.get("Name"))
+    return ""
+
+
+def _first_nonblank(*values: Any) -> str:
+    for value in values:
+        if _has_value(value):
+            return _display_value(value)
+    return ""
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    return not isinstance(value, str) or bool(value.strip())
+
+
+def _display_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    return str(value).strip()
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalized(value: Any) -> str:
+    return _clean_text(value).casefold()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,67 @@ def test_profile_updates_cli_is_nonzero_when_records_fail(monkeypatch, capsys):
 
     assert app.main(["profile-updates"]) == 1
     assert "audit-1: feed unavailable" in capsys.readouterr().err
+
+
+def test_stage_profile_updates_cli_uses_custom_output_and_prints_counts(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app, "get_credentials", lambda env: {"ok": "yes"})
+    monkeypatch.setattr(app, "get_oauth_url", lambda env: "https://example/token")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: object()
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: object())
+
+    class Result:
+        rows = [{"has_warnings": "true"}, {"has_warnings": "false"}]
+        warning_count = 1
+
+    class Service:
+        def __init__(self, client):
+            pass
+
+        def stage(self):
+            return Result()
+
+    monkeypatch.setattr(app, "ProfileUpdateStagingService", Service)
+    monkeypatch.setattr(
+        app,
+        "write_staged_profile_updates",
+        lambda rows, output_dir: output_dir / "finished",
+    )
+
+    assert app.main(["stage-profile-updates", "--output-dir", str(tmp_path)]) == 0
+    output = capsys.readouterr().out
+    assert str(tmp_path / "finished" / "profile_updates.csv") in output
+    assert "staged rows: 2" in output
+    assert "warnings: 1" in output
+
+
+def test_stage_profile_updates_cli_reports_salesforce_failure(monkeypatch, capsys):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(
+        app,
+        "get_credentials",
+        lambda env: (_ for _ in ()).throw(
+            app.SalesforceError("Salesforce unavailable")
+        ),
+    )
+
+    assert app.main(["stage-profile-updates"]) == 1
+    assert (
+        "Stage profile updates failed: Salesforce unavailable"
+        in capsys.readouterr().err
+    )
+
+
+def test_stage_profile_updates_cli_reports_file_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        app,
+        "_run_stage_profile_updates",
+        lambda output_dir: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    assert app.main(["stage-profile-updates"]) == 1
+    assert "Stage profile updates failed: disk full" in capsys.readouterr().err

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -1,0 +1,389 @@
+import csv
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from aisc_salesforce.stage_profile_updates import (
+    ACCOUNT_FIELDS,
+    CONTACT_FIELDS,
+    CSV_COLUMNS,
+    ProfileUpdateStagingService,
+    write_staged_profile_updates,
+)
+
+
+def submission(**changes):
+    record = {
+        "Id": "submission-1",
+        "Name": "PU-100",
+        "CreatedDate": "2026-07-15T14:30:00.000+0000",
+        "Status__c": "New",
+        "Account__c": "account-1",
+        "Account__r": {"Name": "Acme Steel"},
+        "Email__c": "submitter@example.com",
+        "Name__c": "Sam Submitter",
+        "Phone__c": "312-555-0100",
+    }
+    record.update(changes)
+    return record
+
+
+def account(**changes):
+    record = {
+        "Id": "account-1",
+        "Name": "Acme Steel",
+        "Certification_ID__c": "C-100",
+        "BillingStreet": "1 Main St",
+        "BillingCity": "Chicago",
+        "BillingState": "IL",
+        "BillingPostalCode": "60601",
+        "BillingCountry": "USA",
+        "ParentId": "parent-1",
+        "Cert_Certification_Contact__c": "contact-cert",
+        "Cert_Principal_Contact__c": "contact-principal",
+        "Cert_Accounting_Contact__c": "contact-accounting",
+        "Cert_Marketing_Contact__c": "contact-quality",
+        "Cert_Safety_Contact__c": "contact-ny",
+    }
+    record.update(changes)
+    return record
+
+
+class FakeClient:
+    def __init__(self, submissions, accounts=None, siblings=None, contacts=None):
+        self.submissions = submissions
+        self.accounts = accounts or []
+        self.siblings = siblings or []
+        self.contacts = contacts or []
+        self.queries = []
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where, order_by))
+        if object_name == "Company_Profile_Change__c":
+            return list(self.submissions)
+        if object_name == "Account":
+            if where and where.startswith("Id IN"):
+                return list(self.accounts)
+            return list(self.siblings)
+        if object_name == "Contact":
+            return list(self.contacts)
+        raise AssertionError(object_name)
+
+
+def stage(submissions, *, accounts=None, siblings=None, contacts=None):
+    client = FakeClient(submissions, accounts, siblings, contacts)
+    result = ProfileUpdateStagingService(client).stage()
+    return result, client
+
+
+def test_merges_same_account_and_email_with_later_nonblank_values():
+    first = submission(
+        Id="submission-1",
+        Name="PU-100",
+        Revised_Company_Name__c="Acme Company",
+        Comments__c="First comment",
+    )
+    second = submission(
+        Id="submission-2",
+        Name="PU-101",
+        CreatedDate="2026-07-16T14:30:00.000+0000",
+        Email__c=" SUBMITTER@EXAMPLE.COM ",
+        Revised_Company_Name__c="Acme Company LLC",
+        Comments__c="",
+    )
+
+    result, client = stage([second, first], accounts=[account()])
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert json.loads(row["source_submission_ids"]) == [
+        "submission-1",
+        "submission-2",
+    ]
+    assert json.loads(row["source_submission_names"]) == ["PU-100", "PU-101"]
+    assert row["earliest_submission_date"] == first["CreatedDate"]
+    assert row["latest_submission_date"] == second["CreatedDate"]
+    assert row["revised_company_name"] == "Acme Company LLC"
+    assert row["comments"] == "First comment"
+    assert client.queries[0][3] == "CreatedDate ASC, Id ASC"
+    assert client.queries[1][1] == ACCOUNT_FIELDS
+    assert client.queries[-1][1] == CONTACT_FIELDS
+
+
+def test_keeps_different_emails_separate_and_blank_emails_independent():
+    records = [
+        submission(Id="one", Email__c="first@example.com"),
+        submission(Id="two", Email__c="second@example.com"),
+        submission(Id="three", Email__c=""),
+        submission(Id="four", Email__c="  "),
+    ]
+
+    result, _ = stage(records, accounts=[account()])
+
+    assert len(result.rows) == 4
+    blank_rows = [row for row in result.rows if not row["submitter_email"]]
+    assert len(blank_rows) == 2
+    assert all(row["has_warnings"] == "true" for row in blank_rows)
+    assert all("blank submitter email" in row["warnings"].lower() for row in blank_rows)
+
+
+def test_different_accounts_stay_separate_and_merged_row_can_have_key_and_role_data():
+    records = [
+        submission(
+            Id="key",
+            Revised_Company_Owner__c="Taylor Owner",
+        ),
+        submission(
+            Id="role",
+            CreatedDate="2026-07-16T14:30:00.000+0000",
+            Cert_Email__c="new-cert@example.com",
+        ),
+        submission(
+            Id="other-account",
+            Account__c="account-2",
+            Account__r={"Name": "Other Steel"},
+        ),
+    ]
+
+    result, _ = stage(
+        records,
+        accounts=[account(), account(Id="account-2", Name="Other Steel")],
+    )
+
+    assert len(result.rows) == 2
+    merged = next(row for row in result.rows if row["account_id"] == "account-1")
+    assert merged["revised_company_owner"] == "Taylor Owner"
+    assert merged["certification_email"] == "new-cert@example.com"
+
+
+def test_partial_address_uses_account_billing_address():
+    record = submission(
+        Revised_Facility_Street__c="99 New Ave",
+        Revised_Facility_City__c="",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["revised_facility_street"] == "99 New Ave"
+    assert row["revised_facility_city"] == "Chicago"
+    assert row["revised_facility_state"] == "IL"
+    assert row["revised_facility_zip"] == "60601"
+    assert row["revised_facility_country"] == "USA"
+
+
+def test_complete_address_does_not_use_account_billing_values():
+    record = submission(
+        Revised_Facility_Street__c="2 New St",
+        Revised_Facility_City__c="Gary",
+        Revised_Facility_State__c="IN",
+        Revised_Facility_Zip__c="46402",
+        Revised_Facility_Country__c="USA",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert [
+        row["revised_facility_street"],
+        row["revised_facility_city"],
+        row["revised_facility_state"],
+        row["revised_facility_zip"],
+        row["revised_facility_country"],
+    ] == ["2 New St", "Gary", "IN", "46402", "USA"]
+
+
+def test_key_answers_are_labeled_and_blank_roles_stay_empty():
+    record = submission(
+        Type__c=" key DATA ",
+        Did_the_Cert_contact_change__c="Yes",
+        Will_software_change__c="No",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert "Certification contact changed: Yes" in row["key_answers"]
+    assert "Software will change: No" in row["key_answers"]
+    assert len(row["key_answers"].splitlines()) == 8
+    for column in CSV_COLUMNS:
+        if column.startswith("certification_") and column != "certification_id":
+            assert row[column] == ""
+
+
+def test_name_resolution_stops_at_first_candidate_tier():
+    record = submission(
+        Cert_First_Name__c="Jordan",
+        Cert_Last_Name__c="Lee",
+        Principal_First_Name__c=" jordan ",
+        Principal_Last_Name__c="LEE",
+        Principal_Email__c="jordan@example.com",
+    )
+    contacts = [
+        {
+            "Id": "account-jordan",
+            "AccountId": "account-1",
+            "FirstName": "Jordan",
+            "LastName": "Lee",
+            "Title": "Manager",
+            "Email": "old@example.com",
+            "Phone": "123",
+        }
+    ]
+
+    result, _ = stage([record], accounts=[account()], contacts=contacts)
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "use_submitted_contact"
+    assert row["certification_resolution_source"] == "submitted_role"
+    assert row["certification_source_submission_id"] == "submission-1"
+    assert row["certification_source_role"] == "principal"
+    assert row["certification_salesforce_contact_id"] == ""
+
+
+def test_name_resolution_uses_account_then_sibling_contacts_and_warns_on_ambiguity():
+    account_contact = {
+        "Id": "account-match",
+        "AccountId": "account-1",
+        "FirstName": "Taylor",
+        "LastName": "Kim",
+        "Email": "taylor@example.com",
+    }
+    sibling_contact = {
+        "Id": "sibling-match",
+        "AccountId": "sibling-1",
+        "FirstName": "Morgan",
+        "LastName": "Reed",
+        "Email": "morgan@example.com",
+    }
+    record = submission(
+        Cert_First_Name__c="Taylor",
+        Principal_First_Name__c="Morgan",
+        Principal_Last_Name__c="Reed",
+    )
+    sibling = account(Id="sibling-1", Name="Acme West")
+
+    result, _ = stage(
+        [record],
+        accounts=[account()],
+        siblings=[sibling],
+        contacts=[account_contact, sibling_contact],
+    )
+
+    row = result.rows[0]
+    assert row["certification_salesforce_contact_id"] == "account-match"
+    assert row["certification_resolution_source"] == "account_contact"
+    assert row["principal_salesforce_contact_id"] == "sibling-match"
+    assert row["principal_resolution_source"] == "sibling_contact"
+
+    result, _ = stage(
+        [submission(Cert_First_Name__c="Taylor")],
+        accounts=[account()],
+        contacts=[account_contact, {**account_contact, "Id": "duplicate"}],
+    )
+    assert "ambiguous" in result.rows[0]["certification_warning"].lower()
+
+
+def test_email_and_partial_field_resolution_use_existing_role_contact():
+    matching = {
+        "Id": "existing-email",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Email": "known@example.com",
+    }
+    record = submission(
+        Cert_Email__c="KNOWN@example.com",
+        AP_Email__c="new@example.com",
+        QC_Title__c="Quality Director",
+        NY_Phone__c="312-555-0188",
+    )
+
+    result, _ = stage([record], accounts=[account()], contacts=[matching])
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "update_contact"
+    assert row["certification_salesforce_contact_id"] == "existing-email"
+    assert row["accounting_resolution_action"] == "change_email"
+    assert row["accounting_salesforce_contact_id"] == "contact-accounting"
+    assert row["quality_resolution_action"] == "update_contact"
+    assert row["quality_salesforce_contact_id"] == "contact-quality"
+    assert row["new_york_resolution_action"] == "update_contact"
+    assert row["new_york_salesforce_contact_id"] == "contact-ny"
+
+
+def test_missing_account_and_last_name_only_are_staged_with_warnings():
+    record = submission(
+        Account__c="missing-account",
+        Cert_Last_Name__c="Nguyen",
+    )
+
+    result, _ = stage([record])
+
+    row = result.rows[0]
+    assert row["account_id"] == "missing-account"
+    assert row["account_name"] == "Acme Steel"
+    assert row["has_warnings"] == "true"
+    assert "could not be retrieved" in row["warnings"]
+    assert "last-name-only" in row["certification_warning"].lower()
+
+
+def test_unresolved_name_and_missing_role_lookup_have_explicit_warnings():
+    record = submission(
+        Cert_First_Name__c="Bob",
+        Cert_Last_Name__c="Jones",
+        AP_Title__c="Controller",
+    )
+    contact = {
+        "Id": "robert",
+        "AccountId": "account-1",
+        "FirstName": "Robert",
+        "LastName": "Jones",
+        "Email": "robert@example.com",
+    }
+
+    result, _ = stage(
+        [record],
+        accounts=[account(Cert_Accounting_Contact__c="")],
+        contacts=[contact],
+    )
+
+    row = result.rows[0]
+    assert row["certification_salesforce_contact_id"] == ""
+    assert "No exact contact match" in row["certification_warning"]
+    assert "no existing Accounting role contact" in row["accounting_warning"]
+
+
+def test_writer_publishes_csv_atomically_and_repeated_runs_are_independent(tmp_path):
+    rows = [{column: "" for column in CSV_COLUMNS}]
+    now = datetime(2026, 7, 17, 12, 30, tzinfo=UTC)
+
+    first = write_staged_profile_updates(rows, tmp_path, now=now)
+    second = write_staged_profile_updates(rows, tmp_path, now=now)
+
+    assert first != second
+    assert first.name == "2026-07-17T12-30-00Z"
+    assert second.name == "2026-07-17T12-30-00Z-01"
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert (first / "profile_updates.csv").read_bytes() == (
+        second / "profile_updates.csv"
+    ).read_bytes()
+    with (first / "profile_updates.csv").open(newline="", encoding="utf-8") as source:
+        reader = csv.DictReader(source)
+        assert reader.fieldnames == CSV_COLUMNS
+        assert list(reader) == rows
+
+
+def test_writer_removes_temporary_output_after_failure(monkeypatch, tmp_path):
+    from aisc_salesforce import stage_profile_updates
+
+    def fail(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(stage_profile_updates, "_write_profile_updates_csv", fail)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_staged_profile_updates([], tmp_path)
+
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- Add a read-only `stage-profile-updates` CLI command that groups New submissions and writes timestamped CSV snapshots.
- Resolve submitted contacts with explicit actions and warnings for human review.
- Document the staging workflow and add comprehensive service, writer, and CLI tests.

Closes #3