### PR TITLE
Add AISC profile update subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Create/reuse Cases, publish a fresh staging CSV, and review it interactively:
 uv run aisc_salesforce process-profile-updates
 ```
 
+Preview the one-time correction of recent legacy Case subjects:
+
+```bash
+uv run aisc_salesforce rename-profile-update-cases
+```
+
 All commands are also available as a Python module:
 
 ```bash
@@ -72,6 +78,66 @@ uv run python -m aisc_salesforce profile-updates
 `profile-updates` prints `created`, `reused`, `skipped`, and `failed` counts. A
 successful run returns exit code `0`; missing configuration or a Salesforce
 failure returns `1`.
+
+### Profile Update Case subjects
+
+New received Cases use this grammar:
+
+```text
+AISC Profile Update for {Account Name} - {Profile Update} {YY-MM-DD}
+```
+
+For example:
+
+```text
+AISC Profile Update for Acme Steel - PU-100 26-07-20
+```
+
+When another submission is reused on the same AISC Case, its complete
+identifier and own received date are appended:
+
+```text
+AISC Profile Update for Acme Steel - PU-099 26-07-01 / PU-100 26-07-15
+```
+
+Identifiers are compared after trimming and without letter-case sensitivity,
+but only complete identifiers match: `PU-10` does not match `PU-100`. If an
+Account-scoped AISC Case already contains an identifier, automation skips that
+submission without reading or posting Chatter.
+
+Existing `Profile Update Received` subjects remain recognized by Case
+automation and staging. Recurring automation leaves those legacy subjects in
+their old format, which keeps retries compatible and prevents out-of-window
+renames.
+
+### One-time legacy subject correction
+
+`rename-profile-update-cases` is preview-only by default:
+
+```bash
+uv run aisc_salesforce rename-profile-update-cases
+```
+
+Review every printed `old subject -> new subject` proposal. Apply those same
+Subject-only changes explicitly:
+
+```bash
+uv run aisc_salesforce rename-profile-update-cases --apply
+```
+
+The command checks today and the preceding six `America/Chicago` calendar
+dates. Those local midnight boundaries are converted to UTC for Salesforce
+`CreatedDate`, which Salesforce stores in GMT. It accepts dated legacy prefixes
+in the forms `YYYY-MM-DD:`, `YYYY-MM-DD -`, and `YY-MM-DD -`. The date embedded
+in the legacy subject—not the Case creation date—is assigned to every Profile
+Update identifier in that subject.
+
+Subjects without a trustworthy embedded date and corrected subjects over 255
+characters are skipped with an explanation. Apply mode PATCHes only `Subject`,
+continues after an individual failure, and exits nonzero if any write fails.
+Both modes print per-Case results and totals for `matched`, `updated` or
+`would update`, `skipped`, and `failed`. A safe rerun ignores already-corrected
+AISC subjects.
 
 ### Profile Update staging
 
@@ -232,7 +298,9 @@ The automation checks Cases only on the relevant Account. It reuses the newest
 appropriate Expected or Received Case and checks the Case and Audit Chatter
 feeds for the exact automation message before posting. Therefore, rerunning
 after a partial failure fills in missing work without duplicating completed
-comments. New submission names are appended with ` / ` once.
+comments. AISC subjects store every appended submission as an exact
+Profile Update/date pair. Legacy subjects remain unchanged except when the
+dedicated correction command is explicitly run with `--apply`.
 
 Audit Dates from 30 days ago through today are eligible. Blank explanations,
 `None`, and `N/A` are ignored. If adding a Profile Update name would make a

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,41 @@
         - is_eligible_audit
         - match_contact
 
+## Profile Update Case subjects
+
+::: aisc_salesforce.profile_update_subjects
+    options:
+      show_root_heading: true
+      members:
+        - ProfileUpdateReference
+        - AiscProfileUpdateSubject
+        - build_aisc_profile_update_subject
+        - parse_aisc_profile_update_subject
+        - parse_legacy_profile_update_subject
+        - is_received_profile_update_subject
+        - subject_has_profile_update
+        - append_profile_update
+        - validate_subject_length
+
+The frozen data classes model an Account name plus ordered Profile Update/date
+pairs. Both recurring automation and staging use these helpers, so identifier
+matching and subject-length validation have one shared implementation.
+
+## Legacy Case subject correction
+
+::: aisc_salesforce.rename_profile_update_cases
+    options:
+      show_root_heading: true
+      members:
+        - RenameCounts
+        - RenameProfileUpdateCasesService
+        - correction_window
+
+`correction_window` converts seven `America/Chicago` local dates to UTC query
+bounds. `RenameProfileUpdateCasesService.run()` defaults to preview mode. Apply
+mode updates only the Case `Subject`, catches individual Salesforce write
+failures, and continues through the queried batch.
+
 ## Salesforce client
 
 ::: aisc_salesforce.salesforce

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,41 @@ failed: 0
 Exit code `0` means the run completed without failures. Exit code `1` means
 configuration, Salesforce communication, or one or more records failed.
 
+### Case subject grammar and duplicate handling
+
+New received Cases and Expected Cases converted after a submission use:
+
+```text
+AISC Profile Update for {Account Name} - {Profile Update} {YY-MM-DD}
+```
+
+Example:
+
+```text
+AISC Profile Update for Acme Steel - PU-100 26-07-20
+```
+
+Every combined Case stores an ordered Profile Update/date pair for each
+submission:
+
+```text
+AISC Profile Update for Acme Steel - PU-099 26-07-01 / PU-100 26-07-15
+```
+
+The date beside each identifier is that submission's received date. Matching
+trims whitespace, ignores letter case, and compares the complete identifier.
+For example, `pu-100` matches `PU-100`, but `PU-10` and `PU-1000` do not.
+
+The daily automation and staging workflow recognize both the AISC grammar and
+legacy subjects containing `Profile Update Received`. When an Account-scoped
+AISC Case already contains the exact identifier, the daily automation
+immediately reports the submission as skipped. It does not query or post
+Chatter for that duplicate.
+
+When recurring automation reuses a legacy received Case, it keeps the old
+subject format. A missing Chatter summary can therefore still be added on a
+retry without silently normalizing legacy Cases outside the correction window.
+
 ## Scheduling and retries
 
 Use cron, Windows Task Scheduler, or another external scheduler to call the
