### PR TITLE
Add iMIS contact consolidation workflow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+# Allow Codex to modify files and automatically run git commands
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"  # Prompts you before risky tasks

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,11 @@ htmlcov/
 .coverage
 .env
 .env.test
+data/
+
+# iMIS CSContactBasic exports and derived files contain personal data.
+imis_contactbasic/
+**/Full_CSContactBasic_*.csv
+**/Combined_CSContactBasic_*.csv
+**/Changed_CSContactBasic_*.csv
+**/New_CSContactBasic_*.csv

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Preview the one-time correction of recent legacy Case subjects:
 uv run aisc_salesforce rename-profile-update-cases
 ```
 
+Consolidate the newest dated iMIS contact export:
+
+```bash
+uv run aisc_salesforce consolidate-imis-contacts \
+  --directory imis_contactbasic
+```
+
 All commands are also available as a Python module:
 
 ```bash
@@ -78,6 +85,43 @@ uv run python -m aisc_salesforce profile-updates
 `profile-updates` prints `created`, `reused`, `skipped`, and `failed` counts. A
 successful run returns exit code `0`; missing configuration or a Salesforce
 failure returns `1`.
+
+### iMIS contact consolidation
+
+Place downloaded exports in `imis_contactbasic/` by default, or select another
+folder with `--directory`. The command discovers dates from filenames rather
+than file modification times:
+
+- Fresh exports use `Full_CSContactBasic_YYMMDD.csv`; `YY` means `20YY`.
+- Combined tables use `Combined_CSContactBasic_YYYYMMDD.csv`.
+
+On the first run, the newest full export creates only a dated combined table.
+On later runs, the newest full export must be newer than the newest combined
+table. The command then publishes a new combined table plus
+`Changed_CSContactBasic_YYYYMMDD.csv` and
+`New_CSContactBasic_YYYYMMDD.csv`. Empty reports still contain the standard
+headers.
+
+Rows match by exact `iMIS Id`. Existing rows keep their position, newer
+matching rows replace them, older-only contacts remain, and new contacts are
+appended in fresh-export order. All 21 fields are compared as exact text, so
+case, whitespace, and blank-value differences count. Identifiers such as
+`iMIS Id`, `Company ID`, and `Major Key` remain strings, preserving leading
+zeroes.
+
+Files may arrange the 21 required headers in any order, but missing or extra
+headers stop the run before output is published. Blank IDs are skipped with
+their CSV row numbers. If one selected file repeats a nonblank ID, every row
+with that ID is omitted from that file and a warning identifies the filename
+and ID. A duplicated ID in the fresh export therefore cannot replace a valid
+older row. Existing outputs are never overwritten, and failed writes clean up
+temporary and partially published files.
+
+> [!WARNING]
+> iMIS contact exports and all three output types contain personal data. Their
+> standard filename patterns are ignored by Git even in a custom directory.
+> Keep them uncommitted, access-controlled, and shared only through approved
+> secure channels.
 
 ### Profile Update Case subjects
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,22 @@
 # API Reference
 
+## iMIS contact consolidation
+
+::: aisc_salesforce.imis_contacts
+    options:
+      show_root_heading: true
+      members:
+        - CONTACT_BASIC_COLUMNS
+        - ConsolidationResult
+        - ContactConsolidationError
+        - consolidate_contactbasic
+
+`consolidate_contactbasic()` accepts a directory and optional output function.
+It returns the selected input paths, published output paths, and row counts in
+a frozen `ConsolidationResult`. Discovery and validation failures use the
+workflow-specific `ContactConsolidationError`, which the CLI turns into exit
+code `1` with a readable message.
+
 ## Profile Update service
 
 ::: aisc_salesforce.profile_updates

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,69 @@ failed: 0
 Exit code `0` means the run completed without failures. Exit code `1` means
 configuration, Salesforce communication, or one or more records failed.
 
