### PR TITLE
Add profile update staging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,12 @@ uv run aisc_salesforce stage-profile-updates \
 ```
 
 Submissions are grouped by Account ID and the submitter email after trimming
-and case-insensitive comparison. Later nonblank values replace earlier values.
-Different emails stay separate, and every blank-email submission stays
-separate and receives a warning. Each CSV row preserves all source submission
-IDs and names as JSON arrays.
+and case-insensitive comparison. Later nonblank values replace earlier values,
+except that every nonblank Comments and Other Personnel Notes value is
+preserved in submission order and joined with a newline. Different emails stay
+separate, and every blank-email submission stays separate and receives a
+warning. Each CSV row preserves all source submission IDs and names as JSON
+arrays.
 
 The CSV has shared submission and Account columns, Key Data columns, and
 prefixed role columns for `certification_`, `principal_`, `accounting_`,
@@ -171,7 +173,18 @@ filled from that Contact where possible. Repeating the same contact information
 in several roles does not create a warning, but conflicting emails for the same
 submitted name are treated as ambiguous.
 
-Before processing a staged row, inspect both `has_warnings` and `warnings`.
+`has_key_updates` is `true` only when at least one source has the exact
+Salesforce `Type__c` value `"Key Data"`. Populated Key Data fields remain
+visible, but do not set this classification by themselves. The required
+`has_contact_derived_values` column is `true` when a nonblank role title or
+phone was copied from another submitted role or a Salesforce Contact. The
+required `has_no_update_content` column is `true` when the group has no
+submitted Key Data fields, role fields, Comments, or Other Personnel Notes.
+Submitter, Account, and Case metadata, `Type__c`, and fallback-derived values do
+not count as submitted update content.
+
+Before processing a staged row, inspect `has_contact_derived_values`,
+`has_no_update_content`, `has_warnings`, and `warnings`.
 `warnings` is newline-separated and identifies ambiguous contacts, incomplete
 Accounts, missing role lookups, partial addresses that could not be filled, and
 other cases needing human review. An unmatched submitted name uses the
@@ -206,10 +219,12 @@ uv run aisc_salesforce process-profile-updates \
 ```
 
 Before each staged CSV row, the command shows the Account, submitter, and source
-Profile Update names. At the Continue/Quit checkpoint, press Enter, type `C`,
-or type `Continue` to review that row. Type `Q` or `Quit` to stop safely.
-Only this checkpoint has a default; change decisions always require an explicit
-answer.
+Profile Update names. It also notes when contact details were supplemented or
+when the combined update has no submitted update content. At the Continue/Quit
+checkpoint, press Enter, type `C`, or type `Continue` to review that row. Type
+`Q` or `Quit` to stop safely. Only this checkpoint has a default; change
+decisions always require an explicit answer. Published CSV files must include
+both new metadata columns; older staged files fail validation.
 
 Each real field change accepts a shortcut or its complete decision phrase:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -233,8 +233,10 @@ with a blank email also stays separate and receives a warning.
 
 Within a group, submissions are ordered by `CreatedDate` and `Id`. Later
 nonblank values replace earlier values, while blank later values do not erase
-earlier information. Source submission IDs and names are retained as JSON
-arrays.
+earlier information. Comments and Other Personnel Notes are the exception:
+every nonblank value is preserved, including repeated identical text, and
+values are joined with `\n` in submission order. Source submission IDs and
+names are retained as JSON arrays.
 
 When at least one revised address component is present, the output contains all
 five components. Missing submitted components are filled from the Account
@@ -248,7 +250,7 @@ Each row contains these groups of columns:
 |---|---|
 | Source and dates | `source_submission_ids`, `source_submission_names`, `earliest_submission_date`, `latest_submission_date` |
 | Account and submitter | `account_id`, `account_name`, `certification_id`, `submitter_name`, `submitter_email`, `submitter_phone` |
