### PR TITLE
Add interactive profile update processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ activemq-data/
 !.env.example
 snapshots/
 staged_profile_updates/
+profile_updates.csv
+review_audit.jsonl
+response_emails.txt
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -93,12 +93,17 @@ prefixed role columns for `certification_`, `principal_`, `accounting_`,
 `quality_`, and `new_york_`. Role columns preserve submitted values and record
 the proposed resolution action, Contact ID, resolution source, source
 submission/role, and any role-specific warning. New York does not have a title
-column.
+column. When an existing Contact is resolved, a missing title or phone is
+filled from that Contact where possible. Repeating the same contact information
+in several roles does not create a warning, but conflicting emails for the same
+submitted name are treated as ambiguous.
 
 Before processing a staged row, inspect both `has_warnings` and `warnings`.
 `warnings` is newline-separated and identifies ambiguous contacts, incomplete
 Accounts, missing role lookups, partial addresses that could not be filled, and
-other cases needing human review.
+other cases needing human review. An unmatched submitted name uses the
+`create_contact` resolution action and warns that a new Contact will need to be
+created.
 
 Each run creates an independent timestamped directory. The CSV is first written
 inside a temporary directory and is published only after the complete write

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Set these values in `.env`:
 
 - `SF_CLIENT_ID` and `SF_CLIENT_SECRET`: credentials for the existing
   Salesforce Connected App.
-- `CERTIFICATION_QUEUE_ID`: the Case owner used by `profile-updates`.
+- `CERTIFICATION_QUEUE_ID`: the Case owner used by `profile-updates` and
+  `process-profile-updates`.
 - `PRIMARY_RESPONDER_ID`: the Case Primary Responder used by
-  `profile-updates`.
+  `profile-updates` and `process-profile-updates`.
 - `SF_LOGIN_URL` (optional): an org URL or complete OAuth token URL. It
   defaults to Salesforce's production login service.
 
@@ -54,6 +55,12 @@ Stage New company profile submissions in a read-only CSV:
 
 ```bash
 uv run aisc_salesforce stage-profile-updates
+```
+
+Create/reuse Cases, publish a fresh staging CSV, and review it interactively:
+
+```bash
+uv run aisc_salesforce process-profile-updates
 ```
 
 All commands are also available as a Python module:
@@ -109,10 +116,69 @@ Each run creates an independent timestamped directory. The CSV is first written
 inside a temporary directory and is published only after the complete write
 succeeds, so a failed run cannot leave a partial snapshot.
 
+### Interactive Profile Update processing
+
+`process-profile-updates` performs the complete processing workflow in this
+order:
+
+1. Run the existing Case automation.
+2. Stop if any required Case operation fails.
+3. Publish a fresh `profile_updates.csv`.
+4. Read that published file back from disk.
+5. Review rows in Account-and-Case batches.
+
+Use `--output-dir` the same way as the staging command:
+
+```bash
+uv run aisc_salesforce process-profile-updates \
+  --output-dir /secure/staged-profile-updates
+```
+
+Each real field change requires one complete decision phrase:
+
+- `apply automatically` writes the displayed value to Salesforce.
+- `make manually` pauses for the reviewer to make the change, then refetches
+  Salesforce and continues only if the value matches.
+- `will not be made` records the rejection without changing Salesforce.
+
+Already-current values are recorded as no-ops and do not prompt. For each
+submitted Contact role, the command displays fresh Contact candidates and asks
+the reviewer to create a Contact, select an existing Contact, or decline. It
+then reviews Contact fields individually and treats the Account role lookup as
+a separate decision. A Contact without the Salesforce-required Last Name
+cannot be created automatically.
+
+The timestamped staging folder contains:
+
+```text
+profile_updates.csv
+review_audit.jsonl
+response_emails.txt
+```
+
+The JSON Lines audit is flushed after every decision and Salesforce result.
+The response file contains one generated paragraph per submitter email. The
+command prints the text but does not send email itself; after sending it
+through the normal email system, the reviewer confirms `yes` or `no`.
+
+When all rows in a Case batch are resolved, source Profile Updates are set to
+`Closed`. The Case is set to `Closed` only after every generated response is
+confirmed sent; otherwise it remains `Pending`. An interruption, failed write,
+or failed manual verification leaves unfinalized Profile Updates open and the
+Case Pending. A retry creates a new staging snapshot of open records and
+records already-applied Salesforce values as no-ops.
+
+> [!WARNING]
+> Staging, audit, and response files contain personal and Salesforce data.
+> They are ignored by Git, but they must still be stored in an
+> access-controlled location and shared only through approved secure channels.
+
 ### Daily scheduling
 