@@ -74,6 +109,88 @@ name, and exact Chatter text to recognize completed work. If a run stops after
 one Chatter post, the next run posts only the missing message.
 
 The project does not install or manage a scheduler itself.
+
+## Rename Profile Update Cases command
+
+Use the one-time command to correct recently created legacy Case subjects. The
+safe default is preview mode:
+
+```bash
+uv run aisc_salesforce rename-profile-update-cases
+```
+
+Preview mode authenticates and queries Salesforce but does not update a Case.
+It prints each proposal in this form:
+
+```text
+00012345: would update: 2026-07-15: Profile Update Received for Acme Steel - PU-100 -> AISC Profile Update for Acme Steel - PU-100 26-07-15
+```
+
+After reviewing the preview, `--apply` is the only option that enables writes:
+
+```bash
+uv run aisc_salesforce rename-profile-update-cases --apply
+```
+
+Apply mode sends a PATCH containing only `Subject`; omitted Case fields are not
+changed. See Salesforce's
+[record-update guidance](https://developer.salesforce.com/docs/marketing/marketing-cloud-growth/guide/mc-manage-objects-update-rest.html).
+
+### Correction window and parsing rules
+
+The query covers seven `America/Chicago` calendar dates: today plus the six
+preceding dates. The lower boundary is local midnight six dates ago, and the
+exclusive upper boundary is the local midnight after today. Both boundaries
+are converted to UTC for the SOQL `CreatedDate` comparison because Salesforce
+stores date/time values in GMT. See Salesforce's
+[date/time guidance](https://developer.salesforce.com/docs/atlas.en-us.formula_date_time_tipsheet.meta/formula_date_time_tipsheet).
+
+These dated legacy prefixes are supported:
+
+- `YYYY-MM-DD: Profile Update Received ...`
+- `YYYY-MM-DD - Profile Update Received ...`
+- `YY-MM-DD - Profile Update Received ...`
+
+The embedded received date is required. It is used instead of the Case
+`CreatedDate`, and a subject with several identifiers gives that same embedded
+date to every identifier:
+
+```text
+26-07-15 - Profile Update Received for Acme Steel - PU-100 / PU-101
+```
+
+becomes:
+
+```text
+AISC Profile Update for Acme Steel - PU-100 26-07-15 / PU-101 26-07-15
+```
+
+An unparseable date, a missing date, or a corrected subject over Salesforce's
+255-character Subject limit is skipped with a reason. The command does not
+guess from `CreatedDate`.
+
+### Output, failures, and reruns
+
+Every Case receives an individual `would update`, `updated`, `skipped`, or
+`failed` line. The final totals are:
+
+```text
+Rename profile update Cases complete:
+matched: 3
+would update: 2
+skipped: 1
+failed: 0
+```
+
+Apply mode prints `updated` instead of `would update`. It continues processing
+after an individual Salesforce update fails so the remaining safe corrections
+can finish. The command exits with code `1` if any update failed and `0`
+otherwise.
+
+Reruns are safe. The Salesforce query targets legacy `Profile Update Received`
+subjects, while a successfully corrected subject begins with `AISC Profile
+Update`; it will not be changed again. Legacy Cases outside the seven-date
+window remain unchanged.
 
 ## Stage Profile Updates command
 
@@ -176,7 +293,9 @@ phone alone does not cause a warning.
 Case preparation adds `case_id`, `case_number`, `case_status`, and
 `case_match_status`. A row is processable only when its match status is
 `matched`. Missing and ambiguous Case matches are blocking warnings and are
-never guessed.
+never guessed. Case subjects are parsed with the same exact identifier rules as
+daily automation, so the `YY-MM-DD` values in AISC subjects are not mistaken
+for part of a Profile Update identifier.
 
 Key Update metadata is explicit:
 

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -15,6 +15,7 @@ from .process_profile_updates import (
     ProfileUpdateProcessingWorkflow,
 )
 from .profile_updates import ProfileUpdateService
+from .rename_profile_update_cases import RenameProfileUpdateCasesService
 from .salesforce import (
     SalesforceClient,
     SalesforceError,
@@ -73,6 +74,15 @@ def main(
         default=Path("staged_profile_updates"),
         help="Directory to contain staging, audit, and response artifacts.",
     )
+    rename_parser = subparsers.add_parser(
+        "rename-profile-update-cases",
+        help="Preview corrections to recent legacy Profile Update Case subjects.",
+    )
+    rename_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the previewed Subject-only Case updates.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -101,6 +111,15 @@ def main(
             )
         except (ProcessingError, SalesforceError, OSError) as error:
             print(f"Process profile updates failed: {error}", file=sys.stderr)
+            return 1
+    if args.command == "rename-profile-update-cases":
+        try:
+            return _run_rename_profile_update_cases(
+                apply=args.apply,
+                output_fn=output_fn,
+            )
+        except (SalesforceError, OSError) as error:
+            print(f"Rename profile update Cases failed: {error}", file=sys.stderr)
             return 1
     return 1
 
@@ -195,6 +214,29 @@ def _run_process_profile_updates(
     output_fn(f"completed Case batches: {result.completed_batches}")
     output_fn(f"pending Case batches: {result.pending_batches}")
     return 0
+
+
+def _run_rename_profile_update_cases(
+    *,
+    apply: bool,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Connect to Salesforce and preview or apply recent subject corrections."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    counts = RenameProfileUpdateCasesService(
+        SalesforceClient(auth), output_fn=output_fn
+    ).run(apply=apply)
+    output_fn("Rename profile update Cases complete:")
+    output_fn(f"matched: {counts.matched}")
+    label = "updated" if apply else "would update"
+    value = counts.updated if apply else counts.would_update
+    output_fn(f"{label}: {value}")
+    output_fn(f"skipped: {counts.skipped}")
+    output_fn(f"failed: {counts.failed}")
+    return 1 if counts.failed else 0
 
 
 def get_profile_update_configuration(

--- a/src/aisc_salesforce/profile_update_subjects.py
+++ b/src/aisc_salesforce/profile_update_subjects.py
@@ -1,0 +1,197 @@
+"""Parse and build Salesforce Case subjects for Profile Updates."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+AISC_PREFIX = "AISC Profile Update for "
+LEGACY_RECEIVED_MARKER = "Profile Update Received"
+SALESFORCE_SUBJECT_LIMIT = 255
+
+_AISC_PAIR = re.compile(r"^(?P<name>.+?)\s+(?P<date>\d{2}-\d{2}-\d{2})$")
+_LEGACY_WITH_DATE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})(?P<separator>:| -)\s*"
+    r"Profile Update Received for (?P<body>.+)$",
+    re.IGNORECASE,
+)
+_LEGACY_SHORT_DATE = re.compile(
+    r"^(?P<date>\d{2}-\d{2}-\d{2}) -\s*"
+    r"Profile Update Received for (?P<body>.+)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ProfileUpdateReference:
+    """One exact Profile Update identifier and its received date."""
+
+    name: str
+    received_date: date
+
+
+@dataclass(frozen=True)
+class AiscProfileUpdateSubject:
+    """The structured information stored in a modern AISC Case subject."""
+
+    account_name: str
+    updates: tuple[ProfileUpdateReference, ...]
+
+
+def build_aisc_profile_update_subject(
+    account_name: str, updates: Iterable[ProfileUpdateReference]
+) -> str:
+    """Build and validate a modern AISC Profile Update Case subject."""
+    clean_account = account_name.strip()
+    references = tuple(updates)
+    if not clean_account:
+        raise ValueError("Account Name is missing.")
+    if not references:
+        raise ValueError("At least one Profile Update is required.")
+
+    pairs = []
+    for reference in references:
+        clean_name = reference.name.strip()
+        if not clean_name:
+            raise ValueError("Profile Update Name is missing.")
+        pairs.append(f"{clean_name} {reference.received_date.strftime('%y-%m-%d')}")
+    subject = f"{AISC_PREFIX}{clean_account} - {' / '.join(pairs)}"
+    validate_subject_length(subject)
+    return subject
+
+
+def parse_aisc_profile_update_subject(
+    subject: Any,
+) -> AiscProfileUpdateSubject | None:
+    """Parse a modern subject, returning ``None`` when its grammar is invalid."""
+    text = _clean_text(subject)
+    if not text.casefold().startswith(AISC_PREFIX.casefold()):
+        return None
+    body = text[len(AISC_PREFIX) :]
+    if " - " not in body:
+        return None
+    account_name, pair_text = body.rsplit(" - ", 1)
+    account_name = account_name.strip()
+    if not account_name:
+        return None
+
+    updates = []
+    for raw_pair in pair_text.split("/"):
+        match = _AISC_PAIR.fullmatch(raw_pair.strip())
+        if match is None:
+            return None
+        received_date = _parse_date(match.group("date"), "%y-%m-%d")
+        name = match.group("name").strip()
+        if received_date is None or not name:
+            return None
+        updates.append(ProfileUpdateReference(name, received_date))
+    if not updates:
+        return None
+    return AiscProfileUpdateSubject(account_name, tuple(updates))
+
+
+def parse_legacy_profile_update_subject(
+    subject: Any,
+) -> AiscProfileUpdateSubject | None:
+    """Parse a supported dated legacy subject for the correction command."""
+    text = _clean_text(subject)
+    match = _LEGACY_WITH_DATE.fullmatch(text)
+    date_format = "%Y-%m-%d"
+    if match is None:
+        match = _LEGACY_SHORT_DATE.fullmatch(text)
+        date_format = "%y-%m-%d"
+    if match is None:
+        return None
+
+    received_date = _parse_date(match.group("date"), date_format)
+    parts = _legacy_body_parts(match.group("body"))
+    if received_date is None or parts is None:
+        return None
+    account_name, names = parts
+    return AiscProfileUpdateSubject(
+        account_name,
+        tuple(ProfileUpdateReference(name, received_date) for name in names),
+    )
+
+
+def is_received_profile_update_subject(subject: Any) -> bool:
+    """Return whether a Case is a modern or legacy received Profile Update."""
+    return parse_aisc_profile_update_subject(subject) is not None or bool(
+        _legacy_names(subject)
+    )
+
+
+def subject_has_profile_update(subject: Any, update_name: str) -> bool:
+    """Match one complete update identifier, ignoring case and outer whitespace."""
+    wanted = update_name.strip().casefold()
+    if not wanted:
+        return False
+    parsed = parse_aisc_profile_update_subject(subject)
+    names = (
+        [reference.name for reference in parsed.updates]
+        if parsed is not None
+        else _legacy_names(subject)
+    )
+    return any(name.strip().casefold() == wanted for name in names)
+
+
+def append_profile_update(subject: str, update_name: str, received_date: date) -> str:
+    """Append an update/date pair while leaving legacy subject text legacy."""
+    clean_name = update_name.strip()
+    if not clean_name:
+        raise ValueError("Profile Update Name is missing.")
+
+    parsed = parse_aisc_profile_update_subject(subject)
+    if parsed is not None:
+        return build_aisc_profile_update_subject(
+            parsed.account_name,
+            (*parsed.updates, ProfileUpdateReference(clean_name, received_date)),
+        )
+    if _legacy_names(subject):
+        updated = f"{subject.strip()} / {clean_name}"
+        validate_subject_length(updated)
+        return updated
+    raise ValueError("Case Subject is not a received Profile Update subject.")
+
+
+def validate_subject_length(subject: str) -> None:
+    """Reject a Case subject that exceeds Salesforce's 255-character limit."""
+    if len(subject) > SALESFORCE_SUBJECT_LIMIT:
+        raise ValueError(
+            f"Case Subject is {len(subject)} characters; "
+            f"Salesforce allows {SALESFORCE_SUBJECT_LIMIT}."
+        )
+
+
+def _legacy_names(subject: Any) -> list[str]:
+    text = _clean_text(subject)
+    if LEGACY_RECEIVED_MARKER.casefold() not in text.casefold():
+        return []
+    if " - " not in text:
+        return []
+    names_text = text.rsplit(" - ", 1)[1]
+    return [name.strip() for name in names_text.split("/") if name.strip()]
+
+
+def _legacy_body_parts(body: str) -> tuple[str, list[str]] | None:
+    if " - " not in body:
+        return None
+    account_name, names_text = body.rsplit(" - ", 1)
+    names = [name.strip() for name in names_text.split("/") if name.strip()]
+    if not account_name.strip() or not names:
+        return None
+    return account_name.strip(), names
+
+
+def _parse_date(value: str, date_format: str) -> date | None:
+    try:
+        return datetime.strptime(value, date_format).date()
+    except ValueError:
+        return None
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/src/aisc_salesforce/profile_updates.py
+++ b/src/aisc_salesforce/profile_updates.py
@@ -6,6 +6,15 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from .profile_update_subjects import (
+    ProfileUpdateReference,
+    append_profile_update,
+    build_aisc_profile_update_subject,
+    is_received_profile_update_subject,
+    parse_aisc_profile_update_subject,
+    subject_has_profile_update,
+    validate_subject_length,
+)
 from .salesforce import SalesforceClient, SalesforceError
 
 AUDIT_FIELDS = [
@@ -289,7 +298,7 @@ class ProfileUpdateService:
             f"{audit_date.isoformat()}: Profile Update Expected for {account_name} "
             f"based on {audit_name}"
         )
-        _check_subject_length(subject)
+        validate_subject_length(subject)
         cases = self._profile_cases(account_id)
 
         matching = self._newest(
@@ -304,7 +313,7 @@ class ProfileUpdateService:
         received = self._newest(
             case
             for case in cases
-            if "profile update received" in _clean_text(case.get("Subject")).casefold()
+            if is_received_profile_update_subject(case.get("Subject"))
         )
         if received is not None:
             worked = False
@@ -382,10 +391,17 @@ class ProfileUpdateService:
         summary = build_submission_summary(submission)
         cases = self._profile_cases(account_id)
 
+        if any(
+            parse_aisc_profile_update_subject(case.get("Subject")) is not None
+            and subject_has_profile_update(case.get("Subject"), update_name)
+            for case in cases
+        ):
+            return "skipped"
+
         same_name_cases = [
             case
             for case in cases
-            if _subject_has_name(case.get("Subject"), update_name)
+            if subject_has_profile_update(case.get("Subject"), update_name)
         ]
         for case in sorted(same_name_cases, key=_case_sort_key, reverse=True):
             case_id = _required_text(case, "Id", "Case ID")
@@ -401,24 +417,22 @@ class ProfileUpdateService:
         received = self._newest(
             case
             for case in cases
-            if "profile update received" in _clean_text(case.get("Subject")).casefold()
+            if is_received_profile_update_subject(case.get("Subject"))
         )
         if received is not None:
             case_id = _required_text(received, "Id", "Case ID")
             old_subject = _required_text(received, "Subject", "Case Subject")
-            subject = f"{old_subject} / {update_name}"
-            _check_subject_length(subject)
+            subject = append_profile_update(old_subject, update_name, created_date)
             self.client.update_record("Case", case_id, {"Subject": subject})
             received["Subject"] = subject
             self._post_if_missing(case_id, summary)
             return "reused"
 
         contact_id = self._submission_contact(submission, account_id)
-        subject = (
-            f"{created_date.isoformat()}: Profile Update Received for {account_name} "
-            f"- {update_name}"
+        subject = build_aisc_profile_update_subject(
+            account_name,
+            [ProfileUpdateReference(update_name, created_date)],
         )
-        _check_subject_length(subject)
         payload = self._case_payload(
             subject=subject,
             account_id=account_id,
@@ -523,14 +537,6 @@ def escape_soql_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "\\'")
 
 
-def _subject_has_name(subject: Any, update_name: str) -> bool:
-    text = _clean_text(subject)
-    if " - " not in text:
-        return False
-    names = [name.strip().casefold() for name in text.rsplit(" - ", 1)[1].split("/")]
-    return update_name.strip().casefold() in names
-
-
 def _clean_text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
@@ -566,10 +572,3 @@ def _record_date(value: Any) -> date:
 
 def _case_sort_key(record: dict[str, Any]) -> tuple[str, str]:
     return (_clean_text(record.get("CreatedDate")), _clean_text(record.get("Id")))
-
-
-def _check_subject_length(subject: str) -> None:
-    if len(subject) > 255:
-        raise ValueError(
-            f"Case Subject is {len(subject)} characters; Salesforce allows 255."
-        )

--- a/src/aisc_salesforce/rename_profile_update_cases.py
+++ b/src/aisc_salesforce/rename_profile_update_cases.py
@@ -1,0 +1,144 @@
+"""Safely preview or apply one-time corrections to legacy Case subjects."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, time, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from .profile_update_subjects import (
+    build_aisc_profile_update_subject,
+    parse_legacy_profile_update_subject,
+)
+from .salesforce import SalesforceClient, SalesforceError
+
+CHICAGO = ZoneInfo("America/Chicago")
+RENAME_CASE_FIELDS = ["Id", "CaseNumber", "Subject", "CreatedDate"]
+
+
+@dataclass
+class RenameCounts:
+    """Totals from one preview or apply run."""
+
+    matched: int = 0
+    updated: int = 0
+    would_update: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+def correction_window(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Return UTC bounds for today and the prior six Chicago calendar dates."""
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    local_today = current.astimezone(CHICAGO).date()
+    local_start = datetime.combine(
+        local_today - timedelta(days=6), time.min, tzinfo=CHICAGO
+    )
+    local_end = datetime.combine(
+        local_today + timedelta(days=1), time.min, tzinfo=CHICAGO
+    )
+    return local_start.astimezone(UTC), local_end.astimezone(UTC)
+
+
+class RenameProfileUpdateCasesService:
+    """Correct dated legacy subjects, using preview mode unless apply is explicit."""
+
+    def __init__(
+        self,
+        client: SalesforceClient,
+        *,
+        now: datetime | None = None,
+        output_fn: Callable[[str], None] = print,
+    ):
+        self.client = client
+        self.now = now
+        self.output_fn = output_fn
+
+    def run(self, *, apply: bool = False) -> RenameCounts:
+        """Preview changes or PATCH only ``Subject`` when ``apply`` is true."""
+        start, end = correction_window(self.now)
+        cases = self.client.query_records(
+            "Case",
+            RENAME_CASE_FIELDS,
+            where=(
+                "Subject LIKE '%Profile Update Received%' AND "
+                f"CreatedDate >= {_salesforce_datetime(start)} AND "
+                f"CreatedDate < {_salesforce_datetime(end)}"
+            ),
+            order_by="CreatedDate ASC, Id ASC",
+        )
+        counts = RenameCounts()
+        for case in cases:
+            self._process_case(case, apply=apply, counts=counts)
+        return counts
+
+    def _process_case(
+        self,
+        case: dict[str, Any],
+        *,
+        apply: bool,
+        counts: RenameCounts,
+    ) -> None:
+        case_id = _case_label(case)
+        old_subject = _clean_text(case.get("Subject"))
+        parsed = parse_legacy_profile_update_subject(old_subject)
+        if parsed is None:
+            counts.skipped += 1
+            self.output_fn(
+                f"{case_id}: skipped - subject has no trustworthy embedded "
+                "received date."
+            )
+            return
+
+        counts.matched += 1
+        try:
+            new_subject = build_aisc_profile_update_subject(
+                parsed.account_name, parsed.updates
+            )
+        except ValueError as error:
+            counts.skipped += 1
+            self.output_fn(f"{case_id}: skipped - {error}")
+            return
+
+        if not apply:
+            counts.would_update += 1
+            self.output_fn(f"{case_id}: would update: {old_subject} -> {new_subject}")
+            return
+
+        try:
+            self.client.update_record(
+                "Case", _required_id(case), {"Subject": new_subject}
+            )
+        except SalesforceError as error:
+            counts.failed += 1
+            self.output_fn(f"{case_id}: failed - {error}")
+            return
+        counts.updated += 1
+        self.output_fn(f"{case_id}: updated: {old_subject} -> {new_subject}")
+
+
+def _salesforce_datetime(value: datetime) -> str:
+    return value.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _case_label(case: dict[str, Any]) -> str:
+    return (
+        _clean_text(case.get("CaseNumber"))
+        or _clean_text(case.get("Id"))
+        or "(unknown)"
+    )
+
+
+def _required_id(case: dict[str, Any]) -> str:
+    case_id = _clean_text(case.get("Id"))
+    if not case_id:
+        raise SalesforceError("Case ID is missing.")
+    return case_id
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from .profile_update_subjects import subject_has_profile_update
 from .profile_updates import SUBMISSION_FIELDS, escape_soql_string
 from .salesforce import SalesforceClient
 
@@ -454,7 +455,7 @@ class ProfileUpdateStagingService:
             for case in account_cases
             if source_names
             and all(
-                _case_subject_has_name(case.get("Subject"), name)
+                subject_has_profile_update(case.get("Subject"), name)
                 for name in source_names
             )
         ]
@@ -474,7 +475,7 @@ class ProfileUpdateStagingService:
             case
             for case in account_cases
             if any(
-                _case_subject_has_name(case.get("Subject"), name)
+                subject_has_profile_update(case.get("Subject"), name)
                 for name in source_names
             )
         ]
@@ -986,14 +987,6 @@ def _is_key_update(record: dict[str, Any]) -> bool:
     return _normalized(record.get("Type__c")) == "key data" or any(
         _has_value(record.get(api_name)) for api_name in key_fields
     )
-
-
-def _case_subject_has_name(subject: Any, update_name: str) -> bool:
-    text = _clean_text(subject)
-    if " - " not in text:
-        return False
-    names = [name.strip().casefold() for name in text.rsplit(" - ", 1)[1].split("/")]
-    return update_name.strip().casefold() in names
 
 
 def _where_in(field_name: str, values: list[str]) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from aisc_salesforce import app
 from aisc_salesforce.dictionary import ExportField
 from aisc_salesforce.profile_updates import AutomationCounts
+from aisc_salesforce.rename_profile_update_cases import RenameCounts
 
 
 def test_cli_success_uses_custom_output_dir(monkeypatch, tmp_path, capsys):
@@ -303,3 +304,48 @@ def test_process_profile_updates_cli_reports_processing_failure(monkeypatch, cap
         "Process profile updates failed: manual verification failed"
         in capsys.readouterr().err
     )
+
+
+def test_rename_cli_previews_by_default_and_apply_is_explicit(monkeypatch):
+    calls = []
+
+    def run(*, apply, output_fn):
+        calls.append((apply, output_fn))
+        return 0
+
+    monkeypatch.setattr(app, "_run_rename_profile_update_cases", run)
+
+    assert app.main(["rename-profile-update-cases"]) == 0
+    assert app.main(["rename-profile-update-cases", "--apply"]) == 0
+    assert [apply for apply, _ in calls] == [False, True]
+
+
+def test_rename_cli_prints_totals_and_fails_only_for_update_failures(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app, "get_credentials", lambda environment: {"ok": "yes"})
+    monkeypatch.setattr(app, "get_oauth_url", lambda environment: "token-url")
+    monkeypatch.setattr(
+        app,
+        "request_access_token",
+        lambda credentials, oauth_url: "auth",
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: "client")
+
+    class Service:
+        def __init__(self, client, *, output_fn):
+            pass
+
+        def run(self, *, apply):
+            assert apply is True
+            return RenameCounts(matched=3, updated=1, skipped=1, failed=1)
+
+    monkeypatch.setattr(app, "RenameProfileUpdateCasesService", Service)
+
+    assert app._run_rename_profile_update_cases(apply=True) == 1
+    output = capsys.readouterr().out
+    assert "matched: 3" in output
+    assert "updated: 1" in output
+    assert "skipped: 1" in output
+    assert "failed: 1" in output

--- a/tests/test_profile_update_subjects.py
+++ b/tests/test_profile_update_subjects.py
@@ -1,0 +1,128 @@
+from datetime import date
+
+import pytest
+
+from aisc_salesforce.profile_update_subjects import (
+    AiscProfileUpdateSubject,
+    ProfileUpdateReference,
+    append_profile_update,
+    build_aisc_profile_update_subject,
+    is_received_profile_update_subject,
+    parse_aisc_profile_update_subject,
+    parse_legacy_profile_update_subject,
+    subject_has_profile_update,
+)
+
+
+def test_builds_and_parses_aisc_subject_with_ordered_update_date_pairs():
+    subject = build_aisc_profile_update_subject(
+        "Acme Steel",
+        [
+            ProfileUpdateReference("PU-099", date(2026, 7, 1)),
+            ProfileUpdateReference("PU-100", date(2026, 7, 15)),
+        ],
+    )
+
+    assert (
+        subject
+        == "AISC Profile Update for Acme Steel - PU-099 26-07-01 / PU-100 26-07-15"
+    )
+    assert parse_aisc_profile_update_subject(subject) == AiscProfileUpdateSubject(
+        "Acme Steel",
+        (
+            ProfileUpdateReference("PU-099", date(2026, 7, 1)),
+            ProfileUpdateReference("PU-100", date(2026, 7, 15)),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        ("pu-100", True),
+        (" PU-100 ", True),
+        ("PU-10", False),
+        ("PU-1000", False),
+    ],
+)
+def test_matching_is_trimmed_case_insensitive_and_never_partial(candidate, expected):
+    subject = "AISC Profile Update for Acme Steel - PU-100 26-07-15"
+
+    assert subject_has_profile_update(subject, candidate) is expected
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+        "2026-07-15 - Profile Update Received for Acme Steel - PU-100",
+        "26-07-15 - Profile Update Received for Acme Steel - PU-100",
+        "Profile Update Received for Acme Steel - PU-100",
+        "AISC Profile Update for Acme Steel - PU-100 26-07-15",
+    ],
+)
+def test_received_recognition_and_exact_matching_support_aisc_and_legacy(subject):
+    assert is_received_profile_update_subject(subject)
+    assert subject_has_profile_update(subject, "pu-100")
+    assert not subject_has_profile_update(subject, "PU-10")
+
+
+@pytest.mark.parametrize(
+    ("subject", "received_date"),
+    [
+        (
+            "2026-07-15: Profile Update Received for Acme Steel - PU-100 / PU-101",
+            date(2026, 7, 15),
+        ),
+        (
+            "2026-07-15 - Profile Update Received for Acme Steel - PU-100",
+            date(2026, 7, 15),
+        ),
+        (
+            "26-07-15 - Profile Update Received for Acme Steel - PU-100",
+            date(2026, 7, 15),
+        ),
+    ],
+)
+def test_legacy_parser_uses_embedded_date_for_every_update(subject, received_date):
+    parsed = parse_legacy_profile_update_subject(subject)
+
+    assert parsed == AiscProfileUpdateSubject(
+        "Acme Steel",
+        tuple(
+            ProfileUpdateReference(name, received_date)
+            for name in ("PU-100", "PU-101")[: len(parsed.updates)]
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "Profile Update Received for Acme Steel - PU-100",
+        "not-a-date: Profile Update Received for Acme Steel - PU-100",
+        "2026-02-30: Profile Update Received for Acme Steel - PU-100",
+    ],
+)
+def test_migration_parser_rejects_legacy_subject_without_trustworthy_date(subject):
+    assert parse_legacy_profile_update_subject(subject) is None
+
+
+def test_appending_adds_date_to_aisc_but_preserves_legacy_format():
+    aisc = "AISC Profile Update for Acme Steel - PU-099 26-07-01"
+    legacy = "2026-07-01: Profile Update Received for Acme Steel - PU-099"
+
+    assert append_profile_update(aisc, "PU-100", date(2026, 7, 15)) == (
+        "AISC Profile Update for Acme Steel - PU-099 26-07-01 / PU-100 26-07-15"
+    )
+    assert append_profile_update(legacy, "PU-100", date(2026, 7, 15)) == (
+        "2026-07-01: Profile Update Received for Acme Steel - PU-099 / PU-100"
+    )
+
+
+def test_subject_builder_rejects_salesforce_subjects_over_255_characters():
+    with pytest.raises(ValueError, match="255"):
+        build_aisc_profile_update_subject(
+            "A" * 240,
+            [ProfileUpdateReference("PU-100", date(2026, 7, 15))],
+        )

--- a/tests/test_profile_updates.py
+++ b/tests/test_profile_updates.py
@@ -178,6 +178,24 @@ def test_audit_reuses_received_case_and_reopens_only_when_closed():
     assert client.posted[0] == ("received-1", "The company moved.")
 
 
+def test_audit_recognizes_aisc_received_case():
+    received = {
+        "Id": "received-1",
+        "CaseNumber": "0042",
+        "Subject": "AISC Profile Update for Acme Steel - PU-100 26-07-15",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-15T00:00:00.000+0000",
+    }
+    client = FakeClient(audits=[audit()], cases={"account-1": [received]})
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert client.created == []
+    assert client.posted[0] == ("received-1", "The company moved.")
+
+
 def test_audit_preserves_open_received_status_and_skips_newer_other_case():
     open_received = {
         "Id": "received-open",
@@ -262,7 +280,7 @@ def test_new_submission_converts_newest_expected_case():
             "Case",
             "expected-newest",
             {
-                "Subject": "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+                "Subject": "AISC Profile Update for Acme Steel - PU-100 26-07-15",
                 "OwnerId": "queue-id",
                 "Primary_Responder__c": "responder-id",
                 "ContactId": "contact-1",
@@ -287,7 +305,7 @@ def test_new_submission_creates_received_case_with_exact_payload():
         (
             "Case",
             {
-                "Subject": "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+                "Subject": "AISC Profile Update for Acme Steel - PU-100 26-07-15",
                 "OwnerId": "queue-id",
                 "Primary_Responder__c": "responder-id",
                 "ContactId": None,
@@ -306,7 +324,7 @@ def test_new_submission_creates_received_case_with_exact_payload():
 def test_submission_reuses_received_case_and_appends_name_once():
     received = {
         "Id": "received-1",
-        "Subject": "2026-07-01: Profile Update Received for Acme Steel - PU-099",
+        "Subject": "AISC Profile Update for Acme Steel - PU-099 26-07-01",
         "Status": "Working",
         "IsClosed": False,
         "CreatedDate": "2026-07-01T00:00:00.000+0000",
@@ -323,7 +341,8 @@ def test_submission_reuses_received_case_and_appends_name_once():
             "received-1",
             {
                 "Subject": (
-                    "2026-07-01: Profile Update Received for Acme Steel - PU-099 / PU-100"
+                    "AISC Profile Update for Acme Steel - "
+                    "PU-099 26-07-01 / PU-100 26-07-15"
                 )
             },
         )
@@ -333,11 +352,67 @@ def test_submission_reuses_received_case_and_appends_name_once():
     client.updated.clear()
     client.posted.clear()
     client.feeds["received-1"] = [build_submission_summary(submission())]
-    received["Subject"] += " / PU-100"
+    received["Subject"] += " / PU-100 26-07-15"
     retry_counts = service(client).run()
     assert retry_counts.skipped == 1
     assert not client.updated
     assert not client.posted
+
+
+def test_existing_aisc_update_skips_before_reading_chatter_or_writing():
+    received = {
+        "Id": "received-1",
+        "Subject": (
+            "AISC Profile Update for Acme Steel - PU-099 26-07-01 / pu-100 26-07-15"
+        ),
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-15T15:00:00.000+0000",
+    }
+    client = FakeClient(submissions=[submission()], cases={"account-1": [received]})
+
+    counts = service(client).run()
+
+    assert counts.skipped == 1
+    assert client.updated == []
+    assert client.posted == []
+    assert client.feeds == {}
+
+
+def test_partial_profile_update_number_does_not_count_as_duplicate():
+    received = {
+        "Id": "received-1",
+        "Subject": "AISC Profile Update for Acme Steel - PU-100 26-07-01",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    client = FakeClient(
+        submissions=[submission(Name="PU-10")],
+        cases={"account-1": [received]},
+    )
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert client.updated[0][2]["Subject"].endswith(" / PU-10 26-07-15")
+
+
+def test_legacy_retry_still_posts_missing_summary_without_renaming_subject():
+    received = {
+        "Id": "received-1",
+        "Subject": "2026-07-01: Profile Update Received for Acme Steel - PU-100",
+        "Status": "Working",
+        "IsClosed": False,
+        "CreatedDate": "2026-07-01T00:00:00.000+0000",
+    }
+    client = FakeClient(submissions=[submission()], cases={"account-1": [received]})
+
+    counts = service(client).run()
+
+    assert counts.reused == 1
+    assert client.updated == []
+    assert client.posted == [("received-1", build_submission_summary(submission()))]
 
 
 def test_contact_matching_prefers_account_and_rejects_ambiguity():

--- a/tests/test_rename_profile_update_cases.py
+++ b/tests/test_rename_profile_update_cases.py
@@ -1,0 +1,161 @@
+from datetime import UTC, datetime
+
+from aisc_salesforce.rename_profile_update_cases import (
+    RenameProfileUpdateCasesService,
+    correction_window,
+)
+from aisc_salesforce.salesforce import SalesforceError
+
+NOW = datetime(2026, 7, 20, 18, 30, tzinfo=UTC)
+
+
+def legacy_case(case_id, subject):
+    return {"Id": case_id, "CaseNumber": case_id, "Subject": subject}
+
+
+class FakeClient:
+    def __init__(self, cases):
+        self.cases = cases
+        self.queries = []
+        self.updated = []
+        self.fail_ids = set()
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where, order_by))
+        return list(self.cases)
+
+    def update_record(self, object_name, record_id, payload):
+        if record_id in self.fail_ids:
+            raise SalesforceError("write failed")
+        self.updated.append((object_name, record_id, payload))
+
+
+def test_correction_window_is_seven_chicago_dates_converted_to_utc():
+    start, end = correction_window(NOW)
+
+    assert start == datetime(2026, 7, 14, 5, tzinfo=UTC)
+    assert end == datetime(2026, 7, 21, 5, tzinfo=UTC)
+
+
+def test_correction_window_uses_the_winter_chicago_utc_offset():
+    start, end = correction_window(datetime(2026, 1, 20, 18, 30, tzinfo=UTC))
+
+    assert start == datetime(2026, 1, 14, 6, tzinfo=UTC)
+    assert end == datetime(2026, 1, 21, 6, tzinfo=UTC)
+
+
+def test_preview_is_default_and_never_writes():
+    client = FakeClient(
+        [
+            legacy_case(
+                "5001",
+                "2026-07-15: Profile Update Received for Acme Steel - PU-100",
+            )
+        ]
+    )
+    output = []
+
+    counts = RenameProfileUpdateCasesService(
+        client, now=NOW, output_fn=output.append
+    ).run()
+
+    assert counts.matched == 1
+    assert counts.would_update == 1
+    assert counts.updated == 0
+    assert client.updated == []
+    assert any(
+        "2026-07-15: Profile Update Received for Acme Steel - PU-100"
+        " -> AISC Profile Update for Acme Steel - PU-100 26-07-15" in line
+        for line in output
+    )
+    where = client.queries[0][2]
+    assert "CreatedDate >= 2026-07-14T05:00:00Z" in where
+    assert "CreatedDate < 2026-07-21T05:00:00Z" in where
+
+
+def test_apply_updates_only_subject_and_multiple_names_share_embedded_date():
+    client = FakeClient(
+        [
+            legacy_case(
+                "5001",
+                "26-07-15 - Profile Update Received for Acme Steel - PU-100 / PU-101",
+            )
+        ]
+    )
+
+    counts = RenameProfileUpdateCasesService(client, now=NOW).run(apply=True)
+
+    assert counts.updated == 1
+    assert client.updated == [
+        (
+            "Case",
+            "5001",
+            {
+                "Subject": (
+                    "AISC Profile Update for Acme Steel - "
+                    "PU-100 26-07-15 / PU-101 26-07-15"
+                )
+            },
+        )
+    ]
+
+
+def test_apply_continues_after_partial_failure_and_reports_nonzero_failure_count():
+    client = FakeClient(
+        [
+            legacy_case(
+                "fails",
+                "2026-07-15 - Profile Update Received for Acme - PU-100",
+            ),
+            legacy_case(
+                "works",
+                "2026-07-16: Profile Update Received for Beta - PU-200",
+            ),
+        ]
+    )
+    client.fail_ids.add("fails")
+
+    counts = RenameProfileUpdateCasesService(client, now=NOW).run(apply=True)
+
+    assert counts.matched == 2
+    assert counts.updated == 1
+    assert counts.failed == 1
+    assert client.updated == [
+        (
+            "Case",
+            "works",
+            {"Subject": "AISC Profile Update for Beta - PU-200 26-07-16"},
+        )
+    ]
+
+
+def test_unparseable_and_overlong_subjects_are_skipped_and_reruns_are_safe():
+    client = FakeClient(
+        [
+            legacy_case(
+                "no-date",
+                "Profile Update Received for Acme Steel - PU-100",
+            ),
+            legacy_case(
+                "too-long",
+                "2026-07-15: Profile Update Received for " + "A" * 240 + " - PU-100",
+            ),
+            legacy_case(
+                "already-new",
+                "AISC Profile Update for Acme Steel - PU-100 26-07-15",
+            ),
+        ]
+    )
+    output = []
+
+    counts = RenameProfileUpdateCasesService(
+        client, now=NOW, output_fn=output.append
+    ).run(apply=True)
+
+    assert counts.matched == 1
+    assert counts.updated == 0
+    assert counts.skipped == 3
+    assert counts.failed == 0
+    assert client.updated == []
+    assert any("trustworthy embedded received date" in line for line in output)
+    assert any("255" in line for line in output)

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -577,6 +577,51 @@ def test_staging_records_case_and_key_update_metadata():
     assert "AccountId IN ('account-1')" in case_query[2]
 
 
+def test_staging_matches_aisc_pairs_without_treating_dates_as_update_names():
+    records = [
+        submission(Name="PU-099"),
+        submission(
+            Id="submission-2",
+            Name="PU-100",
+            CreatedDate="2026-07-16T14:30:00.000+0000",
+        ),
+    ]
+    aisc_case = {
+        "Id": "case-1",
+        "CaseNumber": "0001",
+        "Subject": (
+            "AISC Profile Update for Acme Steel - PU-099 26-07-01 / PU-100 26-07-15"
+        ),
+        "Status": "Pending",
+        "CreatedDate": "2026-07-16T15:00:00.000+0000",
+        "AccountId": "account-1",
+    }
+
+    result, _ = stage(records, accounts=[account()], cases=[aisc_case])
+
+    assert result.rows[0]["case_match_status"] == "matched"
+    assert result.rows[0]["case_id"] == "case-1"
+
+
+def test_staging_profile_update_matching_is_exact_not_partial():
+    aisc_case = {
+        "Id": "case-1",
+        "CaseNumber": "0001",
+        "Subject": "AISC Profile Update for Acme Steel - PU-100 26-07-15",
+        "Status": "Pending",
+        "CreatedDate": "2026-07-15T15:00:00.000+0000",
+        "AccountId": "account-1",
+    }
+
+    result, _ = stage(
+        [submission(Name="PU-10")],
+        accounts=[account()],
+        cases=[aisc_case],
+    )
+
+    assert result.rows[0]["case_match_status"] == "missing"
+
+
 def test_missing_or_ambiguous_case_match_is_a_blocking_warning():
     record = submission()
 


### PR DESCRIPTION
## Summary
- Add structured AISC Profile Update Case subjects with dated identifiers.
- Prevent duplicate submissions and preserve legacy subject compatibility.
- Add preview/apply tooling for correcting recent legacy Case subjects, plus documentation and tests.

Closes #8