-| Notes and review | `comments`, `personnel_notes`, `has_warnings`, `warnings` |
+| Notes and review | `comments`, `personnel_notes`, `has_contact_derived_values`, `has_no_update_content`, `has_warnings`, `warnings` |
 | Key Data | `effective_date`, revised company name/owner, five revised address columns, and `key_answers` |
 | Contact roles | Columns prefixed with `certification_`, `principal_`, `accounting_`, `quality_`, and `new_york_` |
 
@@ -282,13 +284,27 @@ tier are reported as ambiguous. Repeated identical contact information in
 several submitted roles counts as one candidate; the same name paired with
 conflicting emails remains ambiguous. When a Contact is resolved, missing title
 and phone values are filled from that Contact where possible. Missing title or
-phone alone does not cause a warning.
+phone alone does not cause a warning. `has_contact_derived_values` is `true`
+only when a nonblank title or phone was actually copied from another submitted
+role or a Salesforce Contact. Values submitted directly for that role do not
+set the flag.
+
+`has_no_update_content` is `true` when the grouped raw submissions contain no
+Key Data fields, role fields, Comments, or Other Personnel Notes. Account,
+Case, certification, and submitter metadata do not count. `Type__c` also does
+not count, so an exact `"Key Data"` submission with no update fields can have
+both `has_key_updates=true` and `has_no_update_content=true`. Values filled from
+an Account, another role, or a Salesforce Contact cannot turn the empty-content
+flag off.
 
 !!! warning
 
-    The interactive processor inspects `has_warnings` and `warnings` before
-    acting on a row. The `warnings` field is readable, newline-separated text;
-    role warnings are also copied into the matching prefixed `warning` column.
+    The interactive processor requires `has_contact_derived_values` and
+    `has_no_update_content` in addition to the existing CSV columns. Older
+    staged CSV files fail validation. It also inspects `has_warnings` and
+    `warnings` before acting on a row. The `warnings` field is readable,
+    newline-separated text; role warnings are also copied into the matching
+    prefixed `warning` column.
 
 Case preparation adds `case_id`, `case_number`, `case_status`, and
 `case_match_status`. A row is processable only when its match status is
@@ -299,9 +315,13 @@ for part of a Profile Update identifier.
 
 Key Update metadata is explicit:
 
-- `has_key_updates` is `true` when at least one source is marked as Key Data or
-  contains a Key Update field.
+- `has_key_updates` is `true` only when at least one source has the exact
+  Salesforce `Type__c` value `"Key Data"`. Case differences, surrounding
+  spaces, `None`, and populated Key Data fields alone do not set it.
 - `earliest_key_update_date` is the oldest such source `CreatedDate`.
+
+Populated Key Data fields remain visible in their normal CSV columns and in
+`key_answers` even when they do not set `has_key_updates`.
 
 ## Process Profile Updates command
 
@@ -340,7 +360,13 @@ proposals. Effective date and the Key Update answers remain context unless
 they map to one of those real Account fields.
 
 Before every staged CSV row, a heading shows its Account, submitter, and source
-Profile Update names. The next prompt is a checkpoint:
+Profile Update names. When the matching CSV flag is `true`, the heading also
+shows one or both of these lines:
+
+- `Note: contact details were supplemented from available contact information.`
+- `Note: this combined profile update has no submitted update content.`
+
+The next prompt is a checkpoint:
 
 | Checkpoint answer | Result |
 |---|---|

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -618,6 +618,16 @@ class InteractiveProfileUpdateProcessor:
             f"Submitter: {submitter_name} <{submitter_email}>\n"
             f"Profile Updates: {source_names or '(unnamed)'}"
         )