-The command is non-interactive, so an external scheduler can run it once per
-day. For example, a Linux cron entry can change to the repository and run it at
+The `profile-updates` Case-preparation command is non-interactive, so an
+external scheduler can run it once per day. The
+`process-profile-updates` review command remains interactive. For example, a
+Linux cron entry can change to the repository and run Case preparation at
 2:00 AM:
 
 ```cron

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,40 @@ with the target record supplied as `subjectId`.
         - write_staged_profile_updates
 
 `ProfileUpdateStagingService` only reads Salesforce data. The writer publishes
-the resulting rows atomically in a timestamped directory.
+the resulting rows atomically in a timestamped directory. Rows include
+blocking-safe Case match fields plus Key Update presence and earliest-date
+metadata.
+
+## Interactive Profile Update processing
+
+::: aisc_salesforce.process_profile_updates
+    options:
+      show_root_heading: true
+      members:
+        - ChangeProposal
+        - ReviewDecision
+        - ActionResult
+        - ActionStatus
+        - CaseBatch
+        - ProcessingResult
+        - ProcessingError
+        - ProcessingInterrupted
+        - ProfileUpdateProcessingWorkflow
+        - InteractiveProfileUpdateProcessor
+        - read_staged_profile_updates
+        - build_case_batches
+        - format_response_emails
+
+`ProfileUpdateProcessingWorkflow` keeps Case preparation, staging publication,
+disk validation, and review in a fixed order. The smaller processing data types
+keep proposal construction, decisions, execution, response formatting, and
+audit writing separate.
+
+`InteractiveProfileUpdateProcessor` refetches a target immediately before each
+decision. It writes `review_audit.jsonl` after every result and
+`response_emails.txt` for applied or manually verified changes. Profile Update
+closure and the Case's final status happen only after the entire Case batch is
+resolved.
 
 ## CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ Welcome to the **aisc-salesforce** documentation.
 ## Overview
 
 aisc-salesforce creates read-only data snapshots, stages submitted Profile
-Updates for human review, and automates daily Profile Update Case work from
-certification audits and participant submissions.
+Updates, automates Profile Update Case work, and provides an audited interactive
+review command for approved Account and Contact changes.
 
 ## Quick Links
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -150,16 +150,22 @@ blank role columns.
 
 Resolution actions are `update_contact` for an exact match or a title/phone
 update, `change_email` for a new email applied to the Account's current role
-contact, and `use_submitted_contact` when another submitted role is the first
-exact match. Resolution sources show whether the match came from another
-submitted role, an Account Contact, a sibling Account Contact, or the Account's
-current role lookup.
+contact, `use_submitted_contact` when another submitted role is the first exact
+match, and `create_contact` when an unmatched submitted name describes a new
+Contact. A missing Contact ID or a `create_contact` action always comes with a
+warning for human review. Resolution sources show whether the match came from
+another submitted role, submitted data for a new Contact, an Account Contact, a
+sibling Account Contact, or the Account's current role lookup.
 
 Contact text is compared after trimming and case folding. The resolver does not
 guess nicknames. Name searches stop at the first tier containing candidates:
 other submitted roles, the current Account's Contacts, then Contacts belonging
 to sibling Accounts with the same Parent. Multiple candidates at that first
-tier are reported as ambiguous.
+tier are reported as ambiguous. Repeated identical contact information in
+several submitted roles counts as one candidate; the same name paired with
+conflicting emails remains ambiguous. When a Contact is resolved, missing title
+and phone values are filled from that Contact where possible. Missing title or
+phone alone does not cause a warning.
 
 !!! warning
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -169,6 +169,104 @@ phone alone does not cause a warning.
 
 !!! warning
 
-    A future processor must inspect `has_warnings` and `warnings` before acting
-    on a row. The `warnings` field is readable, newline-separated text; role
-    warnings are also copied into the matching prefixed `warning` column.
+    The interactive processor inspects `has_warnings` and `warnings` before
+    acting on a row. The `warnings` field is readable, newline-separated text;
+    role warnings are also copied into the matching prefixed `warning` column.
+
+Case preparation adds `case_id`, `case_number`, `case_status`, and
+`case_match_status`. A row is processable only when its match status is
+`matched`. Missing and ambiguous Case matches are blocking warnings and are
+never guessed.
+
+Key Update metadata is explicit:
+
+- `has_key_updates` is `true` when at least one source is marked as Key Data or
+  contains a Key Update field.
+- `earliest_key_update_date` is the oldest such source `CreatedDate`.
+
+## Process Profile Updates command
+
+Run the Case preparation, fresh staging, and interactive review as one command:
+
+```bash
+uv run aisc_salesforce process-profile-updates
+uv run aisc_salesforce process-profile-updates \
+  --output-dir /secure/staged-profile-updates
+```
+
+The command has no dry-run option. A staged recommendation alone never causes
+a Salesforce data change. The command first runs `ProfileUpdateService`; if
+Case creation or reuse fails, it stops before staging or review. It then
+publishes and validates a new CSV and groups all rows with the same Account and
+Case. Batches containing a Key Update strictly older than seven days are
+reviewed first, followed by the remaining batches from oldest to newest.
+
+### What the reviewer sees
+
+Before decisions, the command fetches current Profile Update, Account, Contact,
+and Account History data. Account History is limited to the source submission
+day in `America/Chicago`. Its field, previous value, new value, and timestamp
+are displayed together with Comments, Other Personnel notes, Key Update
+answers, effective date, and warnings.
+
+Account name, company owner, and each billing-address component are separate
+proposals. Effective date and the Key Update answers remain context unless
+they map to one of those real Account fields.
+
+For a real change, type exactly one of:
+
+| Decision | Result |
+|---|---|
+| `apply automatically` | Update Salesforce with the proposed value |
+| `make manually` | Pause, refetch, and verify the reviewer’s Salesforce change |
+| `will not be made` | Record the rejection without a Salesforce data change |
+
+An already-current value is an audited no-op. It does not prompt and does not
+appear in response-email text.
+
+For a submitted Contact role, first choose `create contact`, `select existing`,
+or `decline`. Fresh candidate Contacts are displayed. Contact fields are then
+reviewed individually, followed by a separate proposal for the Account role
+lookup. Automatic Contact creation requires a Last Name; incomplete data must
+be completed manually or declined.
+
+### Output and finalization
+
+Each timestamped run folder contains:
+
+| File | Purpose |
+|---|---|
+| `profile_updates.csv` | Exact published staging input used by the reviewer |
+| `review_audit.jsonl` | One immediately flushed JSON object per decision/result |
+| `response_emails.txt` | Generated response text grouped by submitter email |
+
+Only automatically applied and manually verified changes appear in response
+text. Each item uses `ITEM: NEW INFORMATION` followed by
+`Replaces OLD INFORMATION`. The Account paragraph begins:
+
+> Thank you for updating your information with AISC. The changes are summarized
+> below. An updated Participant Portal login will be sent by a separate email,
+> if needed. Unless otherwise noted, previous contacts will remain in the
+> {ACCOUNT NAME} contact list.
+
+The command generates and prints email text; it does not send email. The
+reviewer sends it through the approved email system and confirms whether it was
+sent.
+
+After a resolved batch, source Profile Updates are set to `Closed`. The Case is
+set to `Closed` only when every generated response is confirmed sent. If a
+response is not sent, the source records are closed and the Case stays
+`Pending`.
+
+On interruption, a Salesforce failure, or a manual value that does not verify,
+the audit is flushed, unfinalized source Profile Updates stay open, the Case is
+kept Pending, and the command exits nonzero. Retrying restages open records.
+Values applied before the interruption are fetched again and recorded as
+no-ops, so they are not applied or emailed twice.
+
+!!! warning
+
+    All three artifacts can contain sensitive personal and Salesforce data.
+    Git ignores their default location and generated filenames. Store custom
+    output directories securely, limit access, and do not attach these files
+    to public issues or commits.

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from .dictionary import DictionaryError, load_export_plan
+from .process_profile_updates import (
+    InteractiveProfileUpdateProcessor,
+    ProcessingError,
+    ProfileUpdateProcessingWorkflow,
+)
 from .profile_updates import ProfileUpdateService
 from .salesforce import (
     SalesforceClient,
@@ -23,7 +29,12 @@ from .stage_profile_updates import (
 )
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> int:
     """Run the CLI and return a shell-friendly status code."""
     parser = argparse.ArgumentParser(
         description="Run AISC Salesforce data and workflow commands."
@@ -52,6 +63,16 @@ def main(argv: list[str] | None = None) -> int:
         default=Path("staged_profile_updates"),
         help="Directory to contain staged profile update folders.",
     )
+    process_parser = subparsers.add_parser(
+        "process-profile-updates",
+        help="Create/reuse Cases, stage submissions, and review changes interactively.",
+    )
+    process_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("staged_profile_updates"),
+        help="Directory to contain staging, audit, and response artifacts.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -70,6 +91,16 @@ def main(argv: list[str] | None = None) -> int:
             return _run_stage_profile_updates(args.output_dir)
         except (SalesforceError, OSError) as error:
             print(f"Stage profile updates failed: {error}", file=sys.stderr)
+            return 1
+    if args.command == "process-profile-updates":
+        try:
+            return _run_process_profile_updates(
+                args.output_dir,
+                input_fn=input_fn,
+                output_fn=output_fn,
+            )
+        except (ProcessingError, SalesforceError, OSError) as error:
+            print(f"Process profile updates failed: {error}", file=sys.stderr)
             return 1
     return 1
 
@@ -125,6 +156,37 @@ def _run_stage_profile_updates(output_dir: Path) -> int:
     print(f"Staged profile updates complete: {snapshot_path / 'profile_updates.csv'}")
     print(f"staged rows: {len(result.rows)}")
     print(f"warnings: {result.warning_count}")
+    return 0
+
+
+def _run_process_profile_updates(
+    output_dir: Path,
+    *,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Connect to Salesforce and run the interactive Profile Update workflow."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    queue_id, responder_id = get_profile_update_configuration(environment)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    client = SalesforceClient(auth)
+    workflow = ProfileUpdateProcessingWorkflow(
+        ProfileUpdateService(client, queue_id, responder_id),
+        ProfileUpdateStagingService(client),
+        InteractiveProfileUpdateProcessor(
+            client,
+            input_fn=input_fn,
+            output_fn=output_fn,
+        ),
+    )
+    result = workflow.run(output_dir)
+    output_fn(f"Processed Profile Updates from: {result.staging_path}")
+    output_fn(f"Audit trail: {result.audit_path}")
+    output_fn(f"Response emails: {result.response_path}")
+    output_fn(f"completed Case batches: {result.completed_batches}")
+    output_fn(f"pending Case batches: {result.pending_batches}")
     return 0
 
 

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -1,0 +1,1344 @@
+"""Interactive, audited processing for staged Profile Update submissions."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, time, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, TextIO
+from zoneinfo import ZoneInfo
+
+from .profile_updates import SUBMISSION_FIELDS, AutomationCounts, escape_soql_string
+from .salesforce import SalesforceClient, SalesforceError
+from .stage_profile_updates import (
+    CSV_COLUMNS,
+    ROLE_DEFINITIONS,
+    ProfileUpdateStagingService,
+    StagingResult,
+    write_staged_profile_updates,
+)
+
+CHICAGO = ZoneInfo("America/Chicago")
+
+ACCOUNT_REVIEW_FIELDS = [
+    "Id",
+    "Name",
+    "Company_Owner__c",
+    "BillingStreet",
+    "BillingCity",
+    "BillingState",
+    "BillingPostalCode",
+    "BillingCountry",
+    *(role.account_lookup for role in ROLE_DEFINITIONS),
+]
+
+CONTACT_REVIEW_FIELDS = [
+    "Id",
+    "AccountId",
+    "FirstName",
+    "LastName",
+    "Title",
+    "Email",
+    "Phone",
+]
+
+ACCOUNT_HISTORY_FIELDS = [
+    "Id",
+    "AccountId",
+    "Field",
+    "OldValue",
+    "NewValue",
+    "CreatedDate",
+]
+
+ACCOUNT_PROPOSALS = [
+    ("revised_company_name", "Revised_Company_Name__c", "Name", "Company Name"),
+    (
+        "revised_company_owner",
+        "Revised_Company_Owner__c",
+        "Company_Owner__c",
+        "Company Owner",
+    ),
+    (
+        "revised_facility_street",
+        "Revised_Facility_Street__c",
+        "BillingStreet",
+        "Billing Street",
+    ),
+    (
+        "revised_facility_city",
+        "Revised_Facility_City__c",
+        "BillingCity",
+        "Billing City",
+    ),
+    (
+        "revised_facility_state",
+        "Revised_Facility_State__c",
+        "BillingState",
+        "Billing State",
+    ),
+    (
+        "revised_facility_zip",
+        "Revised_Facility_Zip__c",
+        "BillingPostalCode",
+        "Billing ZIP",
+    ),
+    (
+        "revised_facility_country",
+        "Revised_Facility_Country__c",
+        "BillingCountry",
+        "Billing Country",
+    ),
+]
+
+CONTACT_SUFFIX_FIELDS = [
+    ("first_name", "FirstName", "First Name"),
+    ("last_name", "LastName", "Last Name"),
+    ("title", "Title", "Title"),
+    ("email", "Email", "Email"),
+    ("phone", "Phone", "Phone"),
+]
+
+ACCOUNT_EMAIL_OPENING = (
+    "Thank you for updating your information with AISC. The changes are "
+    "summarized below. An updated Participant Portal login will be sent by a "
+    "separate email, if needed. Unless otherwise noted, previous contacts will "
+    "remain in the {account_name} contact list."
+)
+
+
+class ProcessingError(RuntimeError):
+    """The interactive workflow could not finish safely."""
+
+
+class ProcessingInterrupted(ProcessingError):
+    """The reviewer interrupted processing before the batch was finalized."""
+
+
+class ReviewDecision(StrEnum):
+    """The only decisions allowed for a real Salesforce change."""
+
+    APPLY_AUTOMATICALLY = "apply automatically"
+    MAKE_MANUALLY = "make manually"
+    WILL_NOT_BE_MADE = "will not be made"
+
+
+class ActionStatus(StrEnum):
+    """Durable outcomes written to the JSON Lines audit."""
+
+    APPLIED = "applied"
+    VERIFIED_MANUAL = "verified manually"
+    REJECTED = "rejected"
+    NOOP = "no-op"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True)
+class ChangeProposal:
+    """One proposed field or record change shown to the reviewer."""
+
+    source_submission_ids: tuple[str, ...]
+    case_id: str
+    account_id: str
+    account_name: str
+    submitter_email: str
+    target_object: str
+    target_record_id: str
+    field_name: str
+    label: str
+    original_value: Any
+    proposed_value: Any
+    case_number: str = ""
+    context: str = ""
+    warnings: str = ""
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """The reviewer decision and the resulting Salesforce outcome."""
+
+    proposal: ChangeProposal
+    decision: ReviewDecision | None
+    status: ActionStatus
+    action: str = ""
+    error: str = ""
+
+
+@dataclass
+class CaseBatch:
+    """All staged rows that belong to one Account and one Case."""
+
+    account_id: str
+    case_id: str
+    case_number: str
+    rows: list[dict[str, str]]
+    earliest_submission: datetime
+    earliest_key_update: datetime | None = None
+
+    @property
+    def source_submission_ids(self) -> tuple[str, ...]:
+        """Return source IDs in stable first-seen order."""
+        return tuple(
+            dict.fromkeys(
+                source_id
+                for row in self.rows
+                for source_id in _json_string_list(row["source_submission_ids"])
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ProcessingResult:
+    """Artifacts and counts returned after interactive review."""
+
+    staging_path: Path
+    audit_path: Path
+    response_path: Path
+    completed_batches: int
+    pending_batches: int
+
+
+class ProfileUpdateProcessingWorkflow:
+    """Run Case preparation, staging, disk validation, then interactive review."""
+
+    def __init__(
+        self,
+        case_service: Any,
+        staging_service: ProfileUpdateStagingService,
+        processor: InteractiveProfileUpdateProcessor,
+        *,
+        staging_writer: Callable[
+            [list[dict[str, str]], Path], Path
+        ] = write_staged_profile_updates,
+    ):
+        self.case_service = case_service
+        self.staging_service = staging_service
+        self.processor = processor
+        self.staging_writer = staging_writer
+
+    def run(self, output_dir: Path) -> ProcessingResult | Any:
+        """Execute setup in the required order and review the published CSV."""
+        counts: AutomationCounts = self.case_service.run()
+        if counts.failed:
+            details = "; ".join(getattr(self.case_service, "errors", []))
+            suffix = f": {details}" if details else ""
+            raise ProcessingError(
+                f"{counts.failed} required Case operation(s) failed{suffix}"
+            )
+        staged: StagingResult = self.staging_service.stage()
+        staging_path = self.staging_writer(staged.rows, output_dir)
+        rows = read_staged_profile_updates(staging_path / "profile_updates.csv")
+        result = self.processor.review(rows, staging_path)
+        if isinstance(result, ProcessingResult):
+            return ProcessingResult(
+                staging_path=staging_path,
+                audit_path=result.audit_path,
+                response_path=result.response_path,
+                completed_batches=result.completed_batches,
+                pending_batches=result.pending_batches,
+            )
+        return result
+
+
+def read_staged_profile_updates(path: Path) -> list[dict[str, str]]:
+    """Read and validate the exact CSV that was published for review."""
+    with path.open(newline="", encoding="utf-8") as source:
+        reader = csv.DictReader(source)
+        missing = [
+            column for column in CSV_COLUMNS if column not in (reader.fieldnames or [])
+        ]
+        if missing:
+            raise ProcessingError(
+                "Staging CSV is missing required columns: " + ", ".join(missing)
+            )
+        rows = list(reader)
+    for number, row in enumerate(rows, start=2):
+        try:
+            source_ids = _json_string_list(row["source_submission_ids"])
+        except (TypeError, ValueError) as error:
+            raise ProcessingError(
+                f"Staging CSV row {number} has invalid source submission IDs."
+            ) from error
+        if not source_ids:
+            raise ProcessingError(
+                f"Staging CSV row {number} has no source submission IDs."
+            )
+    return rows
+
+
+def build_case_batches(
+    rows: list[dict[str, str]], *, now: datetime | None = None
+) -> list[CaseBatch]:
+    """Group rows by Account/Case and put overdue Key Updates first."""
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for row in rows:
+        case_id = row.get("case_id", "").strip()
+        match_status = row.get("case_match_status", "").strip()
+        if not case_id or match_status != "matched":
+            names = row.get("source_submission_names", "")
+            raise ProcessingError(
+                f"Staging row {names} has a blocking Case match ({match_status or 'missing'})."
+            )
+        account_id = row.get("account_id", "").strip()
+        if not account_id:
+            raise ProcessingError(
+                f"Case {case_id} has a staging row without an Account."
+            )
+        grouped.setdefault((account_id, case_id), []).append(row)
+
+    batches: list[CaseBatch] = []
+    for (account_id, case_id), batch_rows in grouped.items():
+        earliest_submission = min(
+            _required_datetime(row.get("earliest_submission_date", ""))
+            for row in batch_rows
+        )
+        key_dates = [
+            _required_datetime(row["earliest_key_update_date"])
+            for row in batch_rows
+            if row.get("has_key_updates") == "true"
+            and row.get("earliest_key_update_date", "").strip()
+        ]
+        batches.append(
+            CaseBatch(
+                account_id=account_id,
+                case_id=case_id,
+                case_number=next(
+                    (
+                        row.get("case_number", "").strip()
+                        for row in batch_rows
+                        if row.get("case_number", "").strip()
+                    ),
+                    "",
+                ),
+                rows=batch_rows,
+                earliest_submission=earliest_submission,
+                earliest_key_update=min(key_dates) if key_dates else None,
+            )
+        )
+
+    current = _aware_datetime(now or datetime.now(UTC))
+    overdue_before = current - timedelta(days=7)
+    batches.sort(
+        key=lambda batch: (
+            0
+            if batch.earliest_key_update is not None
+            and batch.earliest_key_update < overdue_before
+            else 1,
+            batch.earliest_submission,
+            batch.account_id,
+            batch.case_id,
+        )
+    )
+    return batches
+
+
+class _AuditWriter:
+    def __init__(self, path: Path, now: Callable[[], datetime]):
+        self.path = path
+        self.now = now
+        self.output: TextIO | None = None
+
+    def __enter__(self) -> _AuditWriter:
+        self.output = self.path.open("a", encoding="utf-8")
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        if self.output is not None:
+            self.output.close()
+
+    def append(self, result: ActionResult) -> None:
+        if self.output is None:
+            raise RuntimeError("Audit writer is not open.")
+        proposal = result.proposal
+        entry = {
+            "source_submission_ids": list(proposal.source_submission_ids),
+            "case_id": proposal.case_id,
+            "case_number": proposal.case_number,
+            "account_id": proposal.account_id,
+            "submitter_email": proposal.submitter_email,
+            "target_object": proposal.target_object,
+            "target_record_id": proposal.target_record_id,
+            "field": proposal.field_name,
+            "label": proposal.label,
+            "original_value": proposal.original_value,
+            "proposed_value": proposal.proposed_value,
+            "context": proposal.context,
+            "warnings": proposal.warnings,
+            "decision": result.decision.value if result.decision else "",
+            "action": result.action,
+            "result": result.status.value,
+            "error": result.error,
+            "timestamp": self.now().astimezone(UTC).isoformat(),
+        }
+        self.output.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+        self.output.flush()
+        os.fsync(self.output.fileno())
+
+
+class _ResponseWriter:
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.touch()
+
+    def append(self, case_id: str, email: str, text: str) -> None:
+        with self.path.open("a", encoding="utf-8") as output:
+            output.write(f"Case {case_id}\nTo: {email}\n\n{text}\n\n")
+            output.flush()
+            os.fsync(output.fileno())
+
+
+class InteractiveProfileUpdateProcessor:
+    """Review each fresh Salesforce value and audit every decision immediately."""
+
+    def __init__(
+        self,
+        client: SalesforceClient,
+        *,
+        input_fn: Callable[[str], str] = input,
+        output_fn: Callable[[str], None] = print,
+        now: datetime | None = None,
+    ):
+        self.client = client
+        self.input_fn = input_fn
+        self.output_fn = output_fn
+        self.now = _aware_datetime(now or datetime.now(UTC))
+        self._audit: _AuditWriter | None = None
+
+    def review(
+        self, rows: list[dict[str, str]], artifact_dir: Path
+    ) -> ProcessingResult:
+        """Review all rows and return interruption-safe local artifacts."""
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        audit_path = artifact_dir / "review_audit.jsonl"
+        response_path = artifact_dir / "response_emails.txt"
+        response_writer = _ResponseWriter(response_path)
+        batches = build_case_batches(rows, now=self.now)
+        completed = 0
+        pending = 0
+        try:
+            with _AuditWriter(audit_path, lambda: datetime.now(UTC)) as audit:
+                self._audit = audit
+                for batch in batches:
+                    try:
+                        is_pending = self._review_batch(batch, response_writer)
+                    except ProcessingInterrupted:
+                        self._keep_case_pending(batch)
+                        raise
+                    except (KeyboardInterrupt, EOFError) as error:
+                        self._append_batch_event(
+                            batch,
+                            ActionStatus.INTERRUPTED,
+                            action="review batch",
+                            error="Reviewer interrupted processing.",
+                        )
+                        self._keep_case_pending(batch)
+                        raise ProcessingInterrupted(
+                            "Profile Update review was interrupted."
+                        ) from error
+                    except (ProcessingError, SalesforceError) as error:
+                        if isinstance(error, SalesforceError):
+                            self._append_batch_event(
+                                batch,
+                                ActionStatus.FAILED,
+                                action="review batch",
+                                error=str(error),
+                            )
+                        self._keep_case_pending(batch)
+                        if isinstance(error, ProcessingError):
+                            raise
+                        raise ProcessingError(str(error)) from error
+                    completed += 1
+                    pending += int(is_pending)
+        finally:
+            self._audit = None
+        return ProcessingResult(
+            staging_path=artifact_dir,
+            audit_path=audit_path,
+            response_path=response_path,
+            completed_batches=completed,
+            pending_batches=pending,
+        )
+
+    def _review_batch(self, batch: CaseBatch, response_writer: _ResponseWriter) -> bool:
+        self.output_fn(
+            f"\nReviewing Case {batch.case_number or batch.case_id} "
+            f"for Account {batch.account_id}"
+        )
+        self._update_status_with_audit(
+            batch,
+            batch.case_id,
+            "Case",
+            "Status",
+            "Pending",
+            action="prepare batch",
+        )
+        results: list[ActionResult] = []
+        for row in batch.rows:
+            fresh_submissions = self._fresh_submissions(row)
+            self._show_submission_context(row, fresh_submissions)
+            self._show_account_history(row, fresh_submissions)
+            results.extend(
+                self._review_account_proposals(batch, row, fresh_submissions)
+            )
+            results.extend(self._review_roles(batch, row, fresh_submissions))
+
+        emails = format_response_emails(results)
+        all_sent = True
+        for email, text in emails.items():
+            response_writer.append(batch.case_id, email, text)
+            self.output_fn(f"\nResponse email for {email}:\n{text}")
+            sent = self._prompt_yes_no(
+                f"Was the response email to {email} sent? [yes/no]: "
+            )
+            all_sent = all_sent and sent
+
+        successful_without_email = any(
+            result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
+            and not result.proposal.submitter_email.strip()
+            for result in results
+        )
+        all_sent = all_sent and not successful_without_email
+        for source_id in batch.source_submission_ids:
+            self._update_status_with_audit(
+                batch,
+                source_id,
+                "Company_Profile_Change__c",
+                "Status__c",
+                "Closed",
+            )
+        case_status = "Closed" if all_sent else "Pending"
+        self._update_status_with_audit(
+            batch,
+            batch.case_id,
+            "Case",
+            "Status",
+            case_status,
+        )
+        return not all_sent
+
+    def _fresh_submissions(self, row: dict[str, str]) -> list[dict[str, Any]]:
+        return [
+            self.client.get_record(
+                "Company_Profile_Change__c",
+                source_id,
+                SUBMISSION_FIELDS,
+            )
+            for source_id in _json_string_list(row["source_submission_ids"])
+        ]
+
+    def _show_submission_context(
+        self,
+        row: dict[str, str],
+        submissions: list[dict[str, Any]],
+    ) -> None:
+        self.output_fn(
+            f"Account: {row.get('account_name') or row.get('account_id')}\n"
+            f"Submitter: {row.get('submitter_name')} <{row.get('submitter_email')}>"
+        )
+        for submission in submissions:
+            self.output_fn(
+                f"Profile Update {submission.get('Name') or submission.get('Id')} "
+                f"(status: {submission.get('Status__c', '')})"
+            )
+            comments = _display(submission.get("Comments__c"))
+            notes = _display(submission.get("Other_Personnel_Notes__c"))
+            if comments:
+                self.output_fn(f"Comments: {comments}")
+            if notes:
+                self.output_fn(f"Other Personnel notes: {notes}")
+        if row.get("effective_date"):
+            self.output_fn(f"Effective date: {row['effective_date']}")
+        if row.get("key_answers"):
+            self.output_fn(f"Key Update answers:\n{row['key_answers']}")
+        if row.get("warnings"):
+            self.output_fn(f"Warnings:\n{row['warnings']}")
+
+    def _show_account_history(
+        self,
+        row: dict[str, str],
+        submissions: list[dict[str, Any]],
+    ) -> None:
+        account_id = row["account_id"]
+        days = {
+            _required_datetime(_display(submission.get("CreatedDate")))
+            .astimezone(CHICAGO)
+            .date()
+            for submission in submissions
+            if _display(submission.get("CreatedDate"))
+        }
+        for day in sorted(days):
+            local_start = datetime.combine(day, time.min, tzinfo=CHICAGO)
+            local_end = local_start + timedelta(days=1)
+            start = local_start.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            end = local_end.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            history = self.client.query_records(
+                "AccountHistory",
+                ACCOUNT_HISTORY_FIELDS,
+                where=(
+                    f"AccountId = '{escape_soql_string(account_id)}' "
+                    f"AND CreatedDate >= {start} AND CreatedDate < {end}"
+                ),
+                order_by="CreatedDate ASC, Id ASC",
+            )
+            for item in history:
+                self.output_fn(
+                    "Account History: "
+                    f"{item.get('Field')} changed from "
+                    f"{_display(item.get('OldValue')) or '(blank)'} to "
+                    f"{_display(item.get('NewValue')) or '(blank)'} at "
+                    f"{item.get('CreatedDate')}"
+                )
+
+    def _review_account_proposals(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        submissions: list[dict[str, Any]],
+    ) -> list[ActionResult]:
+        results = []
+        for csv_name, source_field, account_field, label in ACCOUNT_PROPOSALS:
+            proposed = row.get(csv_name, "").strip()
+            fresh_value = _latest_nonblank(submissions, source_field)
+            if fresh_value:
+                proposed = fresh_value
+            if not proposed:
+                continue
+            proposal = self._proposal(
+                batch,
+                row,
+                target_object="Account",
+                target_record_id=batch.account_id,
+                field_name=account_field,
+                label=label,
+                proposed_value=proposed,
+            )
+            results.append(self._review_proposal(proposal))
+        return results
+
+    def _review_roles(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        submissions: list[dict[str, Any]],
+    ) -> list[ActionResult]:
+        results: list[ActionResult] = []
+        for role in ROLE_DEFINITIONS:
+            prefix = role.prefix
+            submitted = {
+                suffix: (
+                    _latest_nonblank(submissions, source_field)
+                    or row.get(f"{prefix}_{suffix}", "").strip()
+                )
+                for suffix, source_field in role.submitted_fields
+            }
+            if not any(submitted.values()):
+                continue
+            contacts = self._fresh_contact_candidates(
+                batch.account_id,
+                row.get(f"{prefix}_salesforce_contact_id", "").strip(),
+            )
+            self.output_fn(f"\n{role.label} Contact candidates:")
+            if contacts:
+                for number, contact in enumerate(contacts, start=1):
+                    self.output_fn(
+                        f"{number}. {contact.get('FirstName', '')} "
+                        f"{contact.get('LastName', '')} "
+                        f"<{contact.get('Email', '')}> [{contact.get('Id')}]"
+                    )
+            else:
+                self.output_fn("(none)")
+
+            choice = self._prompt_contact_choice(role.label)
+            contact_id = ""
+            if choice == "select existing":
+                contact_id = self._select_contact_id(contacts)
+            elif choice == "create contact":
+                created = self._review_new_contact(batch, row, role.label, submitted)
+                results.append(created)
+                if created.status in {
+                    ActionStatus.APPLIED,
+                    ActionStatus.VERIFIED_MANUAL,
+                }:
+                    contact_id = created.proposal.target_record_id
+            else:
+                declined = self._proposal(
+                    batch,
+                    row,
+                    target_object="Account",
+                    target_record_id=batch.account_id,
+                    field_name=role.account_lookup,
+                    label=f"{role.label} Account Role",
+                    proposed_value="No role change",
+                    original_value="",
+                )
+                result = ActionResult(
+                    declined,
+                    ReviewDecision.WILL_NOT_BE_MADE,
+                    ActionStatus.REJECTED,
+                    action="decline contact",
+                )
+                self._append_audit(result)
+                results.append(result)
+
+            if not contact_id:
+                continue
+            for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+                if suffix == "title" and role.title_field is None:
+                    continue
+                proposed = submitted.get(suffix, "")
+                if not proposed:
+                    continue
+                proposal = self._proposal(
+                    batch,
+                    row,
+                    target_object="Contact",
+                    target_record_id=contact_id,
+                    field_name=contact_field,
+                    label=f"{role.label} Contact {field_label}",
+                    proposed_value=proposed,
+                )
+                results.append(self._review_proposal(proposal))
+
+            role_proposal = self._proposal(
+                batch,
+                row,
+                target_object="Account",
+                target_record_id=batch.account_id,
+                field_name=role.account_lookup,
+                label=f"{role.label} Account Role",
+                proposed_value=contact_id,
+            )
+            results.append(self._review_proposal(role_proposal))
+        return results
+
+    def _fresh_contact_candidates(
+        self, account_id: str, staged_contact_id: str
+    ) -> list[dict[str, Any]]:
+        where = f"AccountId = '{escape_soql_string(account_id)}'"
+        if staged_contact_id:
+            where = f"({where} OR Id = '{escape_soql_string(staged_contact_id)}')"
+        contacts = self.client.query_records(
+            "Contact",
+            CONTACT_REVIEW_FIELDS,
+            where=where,
+            order_by="LastName ASC, FirstName ASC, Id ASC",
+        )
+        return [dict(contact) for contact in contacts]
+
+    def _review_new_contact(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        role_label: str,
+        submitted: dict[str, str],
+    ) -> ActionResult:
+        first_name = submitted.get("first_name", "")
+        last_name = submitted.get("last_name", "")
+        display_name = " ".join(value for value in (first_name, last_name) if value)
+        proposal = self._proposal(
+            batch,
+            row,
+            target_object="Contact",
+            target_record_id="(new)",
+            field_name="Contact",
+            label=f"{role_label} Contact",
+            proposed_value=display_name,
+            original_value="",
+        )
+        if not last_name:
+            self.output_fn(
+                f"{role_label} Contact cannot be created automatically because "
+                "the required Last Name field is missing."
+            )
+        self._show_proposal(proposal)
+        try:
+            decision = self._prompt_decision(
+                automatic_allowed=bool(last_name),
+            )
+        except (KeyboardInterrupt, EOFError) as error:
+            result = ActionResult(
+                proposal,
+                None,
+                ActionStatus.INTERRUPTED,
+                action="create Contact",
+                error="Reviewer interrupted processing.",
+            )
+            self._append_audit(result)
+            raise ProcessingInterrupted(
+                "Profile Update review was interrupted."
+            ) from error
+
+        if decision is ReviewDecision.WILL_NOT_BE_MADE:
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.REJECTED,
+                action="create Contact",
+            )
+            self._append_audit(result)
+            return result
+        if decision is ReviewDecision.MAKE_MANUALLY:
+            try:
+                contact_id = self.input_fn(
+                    "Create/select the Contact in Salesforce, then enter its Contact ID: "
+                ).strip()
+                if not contact_id:
+                    raise ProcessingError(
+                        "A Contact ID is required for manual verification."
+                    )
+                fresh = self.client.get_record(
+                    "Contact", contact_id, CONTACT_REVIEW_FIELDS
+                )
+            except (KeyboardInterrupt, EOFError) as error:
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.INTERRUPTED,
+                    action="verify manual Contact creation",
+                    error="Reviewer interrupted processing.",
+                )
+                self._append_audit(result)
+                raise ProcessingInterrupted(
+                    "Profile Update review was interrupted."
+                ) from error
+            except ProcessingError as error:
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="verify manual Contact creation",
+                    error=str(error),
+                )
+                self._append_audit(result)
+                raise
+            except SalesforceError as error:
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="verify manual Contact creation",
+                    error=str(error),
+                )
+                self._append_audit(result)
+                raise ProcessingError(str(error)) from error
+            if not _values_equal(
+                fresh.get("FirstName"), first_name
+            ) or not _values_equal(fresh.get("LastName"), last_name):
+                error = "Manually selected Contact does not match the proposed name."
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="verify manual Contact creation",
+                    error=error,
+                )
+                self._append_audit(result)
+                raise ProcessingError(error)
+            verified_proposal = ChangeProposal(
+                **{
+                    **proposal.__dict__,
+                    "target_record_id": contact_id,
+                }
+            )
+            result = ActionResult(
+                verified_proposal,
+                decision,
+                ActionStatus.VERIFIED_MANUAL,
+                action="verify manual Contact creation",
+            )
+            self._append_audit(result)
+            return result
+
+        payload = {
+            "AccountId": batch.account_id,
+            "LastName": last_name,
+        }
+        if first_name:
+            payload["FirstName"] = first_name
+        try:
+            contact_id = self.client.create_record("Contact", payload)
+        except SalesforceError as error:
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.FAILED,
+                action="create Contact",
+                error=str(error),
+            )
+            self._append_audit(result)
+            raise ProcessingError(str(error)) from error
+        created_proposal = ChangeProposal(
+            **{
+                **proposal.__dict__,
+                "target_record_id": contact_id,
+            }
+        )
+        result = ActionResult(
+            created_proposal,
+            decision,
+            ActionStatus.APPLIED,
+            action="create Contact",
+        )
+        self._append_audit(result)
+        return result
+
+    def _proposal(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        *,
+        target_object: str,
+        target_record_id: str,
+        field_name: str,
+        label: str,
+        proposed_value: Any,
+        original_value: Any | None = None,
+    ) -> ChangeProposal:
+        return ChangeProposal(
+            source_submission_ids=tuple(
+                _json_string_list(row["source_submission_ids"])
+            ),
+            case_id=batch.case_id,
+            case_number=batch.case_number,
+            account_id=batch.account_id,
+            account_name=row.get("account_name", ""),
+            submitter_email=row.get("submitter_email", ""),
+            target_object=target_object,
+            target_record_id=target_record_id,
+            field_name=field_name,
+            label=label,
+            original_value=original_value,
+            proposed_value=proposed_value,
+            context=_proposal_context(row),
+            warnings=row.get("warnings", ""),
+        )
+
+    def _review_proposal(self, proposal: ChangeProposal) -> ActionResult:
+        try:
+            fresh = self.client.get_record(
+                proposal.target_object,
+                proposal.target_record_id,
+                ["Id", proposal.field_name],
+            )
+        except SalesforceError as error:
+            failed = ActionResult(
+                proposal,
+                None,
+                ActionStatus.FAILED,
+                action="fetch current value",
+                error=str(error),
+            )
+            self._append_audit(failed)
+            raise ProcessingError(str(error)) from error
+        proposal = ChangeProposal(
+            **{
+                **proposal.__dict__,
+                "original_value": fresh.get(proposal.field_name),
+            }
+        )
+        if _values_equal(proposal.original_value, proposal.proposed_value):
+            result = ActionResult(
+                proposal,
+                None,
+                ActionStatus.NOOP,
+                action="already current",
+            )
+            self._append_audit(result)
+            self.output_fn(f"{proposal.label}: already current; no change needed.")
+            return result
+
+        self._show_proposal(proposal)
+        try:
+            decision = self._prompt_decision()
+        except (KeyboardInterrupt, EOFError) as error:
+            interrupted = ActionResult(
+                proposal,
+                None,
+                ActionStatus.INTERRUPTED,
+                action="review",
+                error="Reviewer interrupted processing.",
+            )
+            self._append_audit(interrupted)
+            raise ProcessingInterrupted(
+                "Profile Update review was interrupted."
+            ) from error
+
+        if decision is ReviewDecision.WILL_NOT_BE_MADE:
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.REJECTED,
+                action="no Salesforce write",
+            )
+            self._append_audit(result)
+            return result
+        if decision is ReviewDecision.MAKE_MANUALLY:
+            try:
+                self.input_fn(
+                    "Make the change in Salesforce, then press Enter to verify it: "
+                )
+                verified = self.client.get_record(
+                    proposal.target_object,
+                    proposal.target_record_id,
+                    ["Id", proposal.field_name],
+                )
+            except (KeyboardInterrupt, EOFError) as error:
+                interrupted = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.INTERRUPTED,
+                    action="manual verification",
+                    error="Reviewer interrupted processing.",
+                )
+                self._append_audit(interrupted)
+                raise ProcessingInterrupted(
+                    "Profile Update review was interrupted."
+                ) from error
+            except SalesforceError as error:
+                failed = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="manual verification",
+                    error=str(error),
+                )
+                self._append_audit(failed)
+                raise ProcessingError(str(error)) from error
+            if not _values_equal(
+                verified.get(proposal.field_name), proposal.proposed_value
+            ):
+                error = (
+                    f"Salesforce {proposal.label} does not match the proposed value."
+                )
+                failed = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="manual verification",
+                    error=error,
+                )
+                self._append_audit(failed)
+                raise ProcessingError(error)
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.VERIFIED_MANUAL,
+                action="manual verification",
+            )
+            self._append_audit(result)
+            return result
+
+        try:
+            self.client.update_record(
+                proposal.target_object,
+                proposal.target_record_id,
+                {proposal.field_name: proposal.proposed_value},
+            )
+        except SalesforceError as error:
+            failed = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.FAILED,
+                action="update Salesforce",
+                error=str(error),
+            )
+            self._append_audit(failed)
+            raise ProcessingError(str(error)) from error
+        result = ActionResult(
+            proposal,
+            decision,
+            ActionStatus.APPLIED,
+            action="update Salesforce",
+        )
+        self._append_audit(result)
+        return result
+
+    def _show_proposal(self, proposal: ChangeProposal) -> None:
+        self.output_fn(
+            f"\n{proposal.label}\n"
+            f"Current Salesforce value: {_display(proposal.original_value) or '(blank)'}\n"
+            f"Proposed value: {_display(proposal.proposed_value) or '(blank)'}"
+        )
+        if proposal.context:
+            self.output_fn(f"Submission context: {proposal.context}")
+        if proposal.warnings:
+            self.output_fn(f"Warnings: {proposal.warnings}")
+
+    def _prompt_decision(self, *, automatic_allowed: bool = True) -> ReviewDecision:
+        values = {decision.value: decision for decision in ReviewDecision}
+        while True:
+            answer = self.input_fn(
+                "Decision [apply automatically / make manually / will not be made]: "
+            )
+            normalized = answer.strip().casefold()
+            decision = values.get(normalized)
+            if decision is None:
+                self.output_fn("Enter one of the three complete decision phrases.")
+                continue
+            if decision is ReviewDecision.APPLY_AUTOMATICALLY and not automatic_allowed:
+                self.output_fn(
+                    "This incomplete Contact cannot be created automatically; "
+                    "choose make manually or will not be made."
+                )
+                continue
+            return decision
+
+    def _prompt_contact_choice(self, role_label: str) -> str:
+        allowed = {"create contact", "select existing", "decline"}
+        while True:
+            answer = self.input_fn(
+                f"{role_label} Contact choice "
+                "[create contact / select existing / decline]: "
+            )
+            normalized = answer.strip().casefold()
+            if normalized in allowed:
+                return normalized
+            self.output_fn("Choose create contact, select existing, or decline.")
+
+    def _select_contact_id(self, contacts: list[dict[str, Any]]) -> str:
+        while True:
+            answer = self.input_fn(
+                "Enter a candidate number or an existing Salesforce Contact ID: "
+            ).strip()
+            if answer.isdigit() and 1 <= int(answer) <= len(contacts):
+                return _display(contacts[int(answer) - 1].get("Id"))
+            if answer and any(
+                _display(contact.get("Id")) == answer for contact in contacts
+            ):
+                return answer
+            self.output_fn("Select one of the fresh Contact candidates shown.")
+
+    def _prompt_yes_no(self, prompt: str) -> bool:
+        while True:
+            answer = self.input_fn(prompt).strip().casefold()
+            if answer in {"yes", "no"}:
+                return answer == "yes"
+            self.output_fn("Enter yes or no.")
+
+    def _update_status_with_audit(
+        self,
+        batch: CaseBatch,
+        record_id: str,
+        object_name: str,
+        field_name: str,
+        status: str,
+        *,
+        action: str = "finalize batch",
+    ) -> None:
+        proposal = ChangeProposal(
+            source_submission_ids=batch.source_submission_ids,
+            case_id=batch.case_id,
+            case_number=batch.case_number,
+            account_id=batch.account_id,
+            account_name=batch.rows[0].get("account_name", ""),
+            submitter_email="",
+            target_object=object_name,
+            target_record_id=record_id,
+            field_name=field_name,
+            label=f"{object_name} {field_name}",
+            original_value="",
+            proposed_value=status,
+        )
+        try:
+            self.client.update_record(object_name, record_id, {field_name: status})
+        except SalesforceError as error:
+            result = ActionResult(
+                proposal,
+                None,
+                ActionStatus.FAILED,
+                action=action,
+                error=str(error),
+            )
+            self._append_audit(result)
+            raise ProcessingError(str(error)) from error
+        result = ActionResult(
+            proposal,
+            None,
+            ActionStatus.APPLIED,
+            action=action,
+        )
+        self._append_audit(result)
+
+    def _keep_case_pending(self, batch: CaseBatch) -> None:
+        proposal = ChangeProposal(
+            source_submission_ids=batch.source_submission_ids,
+            case_id=batch.case_id,
+            case_number=batch.case_number,
+            account_id=batch.account_id,
+            account_name=batch.rows[0].get("account_name", ""),
+            submitter_email="",
+            target_object="Case",
+            target_record_id=batch.case_id,
+            field_name="Status",
+            label="Case Status",
+            original_value="",
+            proposed_value="Pending",
+        )
+        try:
+            self.client.update_record("Case", batch.case_id, {"Status": "Pending"})
+        except SalesforceError as error:
+            self._append_audit(
+                ActionResult(
+                    proposal,
+                    None,
+                    ActionStatus.FAILED,
+                    action="keep interrupted batch pending",
+                    error=str(error),
+                )
+            )
+        else:
+            self._append_audit(
+                ActionResult(
+                    proposal,
+                    None,
+                    ActionStatus.APPLIED,
+                    action="keep interrupted batch pending",
+                )
+            )
+
+    def _append_batch_event(
+        self,
+        batch: CaseBatch,
+        status: ActionStatus,
+        *,
+        action: str,
+        error: str,
+    ) -> None:
+        proposal = ChangeProposal(
+            source_submission_ids=batch.source_submission_ids,
+            case_id=batch.case_id,
+            case_number=batch.case_number,
+            account_id=batch.account_id,
+            account_name=batch.rows[0].get("account_name", ""),
+            submitter_email="",
+            target_object="CaseBatch",
+            target_record_id=batch.case_id,
+            field_name="workflow",
+            label="Case batch workflow",
+            original_value="",
+            proposed_value="complete",
+        )
+        self._append_audit(
+            ActionResult(
+                proposal,
+                None,
+                status,
+                action=action,
+                error=error,
+            )
+        )
+
+    def _append_audit(self, result: ActionResult) -> None:
+        if self._audit is None:
+            raise RuntimeError("Audit writer is unavailable.")
+        self._audit.append(result)
+
+
+def format_response_emails(results: list[ActionResult]) -> dict[str, str]:
+    """Return one response paragraph per submitter email."""
+    grouped: dict[str, list[ChangeProposal]] = {}
+    for result in results:
+        if result.status not in {
+            ActionStatus.APPLIED,
+            ActionStatus.VERIFIED_MANUAL,
+        }:
+            continue
+        proposal = result.proposal
+        email = proposal.submitter_email.strip()
+        if not email:
+            continue
+        grouped.setdefault(email, []).append(proposal)
+
+    emails: dict[str, str] = {}
+    for email, proposals in grouped.items():
+        account_name = next(
+            (
+                proposal.account_name.strip()
+                for proposal in proposals
+                if proposal.account_name.strip()
+            ),
+            "your account",
+        )
+        lines = [ACCOUNT_EMAIL_OPENING.format(account_name=account_name)]
+        seen: set[tuple[str, str, str, str]] = set()
+        for proposal in proposals:
+            identity = (
+                proposal.target_object,
+                proposal.target_record_id,
+                proposal.field_name,
+                _display(proposal.proposed_value),
+            )
+            if identity in seen:
+                continue
+            seen.add(identity)
+            lines.extend(
+                [
+                    "",
+                    f"{proposal.label}: {_display(proposal.proposed_value) or '(blank)'}",
+                    f"Replaces {_display(proposal.original_value) or '(blank)'}",
+                ]
+            )
+        emails[email] = "\n".join(lines)
+    return emails
+
+
+def _proposal_context(row: dict[str, str]) -> str:
+    parts = []
+    if row.get("effective_date"):
+        parts.append(f"Effective date: {row['effective_date']}")
+    if row.get("key_answers"):
+        parts.append(row["key_answers"])
+    if row.get("comments"):
+        parts.append(f"Comments: {row['comments']}")
+    if row.get("personnel_notes"):
+        parts.append(f"Other Personnel notes: {row['personnel_notes']}")
+    return "\n".join(parts)
+
+
+def _latest_nonblank(records: list[dict[str, Any]], field_name: str) -> str:
+    value = ""
+    for record in records:
+        candidate = _display(record.get(field_name))
+        if candidate:
+            value = candidate
+    return value
+
+
+def _json_string_list(value: str) -> list[str]:
+    parsed = json.loads(value)
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, str) and item.strip() for item in parsed
+    ):
+        raise ValueError("Expected a JSON list of nonblank strings.")
+    return [item.strip() for item in parsed]
+
+
+def _required_datetime(value: str) -> datetime:
+    try:
+        return _aware_datetime(
+            datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        )
+    except (AttributeError, ValueError) as error:
+        raise ProcessingError(f"Invalid Salesforce date/time: {value!r}.") from error
+
+
+def _aware_datetime(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
+
+
+def _display(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    return str(value).strip()
+
+
+def _values_equal(current: Any, proposed: Any) -> bool:
+    return _display(current) == _display(proposed)

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -465,6 +465,13 @@ class ProfileUpdateStagingService:
             if suffix == "warning":
                 continue
             row[f"{prefix}_{suffix}"] = resolution.get(suffix, "")
+        _fill_missing_optional_role_fields(
+            row,
+            role,
+            all_roles,
+            contacts,
+            resolution,
+        )
         row[f"{prefix}_warning"] = warning
         if warning:
             warnings.append(f"{role.definition.label} role: {warning}")
@@ -564,20 +571,26 @@ def _resolve_role(
                 _matching_contact_names(sibling_contacts, first_name, last_name),
             ),
         ]
-        return _first_tier_resolution(tiers)
+        resolution, warning = _first_tier_resolution(tiers, no_match_is_warning=False)
+        if resolution or warning:
+            return resolution, warning
+        return _new_contact_resolution(
+            role,
+            "No exact contact match was found; a new contact will need to be created.",
+        )
 
     if last_name:
-        return {}, "Last-name-only input cannot be resolved safely."
+        return _new_contact_resolution(
+            role,
+            "Last-name-only input cannot be resolved safely; a new contact will "
+            "need to be created after human review.",
+        )
 
     if email:
         tiers = [
             (
                 "submitted_role",
-                [
-                    candidate
-                    for candidate in submitted_candidates
-                    if _normalized(candidate.values.get("email")) == _normalized(email)
-                ],
+                _matching_submitted_emails(submitted_candidates, email),
             ),
             (
                 "account_contact",
@@ -620,7 +633,7 @@ def _resolve_role(
 def _matching_submitted_names(
     candidates: list[MergedRole], first_name: str, last_name: str
 ) -> list[MergedRole]:
-    return [
+    matches = [
         candidate
         for candidate in candidates
         if _normalized(candidate.values.get("first_name")) == _normalized(first_name)
@@ -629,6 +642,59 @@ def _matching_submitted_names(
             or _normalized(candidate.values.get("last_name")) == _normalized(last_name)
         )
     ]
+    return _distinct_submitted_contacts(
+        matches,
+        identity_fields=("first_name", "last_name"),
+        conflict_field="email",
+    )
+
+
+def _matching_submitted_emails(
+    candidates: list[MergedRole], email: str
+) -> list[MergedRole]:
+    matches = [
+        candidate
+        for candidate in candidates
+        if _normalized(candidate.values.get("email")) == _normalized(email)
+    ]
+    return _distinct_submitted_contacts(matches, identity_fields=("email",))
+
+
+def _distinct_submitted_contacts(
+    candidates: list[MergedRole],
+    *,
+    identity_fields: tuple[str, ...],
+    conflict_field: str | None = None,
+) -> list[MergedRole]:
+    """Combine repeated role entries for the same submitted person."""
+    grouped: dict[tuple[str, ...], list[MergedRole]] = {}
+    for candidate in candidates:
+        identity = tuple(
+            _normalized(candidate.values.get(field_name))
+            for field_name in identity_fields
+        )
+        grouped.setdefault(identity, []).append(candidate)
+
+    distinct: list[MergedRole] = []
+    for group in grouped.values():
+        conflicts = (
+            {
+                value
+                for candidate in group
+                if (value := _normalized(candidate.values.get(conflict_field)))
+            }
+            if conflict_field
+            else set()
+        )
+        if len(conflicts) > 1:
+            distinct.extend(group)
+        else:
+            distinct.append(max(group, key=_role_detail_count))
+    return distinct
+
+
+def _role_detail_count(role: MergedRole) -> int:
+    return sum(bool(_clean_text(value)) for value in role.values.values())
 
 
 def _matching_contact_names(
@@ -689,20 +755,80 @@ def _existing_role_resolution(
     missing_message: str,
 ) -> tuple[dict[str, str], str]:
     contact_id = _clean_text(account.get(definition.account_lookup)) if account else ""
+    resolution = {
+        "resolution_action": action,
+        "resolution_source": "account_role_lookup",
+    }
     if not contact_id:
         return (
-            {},
+            resolution,
             f"{missing_message}, and the Account has no existing "
             f"{definition.label} role contact.",
         )
+    resolution["salesforce_contact_id"] = contact_id
+    return resolution, ""
+
+
+def _new_contact_resolution(
+    role: MergedRole, warning: str
+) -> tuple[dict[str, str], str]:
+    """Record that submitted role data describes a contact to be created."""
     return (
         {
-            "resolution_action": action,
-            "salesforce_contact_id": contact_id,
-            "resolution_source": "account_role_lookup",
+            "resolution_action": "create_contact",
+            "resolution_source": "submitted_data",
+            "source_submission_id": role.source_submission_id,
+            "source_role": role.definition.prefix,
         },
-        "",
+        warning,
     )
+
+
+def _fill_missing_optional_role_fields(
+    row: dict[str, str],
+    role: MergedRole,
+    all_roles: list[MergedRole],
+    contacts: list[dict[str, Any]],
+    resolution: dict[str, str],
+) -> None:
+    """Fill missing title and phone from the resolved contact when available."""
+    fallback: dict[str, Any] | None = None
+    if resolution.get("resolution_source") == "submitted_role":
+        source_role = resolution.get("source_role")
+        matched_role = next(
+            (
+                candidate
+                for candidate in all_roles
+                if candidate.definition.prefix == source_role
+            ),
+            None,
+        )
+        if matched_role is not None:
+            fallback = matched_role.values
+    else:
+        contact_id = resolution.get("salesforce_contact_id")
+        fallback = next(
+            (
+                contact
+                for contact in contacts
+                if _clean_text(contact.get("Id")) == contact_id
+            ),
+            None,
+        )
+
+    if fallback is None:
+        return
+    prefix = role.definition.prefix
+    if role.definition.title_field is not None and not row[f"{prefix}_title"]:
+        row[f"{prefix}_title"] = _first_nonblank(
+            fallback.get("title"),
+            fallback.get("Title"),
+        )
+    if not row[f"{prefix}_phone"]:
+        row[f"{prefix}_phone"] = _first_nonblank(
+            fallback.get("phone"),
+            fallback.get("Phone"),
+        )
 
 
 def write_staged_profile_updates(

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -19,6 +19,7 @@ ACCOUNT_FIELDS = [
     "Id",
     "Name",
     "Certification_ID__c",
+    "Company_Owner__c",
     "BillingStreet",
     "BillingCity",
     "BillingState",
@@ -40,6 +41,15 @@ CONTACT_FIELDS = [
     "Title",
     "Email",
     "Phone",
+]
+
+PROFILE_CASE_FIELDS = [
+    "Id",
+    "CaseNumber",
+    "Subject",
+    "Status",
+    "CreatedDate",
+    "AccountId",
 ]
 
 KEY_ANSWER_FIELDS = [
@@ -156,6 +166,10 @@ SHARED_COLUMNS = [
     "latest_submission_date",
     "account_id",
     "account_name",
+    "case_id",
+    "case_number",
+    "case_status",
+    "case_match_status",
     "certification_id",
     "submitter_name",
     "submitter_email",
@@ -167,6 +181,8 @@ SHARED_COLUMNS = [
 ]
 
 KEY_COLUMNS = [
+    "has_key_updates",
+    "earliest_key_update_date",
     "effective_date",
     "revised_company_name",
     "revised_company_owner",
@@ -255,6 +271,7 @@ class ProfileUpdateStagingService:
                 all_accounts_by_id.setdefault(sibling_id, sibling)
 
         contacts = self._query_contacts(list(all_accounts_by_id.values()))
+        cases = self._query_cases(requested_account_ids)
         grouped = _group_submissions(submissions)
         rows = [
             self._build_row(
@@ -262,6 +279,7 @@ class ProfileUpdateStagingService:
                 accounts_by_id,
                 all_accounts_by_id,
                 contacts,
+                cases,
             )
             for records in grouped
         ]
@@ -311,12 +329,26 @@ class ProfileUpdateStagingService:
             order_by="AccountId ASC, Id ASC",
         )
 
+    def _query_cases(self, account_ids: list[str]) -> list[dict[str, Any]]:
+        if not account_ids:
+            return []
+        return self.client.query_records(
+            "Case",
+            PROFILE_CASE_FIELDS,
+            where=(
+                f"{_where_in('AccountId', account_ids)} "
+                "AND Subject LIKE '%Profile Update%'"
+            ),
+            order_by="CreatedDate DESC, Id DESC",
+        )
+
     def _build_row(
         self,
         records: list[dict[str, Any]],
         accounts_by_id: dict[str, dict[str, Any]],
         all_accounts_by_id: dict[str, dict[str, Any]],
         contacts: list[dict[str, Any]],
+        cases: list[dict[str, Any]],
     ) -> dict[str, str]:
         row = {column: "" for column in CSV_COLUMNS}
         merged = _merge_records(records)
@@ -324,6 +356,7 @@ class ProfileUpdateStagingService:
 
         account_id = _clean_text(merged.get("Account__c"))
         account = accounts_by_id.get(account_id)
+        key_records = [record for record in records if _is_key_update(record)]
         row.update(
             {
                 "source_submission_ids": json.dumps(
@@ -338,6 +371,12 @@ class ProfileUpdateStagingService:
                 "latest_submission_date": _clean_text(records[-1].get("CreatedDate")),
                 "account_id": account_id,
                 "account_name": _account_name(account, merged),
+                "has_key_updates": "true" if key_records else "false",
+                "earliest_key_update_date": (
+                    _clean_text(key_records[0].get("CreatedDate"))
+                    if key_records
+                    else ""
+                ),
                 "certification_id": _first_nonblank(
                     account.get("Certification_ID__c") if account else None,
                     merged.get("Certification_ID__c"),
@@ -358,6 +397,7 @@ class ProfileUpdateStagingService:
                 ),
             }
         )
+        self._populate_case(row, records, cases, warnings)
 
         if not row["submitter_email"]:
             warnings.append("Submission group has a blank submitter email.")
@@ -394,6 +434,62 @@ class ProfileUpdateStagingService:
         row["has_warnings"] = "true" if warnings else "false"
         row["warnings"] = "\n".join(warnings)
         return row
+
+    @staticmethod
+    def _populate_case(
+        row: dict[str, str],
+        records: list[dict[str, Any]],
+        cases: list[dict[str, Any]],
+        warnings: list[str],
+    ) -> None:
+        account_id = row["account_id"]
+        source_names = [
+            name for record in records if (name := _clean_text(record.get("Name")))
+        ]
+        account_cases = [
+            case for case in cases if _clean_text(case.get("AccountId")) == account_id
+        ]
+        matches = [
+            case
+            for case in account_cases
+            if source_names
+            and all(
+                _case_subject_has_name(case.get("Subject"), name)
+                for name in source_names
+            )
+        ]
+        if len(matches) == 1:
+            case = matches[0]
+            row.update(
+                {
+                    "case_id": _clean_text(case.get("Id")),
+                    "case_number": _clean_text(case.get("CaseNumber")),
+                    "case_status": _clean_text(case.get("Status")),
+                    "case_match_status": "matched",
+                }
+            )
+            return
+
+        partial_matches = [
+            case
+            for case in account_cases
+            if any(
+                _case_subject_has_name(case.get("Subject"), name)
+                for name in source_names
+            )
+        ]
+        status = "ambiguous" if matches or partial_matches else "missing"
+        row["case_match_status"] = status
+        if status == "ambiguous":
+            warning = (
+                "Blocking Case match: source submissions match more than one "
+                "Case or do not share one Case."
+            )
+        else:
+            warning = (
+                "Blocking Case match: no Case contains the source submission names."
+            )
+        warnings.append(warning)
 
     @staticmethod
     def _populate_address(
@@ -877,6 +973,27 @@ def _submission_sort_key(record: dict[str, Any]) -> tuple[str, str]:
         _clean_text(record.get("CreatedDate")),
         _clean_text(record.get("Id")),
     )
+
+
+def _is_key_update(record: dict[str, Any]) -> bool:
+    key_fields = [
+        "Effective_Date__c",
+        "Revised_Company_Name__c",
+        "Revised_Company_Owner__c",
+        *(api_name for _, api_name, _ in ADDRESS_FIELDS),
+        *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
+    ]
+    return _normalized(record.get("Type__c")) == "key data" or any(
+        _has_value(record.get(api_name)) for api_name in key_fields
+    )
+
+
+def _case_subject_has_name(subject: Any, update_name: str) -> bool:
+    text = _clean_text(subject)
+    if " - " not in text:
+        return False
+    names = [name.strip().casefold() for name in text.rsplit(" - ", 1)[1].split("/")]
+    return update_name.strip().casefold() in names
 
 
 def _where_in(field_name: str, values: list[str]) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,3 +190,50 @@ def test_stage_profile_updates_cli_reports_file_failure(monkeypatch, capsys):
 
     assert app.main(["stage-profile-updates"]) == 1
     assert "Stage profile updates failed: disk full" in capsys.readouterr().err
+
+
+def test_process_profile_updates_cli_injects_interactive_io_and_output_dir(
+    monkeypatch, tmp_path
+):
+    prompts = []
+    output = []
+    calls = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        return "will not be made"
+
+    def run(output_dir, *, input_fn, output_fn):
+        calls.append((output_dir, input_fn, output_fn))
+        output_fn("Processing complete")
+        return 0
+
+    monkeypatch.setattr(app, "_run_process_profile_updates", run)
+
+    assert (
+        app.main(
+            ["process-profile-updates", "--output-dir", str(tmp_path)],
+            input_fn=input_fn,
+            output_fn=output.append,
+        )
+        == 0
+    )
+    assert calls == [(tmp_path, input_fn, output.append)]
+    assert output == ["Processing complete"]
+    assert prompts == []
+
+
+def test_process_profile_updates_cli_reports_processing_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        app,
+        "_run_process_profile_updates",
+        lambda output_dir, **kwargs: (_ for _ in ()).throw(
+            app.ProcessingError("manual verification failed")
+        ),
+    )
+
+    assert app.main(["process-profile-updates"]) == 1
+    assert (
+        "Process profile updates failed: manual verification failed"
+        in capsys.readouterr().err
+    )

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -1,0 +1,680 @@
+import csv
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from aisc_salesforce.process_profile_updates import (
+    ActionResult,
+    ActionStatus,
+    ChangeProposal,
+    InteractiveProfileUpdateProcessor,
+    ProcessingError,
+    ProcessingInterrupted,
+    ProfileUpdateProcessingWorkflow,
+    ReviewDecision,
+    build_case_batches,
+    format_response_emails,
+)
+from aisc_salesforce.profile_updates import AutomationCounts
+from aisc_salesforce.salesforce import SalesforceError
+from aisc_salesforce.stage_profile_updates import CSV_COLUMNS, StagingResult
+
+NOW = datetime(2026, 7, 17, 18, 0, tzinfo=UTC)
+
+
+def staged_row(**changes):
+    row = {column: "" for column in CSV_COLUMNS}
+    row.update(
+        {
+            "source_submission_ids": json.dumps(["submission-1"]),
+            "source_submission_names": json.dumps(["PU-100"]),
+            "earliest_submission_date": "2026-07-15T14:30:00.000+0000",
+            "latest_submission_date": "2026-07-15T14:30:00.000+0000",
+            "account_id": "account-1",
+            "account_name": "Acme Steel",
+            "submitter_name": "Sam Submitter",
+            "submitter_email": "sam@example.com",
+            "case_id": "case-1",
+            "case_number": "00010001",
+            "case_status": "Pending",
+            "case_match_status": "matched",
+            "has_key_updates": "false",
+            "has_warnings": "false",
+        }
+    )
+    row.update(changes)
+    return row
+
+
+def source_record(**changes):
+    record = {
+        "Id": "submission-1",
+        "Name": "PU-100",
+        "CreatedDate": "2026-07-15T14:30:00.000+0000",
+        "Status__c": "New",
+        "Account__c": "account-1",
+        "Name__c": "Sam Submitter",
+        "Email__c": "sam@example.com",
+        "Comments__c": "Fresh comment",
+        "Other_Personnel_Notes__c": "Fresh personnel note",
+    }
+    record.update(changes)
+    return record
+
+
+def account_record(**changes):
+    record = {
+        "Id": "account-1",
+        "Name": "Acme Steel",
+        "Company_Owner__c": "Old Owner",
+        "BillingStreet": "1 Main St",
+        "BillingCity": "Chicago",
+        "BillingState": "IL",
+        "BillingPostalCode": "60601",
+        "BillingCountry": "USA",
+        "Cert_Certification_Contact__c": "old-contact",
+        "Cert_Principal_Contact__c": "",
+        "Cert_Accounting_Contact__c": "",
+        "Cert_Marketing_Contact__c": "",
+        "Cert_Safety_Contact__c": "",
+    }
+    record.update(changes)
+    return record
+
+
+class Feeder:
+    def __init__(self, answers):
+        self.answers = iter(answers)
+        self.prompts = []
+
+    def __call__(self, prompt):
+        self.prompts.append(prompt)
+        answer = next(self.answers)
+        if isinstance(answer, BaseException):
+            raise answer
+        return answer
+
+
+class FakeClient:
+    def __init__(self, *, source=None, account=None, contacts=None, history=None):
+        self.records = {
+            ("Company_Profile_Change__c", "submission-1"): source or source_record(),
+            ("Account", "account-1"): account or account_record(),
+            ("Case", "case-1"): {
+                "Id": "case-1",
+                "CaseNumber": "00010001",
+                "Status": "Pending",
+            },
+        }
+        self.contacts = contacts or []
+        for contact in self.contacts:
+            self.records[("Contact", contact["Id"])] = contact
+        self.history = history or []
+        self.get_sequences = {}
+        self.queries = []
+        self.gets = []
+        self.created = []
+        self.updated = []
+        self.fail_update = None
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where, order_by))
+        if object_name == "Contact":
+            return [dict(contact) for contact in self.contacts]
+        if object_name == "AccountHistory":
+            return [dict(item) for item in self.history]
+        raise AssertionError(object_name)
+
+    def get_record(self, object_name, record_id, fields):
+        self.gets.append((object_name, record_id, tuple(fields)))
+        key = (object_name, record_id)
+        sequence = self.get_sequences.get(key)
+        if sequence:
+            return dict(sequence.pop(0))
+        return dict(self.records[key])
+
+    def create_record(self, object_name, values):
+        record_id = f"created-{len(self.created) + 1}"
+        self.created.append((object_name, dict(values)))
+        self.records[(object_name, record_id)] = {"Id": record_id, **values}
+        if object_name == "Contact":
+            self.contacts.append(self.records[(object_name, record_id)])
+        return record_id
+
+    def update_record(self, object_name, record_id, values):
+        if self.fail_update == (object_name, record_id):
+            raise SalesforceError("write failed")
+        self.updated.append((object_name, record_id, dict(values)))
+        self.records.setdefault((object_name, record_id), {"Id": record_id}).update(
+            values
+        )
+
+
+class CaseService:
+    def __init__(self, events, *, failed=0):
+        self.events = events
+        self.failed = failed
+        self.errors = ["case failed"] if failed else []
+
+    def run(self):
+        self.events.append("cases")
+        return AutomationCounts(created=1, failed=self.failed)
+
+
+class StagingService:
+    def __init__(self, events):
+        self.events = events
+
+    def stage(self):
+        self.events.append("stage")
+        return StagingResult([staged_row(account_name="memory value")], 0)
+
+
+class CapturingProcessor:
+    def __init__(self, events):
+        self.events = events
+        self.rows = None
+
+    def review(self, rows, artifact_dir):
+        self.events.append("review")
+        self.rows = rows
+        return artifact_dir
+
+
+def test_workflow_creates_cases_then_stages_and_reads_the_published_csv(tmp_path):
+    events = []
+    processor = CapturingProcessor(events)
+
+    def writer(rows, output_dir):
+        events.append("write")
+        folder = output_dir / "published"
+        folder.mkdir()
+        disk_row = {**rows[0], "account_name": "value read from disk"}
+        with (folder / "profile_updates.csv").open(
+            "w", newline="", encoding="utf-8"
+        ) as output:
+            csv.DictWriter(output, fieldnames=CSV_COLUMNS).writeheader()
+            csv.DictWriter(output, fieldnames=CSV_COLUMNS).writerow(disk_row)
+        return folder
+
+    workflow = ProfileUpdateProcessingWorkflow(
+        CaseService(events),
+        StagingService(events),
+        processor,
+        staging_writer=writer,
+    )
+
+    workflow.run(tmp_path)
+
+    assert events == ["cases", "stage", "write", "review"]
+    assert processor.rows[0]["account_name"] == "value read from disk"
+
+
+@pytest.mark.parametrize("failure", ["cases", "stage", "write"])
+def test_workflow_aborts_before_review_when_required_setup_fails(tmp_path, failure):
+    events = []
+    processor = CapturingProcessor(events)
+    case_service = CaseService(events, failed=1 if failure == "cases" else 0)
+
+    class MaybeFailingStaging(StagingService):
+        def stage(self):
+            if failure == "stage":
+                raise SalesforceError("stage failed")
+            return super().stage()
+
+    def writer(rows, output_dir):
+        events.append("write")
+        if failure == "write":
+            raise OSError("disk full")
+        raise AssertionError("writer should only be reached by the write failure case")
+
+    workflow = ProfileUpdateProcessingWorkflow(
+        case_service,
+        MaybeFailingStaging(events),
+        processor,
+        staging_writer=writer,
+    )
+
+    with pytest.raises((ProcessingError, SalesforceError, OSError)):
+        workflow.run(tmp_path)
+
+    assert "review" not in events
+
+
+def test_batches_group_account_and_case_and_prioritize_old_key_updates():
+    rows = [
+        staged_row(
+            source_submission_ids='["newer"]',
+            earliest_submission_date="2026-07-16T12:00:00+00:00",
+            case_id="case-newer",
+        ),
+        staged_row(
+            source_submission_ids='["old-key"]',
+            earliest_submission_date="2026-07-01T12:00:00+00:00",
+            earliest_key_update_date="2026-07-01T12:00:00+00:00",
+            has_key_updates="true",
+            case_id="case-key",
+        ),
+        staged_row(
+            source_submission_ids='["same-case"]',
+            earliest_submission_date="2026-07-14T12:00:00+00:00",
+            case_id="case-newer",
+        ),
+        staged_row(
+            source_submission_ids='["oldest-ordinary"]',
+            earliest_submission_date="2026-06-30T12:00:00+00:00",
+            case_id="case-old",
+        ),
+    ]
+
+    batches = build_case_batches(rows, now=NOW)
+
+    assert [batch.case_id for batch in batches] == [
+        "case-key",
+        "case-old",
+        "case-newer",
+    ]
+    assert len(batches[-1].rows) == 2
+
+
+def test_blocking_case_match_is_never_guessed():
+    with pytest.raises(ProcessingError, match="blocking Case match"):
+        build_case_batches(
+            [staged_row(case_id="", case_match_status="ambiguous")],
+            now=NOW,
+        )
+
+
+def test_account_change_uses_fresh_context_audits_and_closes_completed_batch(tmp_path):
+    history = [
+        {
+            "Id": "history-1",
+            "AccountId": "account-1",
+            "Field": "Name",
+            "OldValue": "Older Acme",
+            "NewValue": "Acme Steel",
+            "CreatedDate": "2026-07-15T15:15:00.000+0000",
+        }
+    ]
+    client = FakeClient(history=history)
+    feeder = Feeder(["apply automatically", "yes"])
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=output.append,
+        now=NOW,
+    )
+    row = staged_row(
+        revised_company_name="Acme Steel LLC",
+        comments="Staged comment",
+        personnel_notes="Staged personnel note",
+        warnings="Review this carefully",
+        has_warnings="true",
+        has_key_updates="true",
+        earliest_key_update_date="2026-07-15T14:30:00.000+0000",
+    )
+
+    result = processor.review([row], tmp_path)
+
+    displayed = "\n".join(output)
+    assert "Fresh comment" in displayed
+    assert "Fresh personnel note" in displayed
+    assert "Review this carefully" in displayed
+    assert "Older Acme" in displayed
+    assert ("Account", "account-1", {"Name": "Acme Steel LLC"}) in client.updated
+    assert (
+        "Company_Profile_Change__c",
+        "submission-1",
+        {"Status__c": "Closed"},
+    ) in client.updated
+    assert ("Case", "case-1", {"Status": "Closed"}) in client.updated
+    audit = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    applied = next(item for item in audit if item["field"] == "Name")
+    assert applied["decision"] == "apply automatically"
+    assert applied["result"] == "applied"
+    response = result.response_path.read_text(encoding="utf-8")
+    assert "Thank you for updating your information with AISC." in response
+    assert "Company Name: Acme Steel LLC" in response
+    assert "Replaces Acme Steel" in response
+    assert any(item[0] == "Company_Profile_Change__c" for item in client.gets)
+    history_query = next(
+        query for query in client.queries if query[0] == "AccountHistory"
+    )
+    assert "CreatedDate >=" in history_query[2]
+    assert "CreatedDate <" in history_query[2]
+
+
+def test_current_value_is_an_audited_noop_without_prompt_or_email_item(tmp_path):
+    client = FakeClient(account=account_record(Name="Acme Steel LLC"))
+    feeder = Feeder([])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [staged_row(revised_company_name="Acme Steel LLC")],
+        tmp_path,
+    )
+
+    assert feeder.prompts == []
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        item["result"] == "no-op" and item["field"] == "Name" for item in entries
+    )
+    assert "Company Name:" not in result.response_path.read_text(encoding="utf-8")
+
+
+def test_manual_change_is_refetched_and_must_match(tmp_path):
+    client = FakeClient()
+    client.get_sequences[("Account", "account-1")] = [
+        account_record(),
+        account_record(Name="Acme Steel LLC"),
+    ]
+    feeder = Feeder(["make manually", "", "yes"])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [staged_row(revised_company_name="Acme Steel LLC")],
+        tmp_path,
+    )
+
+    assert ("Account", "account-1", {"Name": "Acme Steel LLC"}) not in client.updated
+    assert "verified manually" in result.audit_path.read_text(encoding="utf-8")
+
+
+def test_manual_change_mismatch_stops_without_closing_sources(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(["make manually", ""])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingError, match="does not match"):
+        processor.review(
+            [staged_row(revised_company_name="Acme Steel LLC")],
+            tmp_path,
+        )
+
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
+
+
+def test_reviewer_selects_contact_then_reviews_fields_and_role_separately(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "old@example.com",
+        "Phone": "312-555-0100",
+    }
+    client = FakeClient(contacts=[contact])
+    feeder = Feeder(
+        [
+            "select existing",
+            "1",
+            "apply automatically",
+            "will not be made",
+            "yes",
+        ]
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    row = staged_row(
+        certification_first_name="Alex",
+        certification_last_name="Smith",
+        certification_email="new@example.com",
+        certification_salesforce_contact_id="contact-1",
+        certification_resolution_action="update_contact",
+    )
+
+    result = processor.review([row], tmp_path)
+
+    assert ("Contact", "contact-1", {"Email": "new@example.com"}) in client.updated
+    assert not any(
+        item[0] == "Account" and "Cert_Certification_Contact__c" in item[2]
+        for item in client.updated
+    )
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        item["field"] == "Email" and item["result"] == "applied" for item in entries
+    )
+    assert any(
+        item["field"] == "Cert_Certification_Contact__c"
+        and item["result"] == "rejected"
+        for item in entries
+    )
+
+
+def test_incomplete_contact_is_not_automatically_created(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(["create contact", "will not be made"])
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                certification_first_name="Only",
+                certification_resolution_action="create_contact",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == []
+    assert "required Last Name" in "\n".join(output)
+
+
+def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(
+        [
+            "create contact",
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "yes",
+        ]
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                certification_first_name="New",
+                certification_last_name="Person",
+                certification_email="new.person@example.com",
+                certification_resolution_action="create_contact",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "New",
+                "LastName": "Person",
+            },
+        )
+    ]
+    assert (
+        "Contact",
+        "created-1",
+        {"Email": "new.person@example.com"},
+    ) in client.updated
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "created-1"},
+    ) in client.updated
+
+
+def test_email_formatter_creates_one_paragraph_per_submitter():
+    first = ChangeProposal(
+        source_submission_ids=("one",),
+        case_id="case-1",
+        account_id="account-1",
+        account_name="Acme Steel",
+        submitter_email="first@example.com",
+        target_object="Account",
+        target_record_id="account-1",
+        field_name="Name",
+        label="Company Name",
+        original_value="Acme",
+        proposed_value="Acme Steel",
+    )
+    second = ChangeProposal(
+        **{
+            **first.__dict__,
+            "source_submission_ids": ("two",),
+            "submitter_email": "second@example.com",
+            "field_name": "BillingCity",
+            "label": "Billing City",
+            "original_value": "Gary",
+            "proposed_value": "Chicago",
+        }
+    )
+    results = [
+        ActionResult(first, ReviewDecision.APPLY_AUTOMATICALLY, ActionStatus.APPLIED),
+        ActionResult(
+            second, ReviewDecision.MAKE_MANUALLY, ActionStatus.VERIFIED_MANUAL
+        ),
+    ]
+
+    emails = format_response_emails(results)
+
+    assert list(emails) == ["first@example.com", "second@example.com"]
+    assert emails["first@example.com"].count("Thank you for updating") == 1
+    assert "Company Name: Acme Steel" in emails["first@example.com"]
+    assert "Billing City: Chicago" in emails["second@example.com"]
+
+
+def test_unsent_response_closes_sources_but_keeps_case_pending(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(["apply automatically", "no"])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review(
+        [staged_row(revised_company_name="Acme Steel LLC")],
+        tmp_path,
+    )
+
+    assert (
+        "Company_Profile_Change__c",
+        "submission-1",
+        {"Status__c": "Closed"},
+    ) in client.updated
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
+
+
+def test_salesforce_failure_is_audited_and_leaves_batch_retryable(tmp_path):
+    client = FakeClient()
+    client.fail_update = ("Account", "account-1")
+    feeder = Feeder(["apply automatically"])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingError, match="write failed"):
+        processor.review(
+            [staged_row(revised_company_name="Acme Steel LLC")],
+            tmp_path,
+        )
+
+    audit_text = (tmp_path / "review_audit.jsonl").read_text(encoding="utf-8")
+    assert '"result": "failed"' in audit_text
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
+
+
+def test_interruption_flushes_audit_and_leaves_batch_retryable(tmp_path):
+    client = FakeClient()
+    feeder = Feeder([KeyboardInterrupt()])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingInterrupted):
+        processor.review(
+            [staged_row(revised_company_name="Acme Steel LLC")],
+            tmp_path,
+        )
+
+    audit_text = (tmp_path / "review_audit.jsonl").read_text(encoding="utf-8")
+    assert '"result": "interrupted"' in audit_text
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
+
+
+def test_interruption_during_email_confirmation_is_also_retryable(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(["apply automatically", KeyboardInterrupt()])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingInterrupted):
+        processor.review(
+            [staged_row(revised_company_name="Acme Steel LLC")],
+            tmp_path,
+        )
+
+    audit_text = (tmp_path / "review_audit.jsonl").read_text(encoding="utf-8")
+    assert '"result": "interrupted"' in audit_text
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -242,6 +242,50 @@ def test_name_resolution_stops_at_first_candidate_tier():
     assert row["certification_salesforce_contact_id"] == ""
 
 
+def test_same_submitted_contact_in_multiple_roles_is_not_ambiguous():
+    record = submission(
+        Cert_First_Name__c="Jordan",
+        Cert_Last_Name__c="Lee",
+        Principal_First_Name__c="Jordan",
+        Principal_Last_Name__c="Lee",
+        Principal_Title__c="President",
+        Principal_Email__c="jordan@example.com",
+        Principal_Phone__c="312-555-0142",
+        AP_First_Name__c="Jordan",
+        AP_Last_Name__c="Lee",
+        AP_Email__c="jordan@example.com",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "use_submitted_contact"
+    assert row["certification_title"] == "President"
+    assert row["certification_phone"] == "312-555-0142"
+    assert row["certification_warning"] == ""
+    assert row["has_warnings"] == "false"
+
+
+def test_same_submitted_name_with_different_emails_is_ambiguous():
+    record = submission(
+        Cert_First_Name__c="Jordan",
+        Cert_Last_Name__c="Lee",
+        Principal_First_Name__c="Jordan",
+        Principal_Last_Name__c="Lee",
+        Principal_Email__c="first.jordan@example.com",
+        AP_First_Name__c="Jordan",
+        AP_Last_Name__c="Lee",
+        AP_Email__c="second.jordan@example.com",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == ""
+    assert "ambiguous" in row["certification_warning"].lower()
+    assert row["has_warnings"] == "true"
+
+
 def test_name_resolution_uses_account_then_sibling_contacts_and_warns_on_ambiguity():
     account_contact = {
         "Id": "account-match",
@@ -285,6 +329,47 @@ def test_name_resolution_uses_account_then_sibling_contacts_and_warns_on_ambigui
     assert "ambiguous" in result.rows[0]["certification_warning"].lower()
 
 
+def test_existing_contact_fills_optional_title_and_phone_without_warning():
+    matching = {
+        "Id": "existing-contact",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Certification Manager",
+        "Email": "alex@example.com",
+        "Phone": "312-555-0105",
+    }
+    record = submission(
+        Cert_First_Name__c="Alex",
+        Cert_Last_Name__c="Smith",
+        Cert_Email__c="alex@example.com",
+    )
+
+    result, _ = stage([record], accounts=[account()], contacts=[matching])
+
+    row = result.rows[0]
+    assert row["certification_salesforce_contact_id"] == "existing-contact"
+    assert row["certification_title"] == "Certification Manager"
+    assert row["certification_phone"] == "312-555-0105"
+    assert row["certification_warning"] == ""
+    assert row["has_warnings"] == "false"
+
+
+def test_email_only_can_match_another_submitted_role():
+    record = submission(
+        Cert_Email__c="shared@example.com",
+        Principal_Email__c=" SHARED@example.com ",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "use_submitted_contact"
+    assert row["certification_resolution_source"] == "submitted_role"
+    assert row["certification_source_role"] == "principal"
+    assert row["certification_warning"] == ""
+
+
 def test_email_and_partial_field_resolution_use_existing_role_contact():
     matching = {
         "Id": "existing-email",
@@ -313,6 +398,56 @@ def test_email_and_partial_field_resolution_use_existing_role_contact():
     assert row["new_york_salesforce_contact_id"] == "contact-ny"
 
 
+def test_role_lookup_contact_fills_missing_optional_details():
+    quality_contact = {
+        "Id": "contact-quality",
+        "AccountId": "account-1",
+        "FirstName": "Quinn",
+        "LastName": "Davis",
+        "Title": "Old title",
+        "Email": "quinn@example.com",
+        "Phone": "312-555-0199",
+    }
+    record = submission(QC_Title__c="Quality Director")
+
+    result, _ = stage(
+        [record],
+        accounts=[account()],
+        contacts=[quality_contact],
+    )
+
+    row = result.rows[0]
+    assert row["quality_title"] == "Quality Director"
+    assert row["quality_phone"] == "312-555-0199"
+    assert row["quality_warning"] == ""
+
+
+def test_unmatched_named_contact_records_create_intent_and_warning():
+    record = submission(
+        Cert_First_Name__c="New",
+        Cert_Last_Name__c="Person",
+        Cert_Email__c="new.person@example.com",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "create_contact"
+    assert "new contact will need to be created" in row["certification_warning"].lower()
+    assert row["has_warnings"] == "true"
+
+
+def test_unmatched_first_name_only_records_new_contact_warning():
+    result, _ = stage(
+        [submission(Cert_First_Name__c="Unlisted")],
+        accounts=[account()],
+    )
+
+    row = result.rows[0]
+    assert row["certification_resolution_action"] == "create_contact"
+    assert "new contact will need to be created" in row["certification_warning"].lower()
+
+
 def test_missing_account_and_last_name_only_are_staged_with_warnings():
     record = submission(
         Account__c="missing-account",
@@ -325,6 +460,7 @@ def test_missing_account_and_last_name_only_are_staged_with_warnings():
     assert row["account_id"] == "missing-account"
     assert row["account_name"] == "Acme Steel"
     assert row["has_warnings"] == "true"
+    assert row["certification_resolution_action"] == "create_contact"
     assert "could not be retrieved" in row["warnings"]
     assert "last-name-only" in row["certification_warning"].lower()
 
@@ -350,8 +486,9 @@ def test_unresolved_name_and_missing_role_lookup_have_explicit_warnings():
     )
 
     row = result.rows[0]
-    assert row["certification_salesforce_contact_id"] == ""
-    assert "No exact contact match" in row["certification_warning"]
+    assert row["certification_resolution_action"] == "create_contact"
+    assert "new contact will need to be created" in row["certification_warning"]
+    assert row["accounting_resolution_action"] == "update_contact"
     assert "no existing Accounting role contact" in row["accounting_warning"]
 
 

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -51,11 +51,41 @@ def account(**changes):
 
 
 class FakeClient:
-    def __init__(self, submissions, accounts=None, siblings=None, contacts=None):
+    def __init__(
+        self,
+        submissions,
+        accounts=None,
+        siblings=None,
+        contacts=None,
+        cases=None,
+    ):
         self.submissions = submissions
         self.accounts = accounts or []
         self.siblings = siblings or []
         self.contacts = contacts or []
+        self.cases = (
+            cases
+            if cases is not None
+            else [
+                {
+                    "Id": "case-1",
+                    "CaseNumber": "00010001",
+                    "Subject": (
+                        "Profile Update Received - "
+                        + " / ".join(
+                            dict.fromkeys(
+                                record.get("Name", "")
+                                for record in submissions
+                                if record.get("Name")
+                            )
+                        )
+                    ),
+                    "Status": "Pending",
+                    "CreatedDate": "2026-07-15T15:00:00.000+0000",
+                    "AccountId": "account-1",
+                }
+            ]
+        )
         self.queries = []
 
     def query_records(self, object_name, fields, *, where=None, order_by=None):
@@ -68,11 +98,13 @@ class FakeClient:
             return list(self.siblings)
         if object_name == "Contact":
             return list(self.contacts)
+        if object_name == "Case":
+            return list(self.cases)
         raise AssertionError(object_name)
 
 
-def stage(submissions, *, accounts=None, siblings=None, contacts=None):
-    client = FakeClient(submissions, accounts, siblings, contacts)
+def stage(submissions, *, accounts=None, siblings=None, contacts=None, cases=None):
+    client = FakeClient(submissions, accounts, siblings, contacts, cases)
     result = ProfileUpdateStagingService(client).stage()
     return result, client
 
@@ -108,7 +140,8 @@ def test_merges_same_account_and_email_with_later_nonblank_values():
     assert row["comments"] == "First comment"
     assert client.queries[0][3] == "CreatedDate ASC, Id ASC"
     assert client.queries[1][1] == ACCOUNT_FIELDS
-    assert client.queries[-1][1] == CONTACT_FIELDS
+    contact_query = next(query for query in client.queries if query[0] == "Contact")
+    assert contact_query[1] == CONTACT_FIELDS
 
 
 def test_keeps_different_emails_separate_and_blank_emails_independent():
@@ -524,3 +557,47 @@ def test_writer_removes_temporary_output_after_failure(monkeypatch, tmp_path):
         write_staged_profile_updates([], tmp_path)
 
     assert list(tmp_path.iterdir()) == []
+
+
+def test_staging_records_case_and_key_update_metadata():
+    record = submission(
+        Type__c="Key Data",
+        Revised_Company_Name__c="Acme Steel LLC",
+    )
+
+    result, client = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["case_id"] == "case-1"
+    assert row["case_number"] == "00010001"
+    assert row["case_match_status"] == "matched"
+    assert row["has_key_updates"] == "true"
+    assert row["earliest_key_update_date"] == record["CreatedDate"]
+    case_query = next(query for query in client.queries if query[0] == "Case")
+    assert "AccountId IN ('account-1')" in case_query[2]
+
+
+def test_missing_or_ambiguous_case_match_is_a_blocking_warning():
+    record = submission()
+
+    missing, _ = stage([record], accounts=[account()], cases=[])
+    assert missing.rows[0]["case_match_status"] == "missing"
+    assert missing.rows[0]["case_id"] == ""
+    assert "blocking" in missing.rows[0]["warnings"].lower()
+
+    matching_case = {
+        "Id": "case-1",
+        "CaseNumber": "0001",
+        "Subject": "Profile Update Received - PU-100",
+        "Status": "Pending",
+        "CreatedDate": "2026-07-15T15:00:00.000+0000",
+        "AccountId": "account-1",
+    }
+    ambiguous, _ = stage(
+        [record],
+        accounts=[account()],
+        cases=[matching_case, {**matching_case, "Id": "case-2"}],
+    )
+    assert ambiguous.rows[0]["case_match_status"] == "ambiguous"
+    assert ambiguous.rows[0]["case_id"] == ""
+    assert "blocking" in ambiguous.rows[0]["warnings"].lower()


### PR DESCRIPTION
## Summary
- add read-only staging for new Salesforce Profile Updates
- add interactive processing with case preparation, contact-role review, audit logging, and response handling
- document the workflow and add unit/CLI coverage

Closes #5