+## Consolidate iMIS contacts command
+
+Put the downloaded CSV files in `imis_contactbasic/` and run:
+
+```bash
+uv run aisc_salesforce consolidate-imis-contacts \
+  --directory imis_contactbasic
+```
+
+`--directory` defaults to `imis_contactbasic`, so it may be omitted. A custom
+secure directory is also supported.
+
+### Dated files and outputs
+
+Dates come from filenames, not modification times. Fresh exports must be named
+`Full_CSContactBasic_YYMMDD.csv`, where `YY` means `20YY`. Previous combined
+tables must be named `Combined_CSContactBasic_YYYYMMDD.csv`.
+
+An initial run writes only the combined table. Once a combined table exists,
+the fresh export date must be later, and the command writes all three files:
+
+```text
+Combined_CSContactBasic_YYYYMMDD.csv
+Changed_CSContactBasic_YYYYMMDD.csv
+New_CSContactBasic_YYYYMMDD.csv
+```
+
+The changed and new files always receive headers, even when they contain no
+rows. An existing target stops the run instead of being overwritten. A failed
+write removes temporary files and any output started by that run.
+
+### CSV and merge rules
+
+Every selected input must contain exactly these columns, in any order:
+
+```text
+City, Company, Full Name, iMIS Id, Member Type, State Province,
+Company ID, Company Member Type, Date Added, Email, Is Company, Is Member,
+Join Date, Major Key, Member Status, Status, Category, Last Updated,
+Full Address, Country, Website
+```
+
+CSV values are kept as text. Leading zeroes in `iMIS Id`, `Company ID`, and
+`Major Key` are not removed. IDs and other fields use exact comparison;
+capitalization, spaces, and blank values are meaningful differences.
+
+The combined file keeps the previous row order. A matching fresh row replaces
+the previous row in place, contacts found only in the previous table remain,
+and new contacts are appended in fresh-export order. Changed and new reports
+also follow fresh-export order and contain complete fresh rows.
+
+Blank or whitespace-only IDs are skipped, and the warning shows the filename
+and CSV row number. When a selected input repeats a nonblank ID, every row with
+that ID is omitted from that input. A duplicated fresh ID leaves a valid row
+from the previous combined table unchanged.
+
+!!! warning
+
+    iMIS input and output files contain personal data. The usual directory and
+    filename patterns are ignored by Git, including in custom directories.
+    Keep these files uncommitted and in an access-controlled location, and
+    share them only through approved secure channels.
+
 ### Case subject grammar and duplicate handling
 
 New received Cases and Expected Cases converted after a submission use:

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from .dictionary import DictionaryError, load_export_plan
+from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
 from .process_profile_updates import (
     InteractiveProfileUpdateProcessor,
     ProcessingError,
@@ -83,6 +84,16 @@ def main(
         action="store_true",
         help="Apply the previewed Subject-only Case updates.",
     )
+    contacts_parser = subparsers.add_parser(
+        "consolidate-imis-contacts",
+        help="Merge the newest dated iMIS CSContactBasic export.",
+    )
+    contacts_parser.add_argument(
+        "--directory",
+        type=Path,
+        default=Path("imis_contactbasic"),
+        help="Directory containing dated CSContactBasic CSV files.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -120,6 +131,15 @@ def main(
             )
         except (SalesforceError, OSError) as error:
             print(f"Rename profile update Cases failed: {error}", file=sys.stderr)
+            return 1
+    if args.command == "consolidate-imis-contacts":
+        try:
+            return _run_consolidate_imis_contacts(
+                args.directory,
+                output_fn=output_fn,
+            )
+        except ContactConsolidationError as error:
+            print(f"iMIS contact consolidation failed: {error}", file=sys.stderr)
             return 1
     return 1
 
@@ -237,6 +257,28 @@ def _run_rename_profile_update_cases(
     output_fn(f"skipped: {counts.skipped}")
     output_fn(f"failed: {counts.failed}")
     return 1 if counts.failed else 0
+
+
+def _run_consolidate_imis_contacts(
+    directory: Path,
+    *,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Consolidate local iMIS contact exports and print a short summary."""
+    result = consolidate_contactbasic(directory, output_fn=output_fn)
+    output_fn(f"Selected fresh export: {result.fresh_export}")
+    if result.prior_combined is None:
+        output_fn("Selected prior combined table: none (initial run)")
+    else:
+        output_fn(f"Selected prior combined table: {result.prior_combined}")
+    output_fn(f"Published combined file: {result.combined_path}")
+    if result.changed_path is not None and result.new_path is not None:
+        output_fn(f"Published changed file: {result.changed_path}")
+        output_fn(f"Published new file: {result.new_path}")
+    output_fn(f"Combined contacts: {result.combined_count}")
+    output_fn(f"Changed contacts: {result.changed_count}")
+    output_fn(f"New contacts: {result.new_count}")
+    return 0
 
 
 def get_profile_update_configuration(

--- a/src/aisc_salesforce/imis_contacts.py
+++ b/src/aisc_salesforce/imis_contacts.py
@@ -1,0 +1,319 @@
+"""Safely consolidate dated iMIS ``CSContactBasic`` CSV exports."""
+
+from __future__ import annotations
+
+import csv
+import os
+import re
+import tempfile
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+CONTACT_BASIC_COLUMNS = (
+    "City",
+    "Company",
+    "Full Name",
+    "iMIS Id",
+    "Member Type",
+    "State Province",
+    "Company ID",
+    "Company Member Type",
+    "Date Added",
+    "Email",
+    "Is Company",
+    "Is Member",
+    "Join Date",
+    "Major Key",
+    "Member Status",
+    "Status",
+    "Category",
+    "Last Updated",
+    "Full Address",
+    "Country",
+    "Website",
+)
+
+_FULL_PREFIX = "Full_CSContactBasic_"
+_COMBINED_PREFIX = "Combined_CSContactBasic_"
+_FULL_PATTERN = re.compile(r"Full_CSContactBasic_(\d{6})\.csv\Z")
+_COMBINED_PATTERN = re.compile(r"Combined_CSContactBasic_(\d{8})\.csv\Z")
+
+
+class ContactConsolidationError(Exception):
+    """Explain why iMIS contact consolidation could not safely finish."""
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    """Files selected and row counts produced by one consolidation run."""
+
+    fresh_export: Path
+    prior_combined: Path | None
+    combined_path: Path
+    changed_path: Path | None
+    new_path: Path | None
+    combined_count: int
+    changed_count: int
+    new_count: int
+
+
+@dataclass(frozen=True)
+class _DatedFile:
+    path: Path
+    export_date: date
+
+
+def consolidate_contactbasic(
+    directory: Path | str = Path("imis_contactbasic"),
+    output_fn: Callable[[str], None] = print,
+) -> ConsolidationResult:
+    """Merge the newest dated contact export with the newest combined table.
+
+    CSV values remain strings throughout the workflow. Duplicate and blank IDs
+    are skipped with warnings sent to ``output_fn``.
+
+    Args:
+        directory: Folder containing the iMIS input and output CSV files.
+        output_fn: Function that receives readable warning messages.
+
+    Returns:
+        Paths and row counts for the completed consolidation.
+
+    Raises:
+        ContactConsolidationError: If discovery, validation, or publication fails.
+    """
+    directory = Path(directory)
+    fresh, prior = _discover_inputs(directory)
+    if prior is not None and fresh.export_date <= prior.export_date:
+        raise ContactConsolidationError(
+            f"Fresh export {fresh.path.name} must be newer than "
+            f"combined table {prior.path.name}."
+        )
+
+    date_text = fresh.export_date.strftime("%Y%m%d")
+    combined_path = directory / f"Combined_CSContactBasic_{date_text}.csv"
+    changed_path = (
+        directory / f"Changed_CSContactBasic_{date_text}.csv" if prior else None
+    )
+    new_path = directory / f"New_CSContactBasic_{date_text}.csv" if prior else None
+    targets = [path for path in (combined_path, changed_path, new_path) if path]
+    collisions = [path.name for path in targets if path.exists()]
+    if collisions:
+        raise ContactConsolidationError(
+            "Refusing to overwrite output that already exists: " + ", ".join(collisions)
+        )
+
+    prior_rows = _read_contact_rows(prior.path, output_fn) if prior else []
+    fresh_rows = _read_contact_rows(fresh.path, output_fn)
+    combined_rows, changed_rows, new_rows = _merge_rows(prior_rows, fresh_rows)
+
+    output_rows: list[tuple[Path, list[dict[str, str]]]] = [
+        (combined_path, combined_rows)
+    ]
+    if changed_path is not None and new_path is not None:
+        output_rows.extend(((changed_path, changed_rows), (new_path, new_rows)))
+    _publish_csv_files(output_rows)
+
+    return ConsolidationResult(
+        fresh_export=fresh.path,
+        prior_combined=prior.path if prior else None,
+        combined_path=combined_path,
+        changed_path=changed_path,
+        new_path=new_path,
+        combined_count=len(combined_rows),
+        changed_count=len(changed_rows),
+        new_count=len(new_rows),
+    )
+
+
+def _discover_inputs(directory: Path) -> tuple[_DatedFile, _DatedFile | None]:
+    if not directory.exists():
+        raise ContactConsolidationError(f"The directory does not exist: {directory}")
+    if not directory.is_dir():
+        raise ContactConsolidationError(f"The path is not a directory: {directory}")
+
+    fresh_files: list[_DatedFile] = []
+    combined_files: list[_DatedFile] = []
+    try:
+        paths = sorted(directory.iterdir(), key=lambda path: path.name)
+    except OSError as error:
+        raise ContactConsolidationError(
+            f"Could not read directory {directory}: {error}"
+        ) from error
+
+    for path in paths:
+        if path.name.startswith(_FULL_PREFIX):
+            fresh_files.append(_parse_dated_file(path, _FULL_PATTERN, "%y%m%d"))
+        elif path.name.startswith(_COMBINED_PREFIX):
+            combined_files.append(_parse_dated_file(path, _COMBINED_PATTERN, "%Y%m%d"))
+
+    if not fresh_files:
+        raise ContactConsolidationError(
+            f"No Full_CSContactBasic_YYMMDD.csv export was found in {directory}."
+        )
+    fresh = max(fresh_files, key=lambda item: item.export_date)
+    prior = max(combined_files, key=lambda item: item.export_date, default=None)
+    return fresh, prior
+
+
+def _parse_dated_file(
+    path: Path, pattern: re.Pattern[str], format_text: str
+) -> _DatedFile:
+    match = pattern.fullmatch(path.name)
+    if match is None:
+        raise ContactConsolidationError(
+            f"Found malformed CSContactBasic filename: {path.name}"
+        )
+    try:
+        export_date = datetime.strptime(match.group(1), format_text).date()
+    except ValueError as error:
+        raise ContactConsolidationError(
+            f"Filename {path.name} contains an invalid date."
+        ) from error
+    if format_text == "%y%m%d":
+        export_date = export_date.replace(year=2000 + int(match.group(1)[:2]))
+    if not path.is_file():
+        raise ContactConsolidationError(f"Expected a CSV file: {path}")
+    return _DatedFile(path, export_date)
+
+
+def _read_contact_rows(
+    path: Path,
+    output_fn: Callable[[str], None],
+) -> list[dict[str, str]]:
+    numbered_rows: list[tuple[int, dict[str, str]]] = []
+    blank_row_numbers: list[int] = []
+    try:
+        with path.open(encoding="utf-8-sig", newline="") as csv_file:
+            reader = csv.DictReader(csv_file, strict=True)
+            _validate_headers(path, reader.fieldnames)
+            for row_number, row in enumerate(reader, start=2):
+                if None in row or any(value is None for value in row.values()):
+                    raise ContactConsolidationError(
+                        f"{path.name} has a malformed CSV record at row {row_number}."
+                    )
+                canonical_row = {
+                    column: row[column] for column in CONTACT_BASIC_COLUMNS
+                }
+                if not canonical_row["iMIS Id"].strip():
+                    blank_row_numbers.append(row_number)
+                else:
+                    numbered_rows.append((row_number, canonical_row))
+    except ContactConsolidationError:
+        raise
+    except (OSError, UnicodeError, csv.Error) as error:
+        raise ContactConsolidationError(
+            f"Could not read {path.name}: {error}"
+        ) from error
+
+    if blank_row_numbers:
+        row_text = ", ".join(str(number) for number in blank_row_numbers)
+        output_fn(
+            f"Warning: {path.name} skipped blank or whitespace-only iMIS Id "
+            f"at CSV row(s): {row_text}."
+        )
+
+    id_counts = Counter(row["iMIS Id"] for _, row in numbered_rows)
+    duplicate_ids = [imis_id for imis_id, count in id_counts.items() if count > 1]
+    if duplicate_ids:
+        output_fn(
+            f"Warning: {path.name} omitted every row for duplicate iMIS Id "
+            f"value(s): {', '.join(duplicate_ids)}."
+        )
+    duplicate_set = set(duplicate_ids)
+    return [row for _, row in numbered_rows if row["iMIS Id"] not in duplicate_set]
+
+
+def _validate_headers(path: Path, fieldnames: list[str] | None) -> None:
+    headers = fieldnames or []
+    expected = set(CONTACT_BASIC_COLUMNS)
+    missing = [column for column in CONTACT_BASIC_COLUMNS if column not in headers]
+    unexpected = [column for column in headers if column not in expected]
+    duplicates = [column for column, count in Counter(headers).items() if count > 1]
+    problems = []
+    if missing:
+        problems.append("missing headers: " + ", ".join(missing))
+    if unexpected:
+        problems.append("unexpected headers: " + ", ".join(unexpected))
+    if duplicates:
+        problems.append("duplicate headers: " + ", ".join(duplicates))
+    if problems:
+        raise ContactConsolidationError(
+            f"{path.name} has invalid CSV headers ({'; '.join(problems)})."
+        )
+
+
+def _merge_rows(
+    prior_rows: Sequence[dict[str, str]],
+    fresh_rows: Sequence[dict[str, str]],
+) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
+    combined = [row.copy() for row in prior_rows]
+    indexes = {row["iMIS Id"]: index for index, row in enumerate(combined)}
+    changed: list[dict[str, str]] = []
+    new: list[dict[str, str]] = []
+    comparison_columns = [
+        column for column in CONTACT_BASIC_COLUMNS if column != "iMIS Id"
+    ]
+
+    for fresh_row in fresh_rows:
+        imis_id = fresh_row["iMIS Id"]
+        index = indexes.get(imis_id)
+        if index is None:
+            indexes[imis_id] = len(combined)
+            combined.append(fresh_row.copy())
+            new.append(fresh_row.copy())
+            continue
+        old_row = combined[index]
+        if any(old_row[column] != fresh_row[column] for column in comparison_columns):
+            changed.append(fresh_row.copy())
+        combined[index] = fresh_row.copy()
+    return combined, changed, new
+
+
+def _publish_csv_files(
+    output_rows: Sequence[tuple[Path, list[dict[str, str]]]],
+) -> None:
+    temporary_paths: list[Path] = []
+    published_paths: list[Path] = []
+    try:
+        for target, rows in output_rows:
+            descriptor, temporary_name = tempfile.mkstemp(
+                dir=target.parent,
+                prefix=f".{target.name}.tmp-",
+            )
+            temporary_path = Path(temporary_name)
+            temporary_paths.append(temporary_path)
+            os.close(descriptor)
+            _write_csv_file(temporary_path, rows)
+
+        for (target, _), temporary_path in zip(
+            output_rows, temporary_paths, strict=True
+        ):
+            os.link(temporary_path, target)
+            published_paths.append(target)
+            temporary_path.unlink()
+    except (OSError, csv.Error) as error:
+        for path in published_paths:
+            _unlink_if_present(path)
+        for path in temporary_paths:
+            _unlink_if_present(path)
+        raise ContactConsolidationError(
+            f"Could not publish iMIS contact CSV files: {error}"
+        ) from error
+
+
+def _write_csv_file(path: Path, rows: Sequence[Mapping[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=CONTACT_BASIC_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _unlink_if_present(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from aisc_salesforce import app
 from aisc_salesforce.dictionary import ExportField
+from aisc_salesforce.imis_contacts import ContactConsolidationError
 from aisc_salesforce.profile_updates import AutomationCounts
 from aisc_salesforce.rename_profile_update_cases import RenameCounts
 
@@ -45,6 +46,71 @@ def test_cli_configuration_failure_is_nonzero(monkeypatch, capsys):
     )
     assert app.main(["snapshot"]) == 1
     assert "SF_CLIENT_SECRET" in capsys.readouterr().err
+
+
+def test_consolidate_contacts_cli_uses_default_directory_and_prints_summary(
+    monkeypatch,
+):
+    output = []
+    expected = SimpleNamespace(
+        fresh_export=app.Path("imis_contactbasic/Full_CSContactBasic_260719.csv"),
+        prior_combined=None,
+        combined_path=app.Path(
+            "imis_contactbasic/Combined_CSContactBasic_20260719.csv"
+        ),
+        changed_path=None,
+        new_path=None,
+        combined_count=4,
+        changed_count=0,
+        new_count=0,
+    )
+
+    def consolidate(directory, *, output_fn):
+        assert directory == app.Path("imis_contactbasic")
+        output_fn("example warning")
+        return expected
+
+    monkeypatch.setattr(app, "consolidate_contactbasic", consolidate)
+
+    assert app.main(["consolidate-imis-contacts"], output_fn=output.append) == 0
+    assert "example warning" in output
+    assert any("Selected fresh export:" in line for line in output)
+    assert any("Combined contacts: 4" in line for line in output)
+
+
+def test_consolidate_contacts_cli_uses_custom_directory(monkeypatch, tmp_path):
+    calls = []
+
+    def run(directory, *, output_fn):
+        calls.append((directory, output_fn))
+        return 0
+
+    monkeypatch.setattr(app, "_run_consolidate_imis_contacts", run)
+
+    assert (
+        app.main(
+            ["consolidate-imis-contacts", "--directory", str(tmp_path)],
+            output_fn=lambda message: None,
+        )
+        == 0
+    )
+    assert calls[0][0] == tmp_path
+
+
+def test_consolidate_contacts_cli_reports_validation_error(monkeypatch, capsys):
+    monkeypatch.setattr(
+        app,
+        "_run_consolidate_imis_contacts",
+        lambda directory, **kwargs: (_ for _ in ()).throw(
+            ContactConsolidationError("No Full_CSContactBasic export was found")
+        ),
+    )
+
+    assert app.main(["consolidate-imis-contacts"]) == 1
+    assert (
+        "iMIS contact consolidation failed: No Full_CSContactBasic export was found"
+        in capsys.readouterr().err
+    )
 
 
 def test_dotenv_removes_inline_comments_but_preserves_hashes(monkeypatch, tmp_path):

--- a/tests/test_imis_contacts.py
+++ b/tests/test_imis_contacts.py
@@ -1,0 +1,309 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from aisc_salesforce import imis_contacts
+from aisc_salesforce.imis_contacts import (
+    CONTACT_BASIC_COLUMNS,
+    ContactConsolidationError,
+    consolidate_contactbasic,
+)
+
+
+def make_row(imis_id: str, **changes: str) -> dict[str, str]:
+    row = {column: "" for column in CONTACT_BASIC_COLUMNS}
+    row.update(
+        {
+            "iMIS Id": imis_id,
+            "Full Name": f"Contact {imis_id}",
+            "Company ID": f"00{imis_id}",
+            "Major Key": f"000{imis_id}",
+        }
+    )
+    row.update(changes)
+    return row
+
+
+def write_csv(
+    path: Path,
+    rows: list[dict[str, str]],
+    *,
+    fieldnames: list[str] | tuple[str, ...] = CONTACT_BASIC_COLUMNS,
+    encoding: str = "utf-8",
+) -> None:
+    with path.open("w", encoding=encoding, newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def read_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    with path.open(encoding="utf-8", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def test_initial_export_creates_only_canonical_combined_file(tmp_path):
+    reversed_columns = list(reversed(CONTACT_BASIC_COLUMNS))
+    write_csv(
+        tmp_path / "Full_CSContactBasic_260719.csv",
+        [make_row("0007")],
+        fieldnames=reversed_columns,
+    )
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    expected = tmp_path / "Combined_CSContactBasic_20260719.csv"
+    assert result.fresh_export.name == "Full_CSContactBasic_260719.csv"
+    assert result.prior_combined is None
+    assert result.combined_path == expected
+    assert result.changed_path is None
+    assert result.new_path is None
+    assert result.combined_count == 1
+    headers, rows = read_csv(expected)
+    assert headers == list(CONTACT_BASIC_COLUMNS)
+    assert rows == [make_row("0007")]
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "Combined_CSContactBasic_20260719.csv",
+        "Full_CSContactBasic_260719.csv",
+    ]
+
+
+def test_discovery_uses_dates_in_names_instead_of_modification_times(tmp_path):
+    older = tmp_path / "Full_CSContactBasic_260701.csv"
+    newer = tmp_path / "Full_CSContactBasic_260719.csv"
+    write_csv(older, [make_row("old")])
+    write_csv(newer, [make_row("new")])
+    older.touch()
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    assert result.fresh_export == newer
+    assert read_csv(result.combined_path)[1] == [make_row("new")]
+
+
+def test_later_export_merges_in_stable_order_and_writes_reports(tmp_path):
+    write_csv(
+        tmp_path / "Combined_CSContactBasic_20260718.csv",
+        [
+            make_row("1", Company="Old company"),
+            make_row("2", City="Retained"),
+            make_row("3", **{"State Province": "unchanged"}),
+        ],
+    )
+    write_csv(
+        tmp_path / "Full_CSContactBasic_260719.csv",
+        [
+            make_row("3", **{"State Province": "unchanged"}),
+            make_row("1", Company="New company"),
+            make_row("4", City="Appended first"),
+            make_row("5", City="Appended second"),
+        ],
+    )
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    assert [row["iMIS Id"] for row in read_csv(result.combined_path)[1]] == [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+    ]
+    combined = read_csv(result.combined_path)[1]
+    assert combined[0]["Company"] == "New company"
+    assert combined[1]["City"] == "Retained"
+    assert read_csv(result.changed_path)[1] == [make_row("1", Company="New company")]
+    assert read_csv(result.new_path)[1] == [
+        make_row("4", City="Appended first"),
+        make_row("5", City="Appended second"),
+    ]
+    assert (result.combined_count, result.changed_count, result.new_count) == (5, 1, 2)
+
+
+def test_later_export_writes_header_only_empty_reports(tmp_path):
+    row = make_row("1")
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [row])
+    write_csv(tmp_path / "Full_CSContactBasic_260719.csv", [row])
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    assert read_csv(result.changed_path) == (list(CONTACT_BASIC_COLUMNS), [])
+    assert read_csv(result.new_path) == (list(CONTACT_BASIC_COLUMNS), [])
+
+
+def test_comparison_is_exact_and_identifiers_keep_leading_zeroes(tmp_path):
+    prior = make_row("0001", Company="Acme", Email="person@example.com")
+    fresh = make_row("0001", Company=" Acme", Email="Person@example.com")
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [prior])
+    write_csv(tmp_path / "Full_CSContactBasic_260719.csv", [fresh])
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    changed = read_csv(result.changed_path)[1]
+    assert changed == [fresh]
+    assert changed[0]["iMIS Id"] == "0001"
+    assert changed[0]["Company ID"] == "000001"
+    assert changed[0]["Major Key"] == "0000001"
+
+
+def test_bom_quoted_commas_and_embedded_newlines_are_preserved(tmp_path):
+    row = make_row("1", Company='Steel, "Quoted"', **{"Full Address": "Line 1\nLine 2"})
+    write_csv(
+        tmp_path / "Full_CSContactBasic_260719.csv",
+        [row],
+        encoding="utf-8-sig",
+    )
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda message: None)
+
+    assert read_csv(result.combined_path)[1] == [row]
+
+
+@pytest.mark.parametrize(
+    ("fieldnames", "message"),
+    [
+        (CONTACT_BASIC_COLUMNS[:-1], "missing headers: Website"),
+        ((*CONTACT_BASIC_COLUMNS, "Unexpected"), "unexpected headers: Unexpected"),
+    ],
+)
+def test_bad_headers_fail_before_writing(tmp_path, fieldnames, message):
+    write_csv(
+        tmp_path / "Full_CSContactBasic_260719.csv",
+        [make_row("1")],
+        fieldnames=fieldnames,
+    )
+
+    with pytest.raises(ContactConsolidationError, match=message):
+        consolidate_contactbasic(tmp_path, output_fn=lambda output: None)
+
+    assert not list(tmp_path.glob("Combined_*.csv"))
+
+
+@pytest.mark.parametrize(
+    ("filename", "message"),
+    [
+        ("Full_CSContactBasic_bad.csv", "malformed CSContactBasic filename"),
+        ("Full_CSContactBasic_261332.csv", "invalid date"),
+        ("Combined_CSContactBasic_2026-07-18.csv", "malformed CSContactBasic filename"),
+        ("Combined_CSContactBasic_20260230.csv", "invalid date"),
+    ],
+)
+def test_malformed_relevant_filenames_fail(tmp_path, filename, message):
+    write_csv(tmp_path / filename, [make_row("1")])
+
+    with pytest.raises(ContactConsolidationError, match=message):
+        consolidate_contactbasic(tmp_path, output_fn=lambda output: None)
+
+
+def test_missing_directory_or_fresh_export_fails(tmp_path):
+    with pytest.raises(ContactConsolidationError, match="directory does not exist"):
+        consolidate_contactbasic(tmp_path / "missing")
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [make_row("1")])
+    with pytest.raises(ContactConsolidationError, match="No Full_CSContactBasic"):
+        consolidate_contactbasic(tmp_path)
+
+
+def test_fresh_export_must_be_newer_than_combined_table(tmp_path):
+    write_csv(tmp_path / "Combined_CSContactBasic_20260719.csv", [make_row("1")])
+    write_csv(tmp_path / "Full_CSContactBasic_260719.csv", [make_row("1")])
+
+    with pytest.raises(ContactConsolidationError, match="must be newer"):
+        consolidate_contactbasic(tmp_path)
+
+
+def test_duplicate_ids_are_all_omitted_and_warned_by_filename(tmp_path):
+    prior_name = "Combined_CSContactBasic_20260718.csv"
+    fresh_name = "Full_CSContactBasic_260719.csv"
+    write_csv(
+        tmp_path / prior_name,
+        [make_row("prior-duplicate"), make_row("keep"), make_row("prior-duplicate")],
+    )
+    write_csv(
+        tmp_path / fresh_name,
+        [
+            make_row("keep", City="should not replace"),
+            make_row("fresh-duplicate"),
+            make_row("fresh-duplicate"),
+            make_row("new"),
+        ],
+    )
+    messages = []
+
+    result = consolidate_contactbasic(tmp_path, output_fn=messages.append)
+
+    assert [row["iMIS Id"] for row in read_csv(result.combined_path)[1]] == [
+        "keep",
+        "new",
+    ]
+    assert read_csv(result.combined_path)[1][0]["City"] == "should not replace"
+    assert any(
+        prior_name in message and "prior-duplicate" in message for message in messages
+    )
+    assert any(
+        fresh_name in message and "fresh-duplicate" in message for message in messages
+    )
+
+
+def test_duplicated_fresh_id_leaves_valid_prior_row_unchanged(tmp_path):
+    old = make_row("1", City="Old")
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [old])
+    write_csv(
+        tmp_path / "Full_CSContactBasic_260719.csv",
+        [make_row("1", City="First"), make_row("1", City="Second")],
+    )
+
+    result = consolidate_contactbasic(tmp_path, output_fn=lambda output: None)
+
+    assert read_csv(result.combined_path)[1] == [old]
+    assert read_csv(result.changed_path)[1] == []
+    assert read_csv(result.new_path)[1] == []
+
+
+def test_blank_ids_are_skipped_and_csv_row_numbers_are_reported(tmp_path):
+    name = "Full_CSContactBasic_260719.csv"
+    write_csv(tmp_path / name, [make_row(""), make_row("   "), make_row("valid")])
+    messages = []
+
+    result = consolidate_contactbasic(tmp_path, output_fn=messages.append)
+
+    assert read_csv(result.combined_path)[1] == [make_row("valid")]
+    assert any(name in message and "2, 3" in message for message in messages)
+
+
+def test_existing_output_collision_is_refused_without_changes(tmp_path):
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [make_row("old")])
+    write_csv(tmp_path / "Full_CSContactBasic_260719.csv", [make_row("new")])
+    collision = tmp_path / "Changed_CSContactBasic_20260719.csv"
+    collision.write_text("do not replace", encoding="utf-8")
+
+    with pytest.raises(ContactConsolidationError, match="already exists"):
+        consolidate_contactbasic(tmp_path)
+
+    assert collision.read_text(encoding="utf-8") == "do not replace"
+    assert not (tmp_path / "Combined_CSContactBasic_20260719.csv").exists()
+
+
+def test_write_failure_removes_temporary_and_new_output_files(tmp_path, monkeypatch):
+    write_csv(tmp_path / "Combined_CSContactBasic_20260718.csv", [make_row("old")])
+    write_csv(tmp_path / "Full_CSContactBasic_260719.csv", [make_row("new")])
+    real_write = imis_contacts._write_csv_file
+    calls = 0
+
+    def fail_second_write(path, rows):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("disk full")
+        return real_write(path, rows)
+
+    monkeypatch.setattr(imis_contacts, "_write_csv_file", fail_second_write)
+
+    with pytest.raises(ContactConsolidationError, match="Could not publish.*disk full"):
+        consolidate_contactbasic(tmp_path)
+
+    assert not list(tmp_path.glob(".*.tmp-*"))
+    assert not (tmp_path / "Combined_CSContactBasic_20260719.csv").exists()
+    assert not (tmp_path / "Changed_CSContactBasic_20260719.csv").exists()
+    assert not (tmp_path / "New_CSContactBasic_20260719.csv").exists()


### PR DESCRIPTION
## Summary
- add dated iMIS CSContactBasic CSV consolidation with safe validation and atomic publication
- add the `consolidate-imis-contacts` CLI command and documentation
- add comprehensive consolidation and CLI tests

Closes #12