+        if row.get("has_contact_derived_values") == "true":
+            heading += (
+                "\nNote: contact details were supplemented from available "
+                "contact information."
+            )
+        if row.get("has_no_update_content") == "true":
+            heading += (
+                "\nNote: this combined profile update has no submitted "
+                "update content."
+            )
         self.output_fn(_section_heading(heading, ITEM_SEPARATOR))
         while True:
             answer = self.input_fn(

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -75,6 +75,14 @@ ADDRESS_FIELDS = [
     ("revised_facility_country", "Revised_Facility_Country__c", "BillingCountry"),
 ]
 
+KEY_UPDATE_FIELDS = [
+    "Effective_Date__c",
+    "Revised_Company_Name__c",
+    "Revised_Company_Owner__c",
+    *(api_name for _, api_name, _ in ADDRESS_FIELDS),
+    *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
+]
+
 
 @dataclass(frozen=True)
 class RoleDefinition:
@@ -177,6 +185,8 @@ SHARED_COLUMNS = [
     "submitter_phone",
     "comments",
     "personnel_notes",
+    "has_contact_derived_values",
+    "has_no_update_content",
     "has_warnings",
     "warnings",
 ]
@@ -385,9 +395,13 @@ class ProfileUpdateStagingService:
                 "submitter_name": _clean_text(merged.get("Name__c")),
                 "submitter_email": _clean_text(merged.get("Email__c")),
                 "submitter_phone": _clean_text(merged.get("Phone__c")),
-                "comments": _display_value(merged.get("Comments__c")),
-                "personnel_notes": _display_value(
-                    merged.get("Other_Personnel_Notes__c")
+                "comments": _collect_submitted_values(records, "Comments__c"),
+                "personnel_notes": _collect_submitted_values(
+                    records, "Other_Personnel_Notes__c"
+                ),
+                "has_contact_derived_values": "false",
+                "has_no_update_content": (
+                    "false" if _has_submitted_update_content(records) else "true"
                 ),
                 "effective_date": _display_value(merged.get("Effective_Date__c")),
                 "revised_company_name": _display_value(
@@ -421,8 +435,9 @@ class ProfileUpdateStagingService:
         self._populate_key_answers(row, merged)
 
         merged_roles = _merge_roles(records)
+        has_contact_derived_values = False
         for merged_role in merged_roles:
-            self._populate_role(
+            role_has_derived_values = self._populate_role(
                 row,
                 merged_role,
                 merged_roles,
@@ -431,7 +446,13 @@ class ProfileUpdateStagingService:
                 contacts,
                 warnings,
             )
+            has_contact_derived_values = (
+                has_contact_derived_values or role_has_derived_values
+            )
 
+        row["has_contact_derived_values"] = (
+            "true" if has_contact_derived_values else "false"
+        )
         row["has_warnings"] = "true" if warnings else "false"
         row["warnings"] = "\n".join(warnings)
         return row
@@ -518,16 +539,9 @@ class ProfileUpdateStagingService:
 
     @staticmethod
     def _populate_key_answers(row: dict[str, str], merged: dict[str, Any]) -> None:
-        key_fields = [
-            "Effective_Date__c",
-            "Revised_Company_Name__c",
-            "Revised_Company_Owner__c",
-            *(api_name for _, api_name, _ in ADDRESS_FIELDS),
-            *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
-        ]
         is_key_data = _normalized(merged.get("Type__c")) == "key data"
         if not is_key_data and not any(
-            _has_value(merged.get(api_name)) for api_name in key_fields
+            _has_value(merged.get(api_name)) for api_name in KEY_UPDATE_FIELDS
         ):
             return
         row["key_answers"] = "\n".join(
@@ -544,10 +558,10 @@ class ProfileUpdateStagingService:
         all_accounts_by_id: dict[str, dict[str, Any]],
         contacts: list[dict[str, Any]],
         warnings: list[str],
-    ) -> None:
+    ) -> bool:
         prefix = role.definition.prefix
         if not role.values:
-            return
+            return False
         for suffix, _ in role.definition.submitted_fields:
             row[f"{prefix}_{suffix}"] = role.values.get(suffix, "")
 
@@ -562,7 +576,7 @@ class ProfileUpdateStagingService:
             if suffix == "warning":
                 continue
             row[f"{prefix}_{suffix}"] = resolution.get(suffix, "")
-        _fill_missing_optional_role_fields(
+        has_derived_values = _fill_missing_optional_role_fields(
             row,
             role,
             all_roles,
@@ -572,6 +586,7 @@ class ProfileUpdateStagingService:
         row[f"{prefix}_warning"] = warning
         if warning:
             warnings.append(f"{role.definition.label} role: {warning}")
+        return has_derived_values
 
 
 def _group_submissions(
@@ -595,6 +610,36 @@ def _merge_records(records: list[dict[str, Any]]) -> dict[str, Any]:
             if _has_value(value):
                 merged[key] = value
     return merged
+
+
+def _collect_submitted_values(
+    records: list[dict[str, Any]], field_name: str
+) -> str:
+    """Join every nonblank submitted value in deterministic submission order."""
+    return "\n".join(
+        _display_value(record.get(field_name))
+        for record in records
+        if _has_value(record.get(field_name))
+    )
+
+
+def _has_submitted_update_content(records: list[dict[str, Any]]) -> bool:
+    """Return whether raw submissions contain any reviewable update content."""
+    update_fields = [
+        *KEY_UPDATE_FIELDS,
+        *(
+            api_name
+            for role in ROLE_DEFINITIONS
+            for _, api_name in role.submitted_fields
+        ),
+        "Comments__c",
+        "Other_Personnel_Notes__c",
+    ]
+    return any(
+        _has_value(record.get(field_name))
+        for record in records
+        for field_name in update_fields
+    )
 
 
 def _merge_roles(records: list[dict[str, Any]]) -> list[MergedRole]:
@@ -887,7 +932,7 @@ def _fill_missing_optional_role_fields(
     all_roles: list[MergedRole],
     contacts: list[dict[str, Any]],
     resolution: dict[str, str],
-) -> None:
+) -> bool:
     """Fill missing title and phone from the resolved contact when available."""
     fallback: dict[str, Any] | None = None
     if resolution.get("resolution_source") == "submitted_role":
@@ -914,18 +959,26 @@ def _fill_missing_optional_role_fields(
         )
 
     if fallback is None:
-        return
+        return False
     prefix = role.definition.prefix
+    copied_value = False
     if role.definition.title_field is not None and not row[f"{prefix}_title"]:
-        row[f"{prefix}_title"] = _first_nonblank(
+        fallback_title = _first_nonblank(
             fallback.get("title"),
             fallback.get("Title"),
         )
+        if fallback_title:
+            row[f"{prefix}_title"] = fallback_title
+            copied_value = True
     if not row[f"{prefix}_phone"]:
-        row[f"{prefix}_phone"] = _first_nonblank(
+        fallback_phone = _first_nonblank(
             fallback.get("phone"),
             fallback.get("Phone"),
         )
+        if fallback_phone:
+            row[f"{prefix}_phone"] = fallback_phone
+            copied_value = True
+    return copied_value
 
 
 def write_staged_profile_updates(
@@ -977,16 +1030,7 @@ def _submission_sort_key(record: dict[str, Any]) -> tuple[str, str]:
 
 
 def _is_key_update(record: dict[str, Any]) -> bool:
-    key_fields = [
-        "Effective_Date__c",
-        "Revised_Company_Name__c",
-        "Revised_Company_Owner__c",
-        *(api_name for _, api_name, _ in ADDRESS_FIELDS),
-        *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
-    ]
-    return _normalized(record.get("Type__c")) == "key data" or any(
-        _has_value(record.get(api_name)) for api_name in key_fields
-    )
+    return record.get("Type__c") == "Key Data"
 
 
 def _where_in(field_name: str, values: list[str]) -> str:

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -15,6 +15,7 @@ from aisc_salesforce.process_profile_updates import (
     ReviewDecision,
     build_case_batches,
     format_response_emails,
+    read_staged_profile_updates,
 )
 from aisc_salesforce.profile_updates import AutomationCounts
 from aisc_salesforce.salesforce import SalesforceError
@@ -251,6 +252,23 @@ def test_workflow_creates_cases_then_stages_and_reads_the_published_csv(tmp_path
     assert positions == sorted(positions)
 
 
+@pytest.mark.parametrize(
+    "missing_column",
+    ["has_contact_derived_values", "has_no_update_content"],
+)
+def test_published_csv_requires_new_staging_metadata_columns(
+    tmp_path, missing_column
+):
+    columns = [column for column in CSV_COLUMNS if column != missing_column]
+    csv_path = tmp_path / "profile_updates.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as output:
+        writer = csv.DictWriter(output, fieldnames=columns)
+        writer.writeheader()
+
+    with pytest.raises(ProcessingError, match=missing_column):
+        read_staged_profile_updates(csv_path)
+
+
 @pytest.mark.parametrize("failure", ["cases", "stage", "write"])
 def test_workflow_aborts_before_review_when_required_setup_fails(tmp_path, failure):
     events = []
@@ -357,6 +375,62 @@ def test_each_staged_row_has_a_continue_checkpoint_and_heading(tmp_path, answer)
     assert "Profile Updates: PU-100" in displayed
     assert "Profile Updates: PU-101" in displayed
     assert result.stopped_early is False
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected_notes"),
+    [
+        (
+            {"has_contact_derived_values": "true"},
+            [
+                (
+                    "Note: contact details were supplemented from available "
+                    "contact information."
+                )
+            ],
+        ),
+        (
+            {"has_no_update_content": "true"},
+            ["Note: this combined profile update has no submitted update content."],
+        ),
+        (
+            {
+                "has_contact_derived_values": "true",
+                "has_no_update_content": "true",
+            },
+            [
+                (
+                    "Note: contact details were supplemented from available "
+                    "contact information."
+                ),
+                (
+                    "Note: this combined profile update has no submitted "
+                    "update content."
+                ),
+            ],
+        ),
+        ({}, []),
+    ],
+)
+def test_staged_row_heading_shows_metadata_notes(tmp_path, flags, expected_notes):
+    client = FakeClient()
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder([]),
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    processor.review([staged_row(**flags)], tmp_path)
+
+    displayed = "\n".join(output)
+    known_notes = [
+        "Note: contact details were supplemented from available contact information.",
+        "Note: this combined profile update has no submitted update content.",
+    ]
+    for note in known_notes:
+        assert (note in displayed) is (note in expected_notes)
 
 
 @pytest.mark.parametrize("answer", ["q", "Quit"])

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -144,6 +144,62 @@ def test_merges_same_account_and_email_with_later_nonblank_values():
     assert contact_query[1] == CONTACT_FIELDS
 
 
+def test_merges_all_nonblank_notes_in_submission_order():
+    records = [
+        submission(
+            Id="submission-3",
+            CreatedDate="2026-07-17T14:30:00.000+0000",
+            Comments__c="Repeated comment",
+            Other_Personnel_Notes__c="Third note",
+        ),
+        submission(
+            Id="submission-1",
+            Comments__c="Repeated comment",
+            Other_Personnel_Notes__c="First note",
+        ),
+        submission(
+            Id="submission-2",
+            CreatedDate="2026-07-16T14:30:00.000+0000",
+            Comments__c="   ",
+            Other_Personnel_Notes__c=None,
+        ),
+    ]
+
+    result, _ = stage(records, accounts=[account()])
+
+    row = result.rows[0]
+    assert row["comments"] == "Repeated comment\nRepeated comment"
+    assert row["personnel_notes"] == "First note\nThird note"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        submission(Type__c=None),
+        submission(Type__c="key data"),
+        submission(Type__c=" Key Data "),
+        submission(Revised_Company_Name__c="Acme Steel LLC"),
+    ],
+)
+def test_key_update_metadata_requires_exact_key_data_type(record):
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["has_key_updates"] == "false"
+    assert row["earliest_key_update_date"] == ""
+
+
+def test_key_update_metadata_accepts_exact_key_data_type_without_content():
+    result, _ = stage(
+        [submission(Type__c="Key Data")],
+        accounts=[account()],
+    )
+
+    row = result.rows[0]
+    assert row["has_key_updates"] == "true"
+    assert row["has_no_update_content"] == "true"
+
+
 def test_keeps_different_emails_separate_and_blank_emails_independent():
     records = [
         submission(Id="one", Email__c="first@example.com"),
@@ -384,8 +440,60 @@ def test_existing_contact_fills_optional_title_and_phone_without_warning():
     assert row["certification_salesforce_contact_id"] == "existing-contact"
     assert row["certification_title"] == "Certification Manager"
     assert row["certification_phone"] == "312-555-0105"
+    assert row["has_contact_derived_values"] == "true"
     assert row["certification_warning"] == ""
     assert row["has_warnings"] == "false"
+
+
+def test_another_submitted_role_filling_optional_contact_details_is_reported():
+    record = submission(
+        Cert_First_Name__c="Jordan",
+        Cert_Last_Name__c="Lee",
+        Principal_First_Name__c="Jordan",
+        Principal_Last_Name__c="Lee",
+        Principal_Title__c="President",
+        Principal_Phone__c="312-555-0142",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["certification_title"] == "President"
+    assert row["certification_phone"] == "312-555-0142"
+    assert row["has_contact_derived_values"] == "true"
+
+
+def test_directly_submitted_optional_contact_details_are_not_reported_as_derived():
+    record = submission(
+        Cert_First_Name__c="Jordan",
+        Cert_Last_Name__c="Lee",
+        Cert_Title__c="President",
+        Cert_Phone__c="312-555-0142",
+    )
+
+    result, _ = stage([record], accounts=[account()])
+
+    assert result.rows[0]["has_contact_derived_values"] == "false"
+
+
+def test_blank_fallback_contact_details_are_not_reported_as_derived():
+    matching = {
+        "Id": "existing-contact",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "",
+        "Email": "alex@example.com",
+        "Phone": None,
+    }
+    record = submission(
+        Cert_First_Name__c="Alex",
+        Cert_Last_Name__c="Smith",
+    )
+
+    result, _ = stage([record], accounts=[account()], contacts=[matching])
+
+    assert result.rows[0]["has_contact_derived_values"] == "false"
 
 
 def test_email_only_can_match_another_submitted_role():
@@ -452,7 +560,44 @@ def test_role_lookup_contact_fills_missing_optional_details():
     row = result.rows[0]
     assert row["quality_title"] == "Quality Director"
     assert row["quality_phone"] == "312-555-0199"
+    assert row["has_contact_derived_values"] == "true"
     assert row["quality_warning"] == ""
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        {"Revised_Company_Name__c": "Acme Steel LLC"},
+        {"Will_software_change__c": "No"},
+        {"Cert_Email__c": "cert@example.com"},
+        {"Comments__c": "Please review"},
+        {"Other_Personnel_Notes__c": "Personnel note"},
+    ],
+)
+def test_submitted_update_content_is_not_marked_empty(content):
+    result, _ = stage([submission(**content)], accounts=[account()])
+
+    assert result.rows[0]["has_no_update_content"] == "false"
+
+
+def test_account_submitter_and_fallback_metadata_do_not_count_as_update_content():
+    result, _ = stage([submission()], accounts=[account()])
+
+    row = result.rows[0]
+    assert row["account_name"] == "Acme Steel"
+    assert row["submitter_email"] == "submitter@example.com"
+    assert row["has_no_update_content"] == "true"
+
+
+def test_address_fallback_does_not_hide_that_submitted_content_exists():
+    result, _ = stage(
+        [submission(Revised_Facility_Street__c="99 New Ave")],
+        accounts=[account()],
+    )
+
+    row = result.rows[0]
+    assert row["revised_facility_city"] == "Chicago"
+    assert row["has_no_update_content"] == "false"
 
 
 def test_unmatched_named_contact_records_create_intent_and_warning():
@@ -542,6 +687,8 @@ def test_writer_publishes_csv_atomically_and_repeated_runs_are_independent(tmp_p
     with (first / "profile_updates.csv").open(newline="", encoding="utf-8") as source:
         reader = csv.DictReader(source)
         assert reader.fieldnames == CSV_COLUMNS
+        assert "has_contact_derived_values" in reader.fieldnames
+        assert "has_no_update_content" in reader.fieldnames
         assert list(reader) == rows
 
 


### PR DESCRIPTION
## Summary
- preserve all submitted Comments and Other Personnel Notes values
- add contact-derived and no-update-content staging metadata
- require and display the new metadata during processing
- document the updated staging behavior

Closes #10