### PR TITLE
Add application snapshot report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ activemq-data/
 .env.*
 !.env.example
 snapshots/
+application_snapshots/
 staged_profile_updates/
 profile_updates.csv
 review_audit.jsonl

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ as `-01`. The CSV always contains the six standard rows in this order:
 `domestic_expedited`, and `international_regular`; empty counts are `0`.
 
 A Case qualifies when its Account certification status is exactly `Initials`,
-its stage is not `Cancelled`, Scope Change is not `Yes`, and its record type is
+its stage is not `Cancel`, Scope Change is not `Yes`, and its record type is
 Fabricator Application, Erector Application, or International Application.
 Null Case stage and Scope Change values remain eligible. Each qualifying Case
 is counted once.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Create a read-only snapshot:
 uv run aisc_salesforce snapshot
 ```
 
+Create a read-only application-stage count:
+
+```bash
+uv run aisc_salesforce application-snapshot
+```
+
 Process recent audit notes and New company profile submissions:
 
 ```bash
@@ -85,6 +91,65 @@ uv run python -m aisc_salesforce profile-updates
 `profile-updates` prints `created`, `reused`, `skipped`, and `failed` counts. A
 successful run returns exit code `0`; missing configuration or a Salesforce
 failure returns `1`.
+
+### Application snapshot
+
+`application-snapshot` reads Salesforce but does not create or update Salesforce
+records:
+
+```bash
+uv run aisc_salesforce application-snapshot
+uv run aisc_salesforce application-snapshot \
+  --output-dir /secure/application-reports
+```
+
+The default output is:
+
+```text
+application_snapshots/YYYY-MM-DDTHH-MM-SSZ/application_snapshot.csv
+```
+
+If that UTC second already has a report, the new folder receives a suffix such
+as `-01`. The CSV always contains the six standard rows in this order:
+`Initial Review`, `Eligibility Review`, `Doc Audit`,
+`Awaiting Audit Assignment`, `Awaiting Audit`, and
+`Awaiting CRG Decision`. Its count columns are `domestic_regular`,
+`domestic_expedited`, and `international_regular`; empty counts are `0`.
+
+A Case qualifies when its Account certification status is exactly `Initials`,
+its stage is not `Cancelled`, Scope Change is not `Yes`, and its record type is
+Fabricator Application, Erector Application, or International Application.
+Null Case stage and Scope Change values remain eligible. Each qualifying Case
+is counted once.
+
+For every Account, the report uses only the newest valid Audit. Cancelled or
+Withdrawn Audits and Additional, Appeal, SA-NYC, or Preassessment Audit types
+are excluded; null status and type values remain valid. `Cert_Audit_Date__c`
+sets an Audit's effective date when present, otherwise the date portion of
+`CreatedDate` is used. Ties use the full `CreatedDate` and then the Audit ID.
+
+United States Accounts are Domestic. Only a Boolean Salesforce value of `true`
+is Expedited; other Domestic Cases are Regular. Every other country, including
+a missing country, is International Regular.
+
+The stage rules check Pending Assignment first. A null or `New Application`
+Case stage becomes `Initial Review`, while ordinary Case stages have
+underscores changed to spaces. For `Doc_Audit`, Reschedule or a missing audit
+date becomes `Awaiting Audit Assignment`; an audit dated today or later becomes
+`Awaiting Audit`; and a past date becomes `Awaiting CRG Decision`. “Today” is
+the `America/Chicago` calendar date.
+
+Unexpected stage labels are appended alphabetically instead of being combined.
+The command prints one warning with every unexpected label and count, followed
+by the output path and qualifying Case count. Authentication, Salesforce,
+invalid-date, or file failures return exit code `1` and do not publish a
+partial report.
+
+> [!WARNING]
+> Application snapshots may contain sensitive operational counts. Their default
+> directory is ignored by Git. When using `--output-dir`, choose an
+> access-controlled location and do not commit or share reports through
+> unapproved channels.
 
 ### iMIS contact consolidation
 

--- a/README.md
+++ b/README.md
@@ -122,33 +122,32 @@ Fabricator Application, Erector Application, or International Application.
 Null Case stage and Scope Change values remain eligible. Each qualifying Case
 is counted once.
 
-For every Account, the report uses only the newest valid Audit. Cancelled or
-Withdrawn Audits and Additional, Appeal, SA-NYC, or Preassessment Audit types
-are excluded; null status and type values remain valid. `Cert_Audit_Date__c`
-sets an Audit's effective date when present, otherwise the date portion of
-`CreatedDate` is used. Ties use the full `CreatedDate` and then the Audit ID.
+For each qualifying Case, the report uses only the newest valid Audit for its
+Account that was created on or after the Case. Canceled or Withdrawn Audits and
+Additional, Appeal, SA-NYC, or Preassessment Audit types are excluded; null
+status and type values remain valid. `Cert_Audit_Date__c` sets an Audit's
+effective date when present, otherwise the date portion of `CreatedDate` is
+used. Ties use the full `CreatedDate` and then the Audit ID.
 
 United States Accounts are Domestic. Only a Boolean Salesforce value of `true`
 is Expedited; other Domestic Cases are Regular. Every other country, including
 a missing country, is International Regular.
 
-The stage rules check Pending Assignment first. A null or `New Application`
-Case stage becomes `Initial Review`, while ordinary Case stages have
-underscores changed to spaces. For `Doc_Audit`, Reschedule or a missing audit
-date becomes `Awaiting Audit Assignment`; an audit dated today or later becomes
-`Awaiting Audit`; and a past date becomes `Awaiting CRG Decision`. “Today” is
-the `America/Chicago` calendar date.
+A `Doc_Audit` Case with a related Audit date is overridden by that date: today
+or later becomes `Awaiting Audit`, while a past date becomes `Awaiting CRG
+Decision`. A null or `New Application` Case stage becomes `Initial Review`, and
+the Audit status Pending Acceptance becomes `Awaiting Audit Assignment`.
+Ordinary Case stages have underscores changed to spaces. For
+`Pending_AuditAssignment`, no related Audit, Reschedule in Progress, or a
+missing audit date becomes `Awaiting Audit Assignment`; an audit dated today or
+later becomes `Awaiting Audit`; and a past date becomes `Awaiting CRG Decision`.
+“Today” is the `America/Chicago` calendar date.
 
 Unexpected stage labels are appended alphabetically instead of being combined.
 The command prints one warning with every unexpected label and count, followed
 by the output path and qualifying Case count. Authentication, Salesforce,
 invalid-date, or file failures return exit code `1` and do not publish a
 partial report.
-
-The command also prints diagnostic counts for the queried records, every Case
-and Audit filter, Account-to-Audit matching, latest-Audit selection, and final
-stage/origin classifications. These messages are intended to make differences
-between Salesforce data and the report easy to investigate.
 
 > [!WARNING]
 > Application snapshots may contain sensitive operational counts. Their default

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ by the output path and qualifying Case count. Authentication, Salesforce,
 invalid-date, or file failures return exit code `1` and do not publish a
 partial report.
 
+The command also prints diagnostic counts for the queried records, every Case
+and Audit filter, Account-to-Audit matching, latest-Audit selection, and final
+stage/origin classifications. These messages are intended to make differences
+between Salesforce data and the report easy to investigate.
+
 > [!WARNING]
 > Application snapshots may contain sensitive operational counts. Their default
 > directory is ignored by Git. When using `--output-dir`, choose an

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,31 @@
 # API Reference
 
+## Application snapshot
+
+::: aisc_salesforce.application_snapshot
+    options:
+      show_root_heading: true
+      members:
+        - RECORD_TYPE_ALIASES
+        - APPLICATION_RECORD_TYPE_IDS
+        - APPLICATION_STAGES
+        - ApplicationSnapshotError
+        - ApplicationSnapshotResult
+        - ApplicationSnapshotService
+        - is_qualifying_case
+        - is_valid_audit
+        - select_latest_valid_audits
+        - application_stage
+        - classify_application_type
+        - aggregate_application_snapshot
+        - write_application_snapshot
+
+`ApplicationSnapshotService.build()` performs the two paginated Salesforce
+queries and returns a frozen `ApplicationSnapshotResult`. The transformation
+helpers are separate from network and file access, which makes each business
+rule directly testable. `write_application_snapshot()` publishes the CSV
+atomically in a timestamped directory.
+
 ## iMIS contact consolidation
 
 ::: aisc_salesforce.imis_contacts

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ Welcome to the **aisc-salesforce** documentation.
 
 ## Overview
 
-aisc-salesforce creates read-only data snapshots, stages submitted Profile
-Updates, automates Profile Update Case work, and provides an audited interactive
-review command for approved Account and Contact changes.
+aisc-salesforce creates read-only data and application-stage snapshots, stages
+submitted Profile Updates, automates Profile Update Case work, and provides an
+audited interactive review command for approved Account and Contact changes.
 
 ## Quick Links
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,6 +121,11 @@ Successful runs print the output path and qualifying Case count. Authentication,
 Salesforce, data-validation, and file errors print
 `Application snapshot failed: ...` and return exit code `1`.
 
+The command also prints diagnostic counts after each Case and Audit filter,
+when Audits match qualifying Accounts, how many latest Audits are selected, and
+how Cases are classified by origin and stage. These messages are intended for
+troubleshooting differences between Salesforce and the CSV.
+
 !!! warning
 
     Application snapshots may contain sensitive operational counts. The

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,12 +92,12 @@ A Case is counted once when all of these rules pass:
 - The Case record type is Fabricator Application, Erector Application, or
   International Application.
 
-For each qualifying Account, Cancelled or Withdrawn Audits are invalid.
-Additional, Appeal, SA-NYC, and Preassessment Audit types are also invalid.
-Null Audit status and type values remain valid. The newest valid Audit is
-selected by `Cert_Audit_Date__c`, falling back to the date portion of
-`CreatedDate`. A tie is resolved by the full `CreatedDate`, then Salesforce
-Audit ID.
+For each qualifying Case, Canceled or Withdrawn Audits are invalid. An Audit
+must also have been created on or after its Case's `CreatedDate`. Additional,
+Appeal, SA-NYC, and Preassessment Audit types are also invalid. Null Audit
+status and type values remain valid. The newest matching valid Audit is selected
+by `Cert_Audit_Date__c`, falling back to the date portion of `CreatedDate`. A
+tie is resolved by the full `CreatedDate`, then Salesforce Audit ID.
 
 `BillingCountry == "United States"` means Domestic. Only the Boolean value
 `true` makes a Domestic Case Expedited; other Domestic Cases are Regular.
@@ -105,13 +105,16 @@ Every other or missing country is International Regular.
 
 Stage decisions use this order:
 
-1. Audit status Pending Assignment becomes `Awaiting Audit Assignment`.
+1. A Doc Audit Case with a related Audit date becomes `Awaiting Audit` when the
+   date is today or in the future, or `Awaiting CRG Decision` when it is past.
 2. A null or New Application Case stage becomes `Initial Review`.
-3. An ordinary Case stage has underscores replaced with spaces.
-4. For Doc Audit, Reschedule or a null audit date becomes
-   `Awaiting Audit Assignment`.
-5. A Doc Audit date today or in the future becomes `Awaiting Audit`.
-6. A past Doc Audit date becomes `Awaiting CRG Decision`.
+3. Audit status Pending Acceptance becomes `Awaiting Audit Assignment`.
+4. An ordinary Case stage has underscores replaced with spaces.
+5. For Pending AuditAssignment, no related Audit, Reschedule in Progress, or a
+   null audit date becomes `Awaiting Audit Assignment`.
+6. A Pending AuditAssignment Audit date today or in the future becomes
+   `Awaiting Audit`.
+7. A past Pending AuditAssignment Audit date becomes `Awaiting CRG Decision`.
 
 Today is evaluated as the current `America/Chicago` calendar date. A malformed
 Salesforce date stops the report with a readable error rather than assigning
@@ -120,11 +123,6 @@ the wrong stage.
 Successful runs print the output path and qualifying Case count. Authentication,
 Salesforce, data-validation, and file errors print
 `Application snapshot failed: ...` and return exit code `1`.
-
-The command also prints diagnostic counts after each Case and Audit filter,
-when Audits match qualifying Accounts, how many latest Audits are selected, and
-how Cases are classified by origin and stage. These messages are intended for
-troubleshooting differences between Salesforce and the CSV.
 
 !!! warning
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,7 +87,7 @@ one non-fatal console warning listing their labels and counts.
 A Case is counted once when all of these rules pass:
 
 - The parent Account's `Cert_Certification_Status__c` is exactly `Initials`.
-- `Cert_Stage__c` is not `Cancelled`; null remains eligible.
+- `Cert_Stage__c` is not `Cancel`; null remains eligible.
 - `Cert_Is_this_a_scope_change__c` is not `Yes`; null remains eligible.
 - The Case record type is Fabricator Application, Erector Application, or
   International Application.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,6 +34,100 @@ uv run aisc_salesforce snapshot
 uv run aisc_salesforce snapshot --output-dir /secure/snapshot-location
 ```
 
+## Application snapshot command
+
+Generate an on-demand, read-only cross-tab of qualifying Application Cases:
+
+```bash
+uv run aisc_salesforce application-snapshot
+uv run aisc_salesforce application-snapshot \
+  --output-dir /secure/application-reports
+```
+
+The command uses Salesforce's
+[REST Query resource](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm)
+and [SOQL relationship fields](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_relationships.htm)
+to read Case and parent Account values. It separately reads the minimal Audit
+fields and follows every Salesforce query page. It does not write to
+Salesforce.
+
+### Output
+
+The default CSV path is:
+
+```text
+application_snapshots/YYYY-MM-DDTHH-MM-SSZ/application_snapshot.csv
+```
+
+A second run in the same UTC second receives a numeric folder suffix, starting
+with `-01`. Publication is atomic: the complete CSV is written in a temporary
+directory before the report folder appears. A failed run removes the temporary
+data.
+
+The CSV columns are:
+
+```text
+application_stage,domestic_regular,domestic_expedited,international_regular
+```
+
+These six rows always appear first and in order, even when every count is zero:
+
+1. Initial Review
+2. Eligibility Review
+3. Doc Audit
+4. Awaiting Audit Assignment
+5. Awaiting Audit
+6. Awaiting CRG Decision
+
+Unexpected stages remain separate, are appended alphabetically, and produce
+one non-fatal console warning listing their labels and counts.
+
+### Filters and classifications
+
+A Case is counted once when all of these rules pass:
+
+- The parent Account's `Cert_Certification_Status__c` is exactly `Initials`.
+- `Cert_Stage__c` is not `Cancelled`; null remains eligible.
+- `Cert_Is_this_a_scope_change__c` is not `Yes`; null remains eligible.
+- The Case record type is Fabricator Application, Erector Application, or
+  International Application.
+
+For each qualifying Account, Cancelled or Withdrawn Audits are invalid.
+Additional, Appeal, SA-NYC, and Preassessment Audit types are also invalid.
+Null Audit status and type values remain valid. The newest valid Audit is
+selected by `Cert_Audit_Date__c`, falling back to the date portion of
+`CreatedDate`. A tie is resolved by the full `CreatedDate`, then Salesforce
+Audit ID.
+
+`BillingCountry == "United States"` means Domestic. Only the Boolean value
+`true` makes a Domestic Case Expedited; other Domestic Cases are Regular.
+Every other or missing country is International Regular.
+
+Stage decisions use this order:
+
+1. Audit status Pending Assignment becomes `Awaiting Audit Assignment`.
+2. A null or New Application Case stage becomes `Initial Review`.
+3. An ordinary Case stage has underscores replaced with spaces.
+4. For Doc Audit, Reschedule or a null audit date becomes
+   `Awaiting Audit Assignment`.
+5. A Doc Audit date today or in the future becomes `Awaiting Audit`.
+6. A past Doc Audit date becomes `Awaiting CRG Decision`.
+
+Today is evaluated as the current `America/Chicago` calendar date. A malformed
+Salesforce date stops the report with a readable error rather than assigning
+the wrong stage.
+
+Successful runs print the output path and qualifying Case count. Authentication,
+Salesforce, data-validation, and file errors print
+`Application snapshot failed: ...` and return exit code `1`.
+
+!!! warning
+
+    Application snapshots may contain sensitive operational counts. The
+    default directory is ignored by Git. Keep custom output locations
+    access-controlled, and do not commit or share these reports through
+    unapproved channels.
+
 ## Profile Update command
 
 Run one daily processing pass:

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -199,9 +199,7 @@ def _run_application_snapshot(
     environment = dict(os.environ)
     credentials = get_credentials(environment)
     auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
-    result = ApplicationSnapshotService(SalesforceClient(auth)).build(
-        output_fn=output_fn
-    )
+    result = ApplicationSnapshotService(SalesforceClient(auth)).build()
     snapshot_path = write_application_snapshot(result, output_dir)
     if result.unexpected_stages:
         details = ", ".join(

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -8,6 +8,11 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from .application_snapshot import (
+    ApplicationSnapshotError,
+    ApplicationSnapshotService,
+    write_application_snapshot,
+)
 from .dictionary import DictionaryError, load_export_plan
 from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
 from .process_profile_updates import (
@@ -50,6 +55,16 @@ def main(
         type=Path,
         default=Path("snapshots"),
         help="Directory to contain snapshot folders.",
+    )
+    application_parser = subparsers.add_parser(
+        "application-snapshot",
+        help="Create a read-only CSV count of qualifying certification applications.",
+    )
+    application_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("application_snapshots"),
+        help="Directory to contain application snapshot folders.",
     )
     subparsers.add_parser(
         "profile-updates",
@@ -100,6 +115,15 @@ def main(
             return _run_snapshot(args.output_dir)
         except (DictionaryError, SalesforceError, OSError) as error:
             print(f"Snapshot failed: {error}", file=sys.stderr)
+            return 1
+    if args.command == "application-snapshot":
+        try:
+            return _run_application_snapshot(
+                args.output_dir,
+                output_fn=output_fn,
+            )
+        except (ApplicationSnapshotError, SalesforceError, OSError) as error:
+            print(f"Application snapshot failed: {error}", file=sys.stderr)
             return 1
     if args.command == "profile-updates":
         try:
@@ -162,6 +186,30 @@ def _run_snapshot(output_dir: Path) -> int:
     print(f"Snapshot complete: {snapshot_path}")
     for object_name, object_records in records.items():
         print(f"{object_name}: {len(object_records)} rows")
+    return 0
+
+
+def _run_application_snapshot(
+    output_dir: Path,
+    *,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Connect to Salesforce and publish one application snapshot."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    result = ApplicationSnapshotService(SalesforceClient(auth)).build()
+    snapshot_path = write_application_snapshot(result, output_dir)
+    if result.unexpected_stages:
+        details = ", ".join(
+            f"{stage} ({count})" for stage, count in result.unexpected_stages.items()
+        )
+        output_fn(f"Warning: unexpected application stages: {details}")
+    output_fn(
+        f"Application snapshot complete: {snapshot_path / 'application_snapshot.csv'}"
+    )
+    output_fn(f"qualifying Cases: {result.qualifying_case_count}")
     return 0
 
 

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -199,7 +199,9 @@ def _run_application_snapshot(
     environment = dict(os.environ)
     credentials = get_credentials(environment)
     auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
-    result = ApplicationSnapshotService(SalesforceClient(auth)).build()
+    result = ApplicationSnapshotService(SalesforceClient(auth)).build(
+        output_fn=output_fn
+    )
     snapshot_path = write_application_snapshot(result, output_dir)
     if result.unexpected_stages:
         details = ", ".join(

--- a/src/aisc_salesforce/application_snapshot.py
+++ b/src/aisc_salesforce/application_snapshot.py
@@ -1,0 +1,371 @@
+"""Build a read-only CSV summary of Salesforce certification applications."""
+
+from __future__ import annotations
+
+import csv
+import os
+import shutil
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+RECORD_TYPE_ALIASES = {
+    "0125w000000BaAdAAK": "Scope Change",
+    "0125w000000BVTTAA4": "Web Question",
+    "0125w000000BXdEAAW": "Audit Date",
+    "0125w000000BZyIAAG": "Membership",
+    "0125w0000013incAAA": "Erector Application",
+    "0125w0000013inhAAA": "Fabricator Application",
+    "0125w0000013inrAAA": "International Application",
+    "012f20000012CCDAA2": "Certification",
+    "012f20000012CCEAA2": "Solutions Center",
+}
+
+APPLICATION_RECORD_TYPE_IDS = frozenset(
+    record_type_id
+    for record_type_id, alias in RECORD_TYPE_ALIASES.items()
+    if alias
+    in {
+        "Fabricator Application",
+        "Erector Application",
+        "International Application",
+    }
+)
+
+CASE_FIELDS = (
+    "Id",
+    "AccountId",
+    "RecordTypeId",
+    "Cert_Stage__c",
+    "Cert_Is_this_a_scope_change__c",
+    "Cert_Expedited_Application__c",
+    "Account.BillingCountry",
+    "Account.Cert_Certification_Status__c",
+)
+
+AUDIT_FIELDS = (
+    "Id",
+    "Cert_Account__c",
+    "Cert_Audit_Date__c",
+    "CreatedDate",
+    "Cert_Audit_Status__c",
+    "Cert_Audit_Type__c",
+)
+
+APPLICATION_STAGES = (
+    "Initial Review",
+    "Eligibility Review",
+    "Doc Audit",
+    "Awaiting Audit Assignment",
+    "Awaiting Audit",
+    "Awaiting CRG Decision",
+)
+
+CSV_COLUMNS = (
+    "application_stage",
+    "domestic_regular",
+    "domestic_expedited",
+    "international_regular",
+)
+
+INVALID_AUDIT_STATUSES = frozenset({"Cancelled", "Withdrawn"})
+INVALID_AUDIT_TYPES = frozenset({"Additional", "Appeal", "SA-NYC", "Preassessment"})
+
+_CASE_WHERE = (
+    "RecordTypeId IN "
+    "('0125w0000013incAAA', '0125w0000013inhAAA', '0125w0000013inrAAA') "
+    "AND Account.Cert_Certification_Status__c = 'Initials' "
+    "AND (Cert_Stage__c != 'Cancelled' OR Cert_Stage__c = NULL) "
+    "AND (Cert_Is_this_a_scope_change__c != 'Yes' "
+    "OR Cert_Is_this_a_scope_change__c = NULL)"
+)
+
+_AUDIT_WHERE = (
+    "(Cert_Audit_Status__c NOT IN ('Cancelled', 'Withdrawn') "
+    "OR Cert_Audit_Status__c = NULL) "
+    "AND (Cert_Audit_Type__c NOT IN "
+    "('Additional', 'Appeal', 'SA-NYC', 'Preassessment') "
+    "OR Cert_Audit_Type__c = NULL)"
+)
+
+
+class ApplicationSnapshotError(ValueError):
+    """Salesforce report data could not be classified safely."""
+
+
+@dataclass(frozen=True)
+class ApplicationSnapshotResult:
+    """Rows and summary metadata for one application snapshot."""
+
+    rows: Sequence[Mapping[str, str | int]]
+    qualifying_case_count: int
+    unexpected_stages: Mapping[str, int]
+
+
+class ApplicationSnapshotService:
+    """Query Salesforce and build one in-memory application snapshot."""
+
+    def __init__(self, client: Any, *, today: date | None = None):
+        self.client = client
+        self.today = today or datetime.now(ZoneInfo("America/Chicago")).date()
+
+    def build(self) -> ApplicationSnapshotResult:
+        """Query Cases and Audits through the paginated Salesforce client."""
+        cases = self.client.query_records(
+            "Case",
+            list(CASE_FIELDS),
+            where=_CASE_WHERE,
+        )
+        audits = self.client.query_records(
+            "Cert_Audit__c",
+            list(AUDIT_FIELDS),
+            where=_AUDIT_WHERE,
+        )
+        return aggregate_application_snapshot(cases, audits, today=self.today)
+
+
+def is_qualifying_case(record: Mapping[str, Any]) -> bool:
+    """Return whether a Case passes every application report filter."""
+    account = record.get("Account")
+    return (
+        isinstance(account, Mapping)
+        and account.get("Cert_Certification_Status__c") == "Initials"
+        and record.get("Cert_Stage__c") != "Cancelled"
+        and record.get("Cert_Is_this_a_scope_change__c") != "Yes"
+        and record.get("RecordTypeId") in APPLICATION_RECORD_TYPE_IDS
+    )
+
+
+def is_valid_audit(record: Mapping[str, Any]) -> bool:
+    """Return whether an Audit can influence an application's stage."""
+    return (
+        record.get("Cert_Audit_Status__c") not in INVALID_AUDIT_STATUSES
+        and record.get("Cert_Audit_Type__c") not in INVALID_AUDIT_TYPES
+    )
+
+
+def select_latest_valid_audits(
+    audits: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """Select the greatest valid Audit ranking key for each Account."""
+    selected: dict[str, Mapping[str, Any]] = {}
+    selected_keys: dict[str, tuple[date, datetime, str]] = {}
+    for audit in audits:
+        if not is_valid_audit(audit):
+            continue
+        account_id = audit.get("Cert_Account__c")
+        if not isinstance(account_id, str) or not account_id:
+            continue
+        ranking_key = _audit_ranking_key(audit)
+        if account_id not in selected_keys or ranking_key > selected_keys[account_id]:
+            selected[account_id] = audit
+            selected_keys[account_id] = ranking_key
+    return selected
+
+
+def application_stage(
+    case: Mapping[str, Any],
+    audit: Mapping[str, Any] | None,
+    *,
+    today: date,
+) -> str:
+    """Apply the supplied Tableau application-stage decision order."""
+    audit_status = audit.get("Cert_Audit_Status__c") if audit else None
+    audit_date_value = audit.get("Cert_Audit_Date__c") if audit else None
+    case_stage = case.get("Cert_Stage__c")
+
+    if audit_status == "Pending Assignment":
+        return "Awaiting Audit Assignment"
+    if case_stage is None:
+        return "Initial Review"
+
+    normalized_stage = str(case_stage).replace("_", " ")
+    if normalized_stage == "New Application":
+        return "Initial Review"
+    if case_stage != "Doc_Audit":
+        return normalized_stage
+    if audit_status == "Reschedule" or audit_date_value is None:
+        return "Awaiting Audit Assignment"
+
+    audit_date = _salesforce_date(
+        audit_date_value,
+        field_name="Cert_Audit_Date__c",
+    )
+    if audit_date >= today:
+        return "Awaiting Audit"
+    return "Awaiting CRG Decision"
+
+
+def classify_application_type(case: Mapping[str, Any]) -> str:
+    """Return the report column for a Case's origin and speed."""
+    account = case.get("Account")
+    billing_country = (
+        account.get("BillingCountry") if isinstance(account, Mapping) else None
+    )
+    if billing_country != "United States":
+        return "international_regular"
+    if case.get("Cert_Expedited_Application__c") is True:
+        return "domestic_expedited"
+    return "domestic_regular"
+
+
+def aggregate_application_snapshot(
+    cases: Sequence[Mapping[str, Any]],
+    audits: Sequence[Mapping[str, Any]],
+    *,
+    today: date,
+) -> ApplicationSnapshotResult:
+    """Filter and count Cases into the fixed application snapshot cross-tab."""
+    qualifying_cases: list[Mapping[str, Any]] = []
+    seen_case_ids: set[str] = set()
+    account_ids: set[str] = set()
+    for case in cases:
+        if not is_qualifying_case(case):
+            continue
+        case_id = case.get("Id")
+        if not isinstance(case_id, str) or not case_id:
+            raise ApplicationSnapshotError("A qualifying Case record is missing Id.")
+        if case_id in seen_case_ids:
+            continue
+        account_id = case.get("AccountId")
+        if not isinstance(account_id, str) or not account_id:
+            raise ApplicationSnapshotError(
+                f"Qualifying Case {case_id} is missing AccountId."
+            )
+        seen_case_ids.add(case_id)
+        account_ids.add(account_id)
+        qualifying_cases.append(case)
+
+    relevant_audits = [
+        audit for audit in audits if audit.get("Cert_Account__c") in account_ids
+    ]
+    audits_by_account = select_latest_valid_audits(relevant_audits)
+    counts: dict[str, Counter[str]] = {}
+    for case in qualifying_cases:
+        stage = application_stage(
+            case,
+            audits_by_account.get(case["AccountId"]),
+            today=today,
+        )
+        counts.setdefault(stage, Counter())[classify_application_type(case)] += 1
+
+    unexpected_labels = sorted(set(counts) - set(APPLICATION_STAGES))
+    stage_labels = [*APPLICATION_STAGES, *unexpected_labels]
+    rows = tuple(
+        {
+            "application_stage": stage,
+            "domestic_regular": counts.get(stage, Counter())["domestic_regular"],
+            "domestic_expedited": counts.get(stage, Counter())["domestic_expedited"],
+            "international_regular": counts.get(stage, Counter())[
+                "international_regular"
+            ],
+        }
+        for stage in stage_labels
+    )
+    unexpected_stages = {
+        stage: sum(counts[stage].values()) for stage in unexpected_labels
+    }
+    return ApplicationSnapshotResult(
+        rows=rows,
+        qualifying_case_count=len(qualifying_cases),
+        unexpected_stages=unexpected_stages,
+    )
+
+
+def write_application_snapshot(
+    result: ApplicationSnapshotResult,
+    output_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> Path:
+    """Atomically publish one timestamped ``application_snapshot.csv``."""
+    timestamp = (now or datetime.now(UTC)).astimezone(UTC)
+    folder_name = timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_path = _available_output_path(output_dir, folder_name)
+    temporary_path = output_dir / f".{folder_name}-{uuid4().hex}.tmp"
+    try:
+        temporary_path.mkdir()
+        _write_application_csv(
+            temporary_path / "application_snapshot.csv",
+            result.rows,
+        )
+        os.replace(temporary_path, final_path)
+    except Exception:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+    return final_path
+
+
+def _audit_ranking_key(
+    audit: Mapping[str, Any],
+) -> tuple[date, datetime, str]:
+    created = _salesforce_datetime(
+        audit.get("CreatedDate"),
+        field_name="CreatedDate",
+    )
+    audit_date_value = audit.get("Cert_Audit_Date__c")
+    effective_date = (
+        _salesforce_date(
+            audit_date_value,
+            field_name="Cert_Audit_Date__c",
+        )
+        if audit_date_value is not None
+        else created.date()
+    )
+    return effective_date, created, str(audit.get("Id") or "")
+
+
+def _salesforce_date(value: Any, *, field_name: str) -> date:
+    if not isinstance(value, str):
+        raise ApplicationSnapshotError(
+            f"Salesforce {field_name} must be an ISO date; received {value!r}."
+        )
+    try:
+        return date.fromisoformat(value)
+    except ValueError as error:
+        raise ApplicationSnapshotError(
+            f"Salesforce {field_name} has an invalid date: {value!r}."
+        ) from error
+
+
+def _salesforce_datetime(value: Any, *, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise ApplicationSnapshotError(
+            f"Salesforce {field_name} must be an ISO date/time; received {value!r}."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ApplicationSnapshotError(
+            f"Salesforce {field_name} has an invalid date/time: {value!r}."
+        ) from error
+    if parsed.tzinfo is None:
+        raise ApplicationSnapshotError(
+            f"Salesforce {field_name} is missing a timezone: {value!r}."
+        )
+    return parsed.astimezone(UTC)
+
+
+def _available_output_path(output_dir: Path, folder_name: str) -> Path:
+    candidate = output_dir / folder_name
+    number = 1
+    while candidate.exists():
+        candidate = output_dir / f"{folder_name}-{number:02d}"
+        number += 1
+    return candidate
+
+
+def _write_application_csv(
+    path: Path,
+    rows: Sequence[Mapping[str, str | int]],
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as output:
+        writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/src/aisc_salesforce/application_snapshot.py
+++ b/src/aisc_salesforce/application_snapshot.py
@@ -6,7 +6,7 @@ import csv
 import os
 import shutil
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -68,8 +68,8 @@ APPLICATION_STAGES = (
 
 CSV_COLUMNS = (
     "application_stage",
-    "domestic_regular",
     "domestic_expedited",
+    "domestic_regular",
     "international_regular",
 )
 
@@ -114,19 +114,30 @@ class ApplicationSnapshotService:
         self.client = client
         self.today = today or datetime.now(ZoneInfo("America/Chicago")).date()
 
-    def build(self) -> ApplicationSnapshotResult:
+    def build(
+        self,
+        *,
+        output_fn: Callable[[str], None] | None = None,
+    ) -> ApplicationSnapshotResult:
         """Query Cases and Audits through the paginated Salesforce client."""
         cases = self.client.query_records(
             "Case",
             list(CASE_FIELDS),
             where=_CASE_WHERE,
         )
+        _emit(output_fn, f"Application snapshot: queried Cases: {len(cases)}")
         audits = self.client.query_records(
             "Cert_Audit__c",
             list(AUDIT_FIELDS),
             where=_AUDIT_WHERE,
         )
-        return aggregate_application_snapshot(cases, audits, today=self.today)
+        _emit(output_fn, f"Application snapshot: queried Audits: {len(audits)}")
+        return aggregate_application_snapshot(
+            cases,
+            audits,
+            today=self.today,
+            output_fn=output_fn,
+        )
 
 
 def is_qualifying_case(record: Mapping[str, Any]) -> bool:
@@ -219,8 +230,50 @@ def aggregate_application_snapshot(
     audits: Sequence[Mapping[str, Any]],
     *,
     today: date,
+    output_fn: Callable[[str], None] | None = None,
 ) -> ApplicationSnapshotResult:
     """Filter and count Cases into the fixed application snapshot cross-tab."""
+    _emit(output_fn, f"Application snapshot: Cases received: {len(cases)}")
+    account_status_cases = [
+        case
+        for case in cases
+        if isinstance(case.get("Account"), Mapping)
+        and case["Account"].get("Cert_Certification_Status__c") == "Initials"
+    ]
+    _emit(
+        output_fn,
+        "Application snapshot: Cases after Account certification status "
+        f"filter: {len(account_status_cases)}",
+    )
+    stage_cases = [
+        case
+        for case in account_status_cases
+        if case.get("Cert_Stage__c") != "Cancelled"
+    ]
+    _emit(
+        output_fn,
+        f"Application snapshot: Cases after Case stage filter: {len(stage_cases)}",
+    )
+    scope_cases = [
+        case
+        for case in stage_cases
+        if case.get("Cert_Is_this_a_scope_change__c") != "Yes"
+    ]
+    _emit(
+        output_fn,
+        f"Application snapshot: Cases after Scope Change filter: {len(scope_cases)}",
+    )
+    record_type_cases = [
+        case
+        for case in scope_cases
+        if case.get("RecordTypeId") in APPLICATION_RECORD_TYPE_IDS
+    ]
+    _emit(
+        output_fn,
+        "Application snapshot: Cases after Application record type filter: "
+        f"{len(record_type_cases)}",
+    )
+
     qualifying_cases: list[Mapping[str, Any]] = []
     seen_case_ids: set[str] = set()
     account_ids: set[str] = set()
@@ -241,10 +294,54 @@ def aggregate_application_snapshot(
         account_ids.add(account_id)
         qualifying_cases.append(case)
 
-    relevant_audits = [
-        audit for audit in audits if audit.get("Cert_Account__c") in account_ids
+    _emit(
+        output_fn,
+        f"Application snapshot: unique qualifying Cases: {len(qualifying_cases)}",
+    )
+    status_audits = [
+        audit
+        for audit in audits
+        if audit.get("Cert_Audit_Status__c") not in INVALID_AUDIT_STATUSES
     ]
+    _emit(
+        output_fn,
+        f"Application snapshot: Audits after status filter: {len(status_audits)}",
+    )
+    valid_audits = [
+        audit
+        for audit in status_audits
+        if audit.get("Cert_Audit_Type__c") not in INVALID_AUDIT_TYPES
+    ]
+    _emit(
+        output_fn,
+        f"Application snapshot: Audits after type filter: {len(valid_audits)}",
+    )
+    _emit(output_fn, f"Application snapshot: valid Audits: {len(valid_audits)}")
+    relevant_audits = [
+        audit for audit in valid_audits if audit.get("Cert_Account__c") in account_ids
+    ]
+    _emit(
+        output_fn,
+        "Application snapshot: valid Audits matched to qualifying Accounts: "
+        f"{len(relevant_audits)}",
+    )
     audits_by_account = select_latest_valid_audits(relevant_audits)
+    _emit(
+        output_fn,
+        f"Application snapshot: latest Audits selected: {len(audits_by_account)}",
+    )
+    matched_cases = sum(
+        case["AccountId"] in audits_by_account for case in qualifying_cases
+    )
+    _emit(
+        output_fn,
+        f"Application snapshot: Cases matched to a latest Audit: {matched_cases}",
+    )
+    _emit(
+        output_fn,
+        "Application snapshot: Cases without a matching latest Audit: "
+        f"{len(qualifying_cases) - matched_cases}",
+    )
     counts: dict[str, Counter[str]] = {}
     for case in qualifying_cases:
         stage = application_stage(
@@ -253,6 +350,19 @@ def aggregate_application_snapshot(
             today=today,
         )
         counts.setdefault(stage, Counter())[classify_application_type(case)] += 1
+
+    _emit(output_fn, f"Application snapshot: Cases classified: {len(qualifying_cases)}")
+    for column in CSV_COLUMNS[1:]:
+        _emit(
+            output_fn,
+            f"Application snapshot: {column} classifications: "
+            f"{sum(stage_counts[column] for stage_counts in counts.values())}",
+        )
+    for stage, stage_counts in sorted(counts.items()):
+        _emit(
+            output_fn,
+            f"Application snapshot: stage '{stage}' count: {sum(stage_counts.values())}",
+        )
 
     unexpected_labels = sorted(set(counts) - set(APPLICATION_STAGES))
     stage_labels = [*APPLICATION_STAGES, *unexpected_labels]
@@ -369,3 +479,8 @@ def _write_application_csv(
         writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _emit(output_fn: Callable[[str], None] | None, message: str) -> None:
+    if output_fn is not None:
+        output_fn(message)

--- a/src/aisc_salesforce/application_snapshot.py
+++ b/src/aisc_salesforce/application_snapshot.py
@@ -6,7 +6,7 @@ import csv
 import os
 import shutil
 from collections import Counter
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -40,6 +40,7 @@ APPLICATION_RECORD_TYPE_IDS = frozenset(
 CASE_FIELDS = (
     "Id",
     "AccountId",
+    "CreatedDate",
     "RecordTypeId",
     "Cert_Stage__c",
     "Cert_Is_this_a_scope_change__c",
@@ -75,7 +76,7 @@ CSV_COLUMNS = (
 
 # Keep Salesforce picklist values in one place so query and Python filters agree.
 CASE_CANCELLED_STAGE = "Cancel"
-INVALID_AUDIT_STATUSES = frozenset({"Cancelled", "Withdrawn"})
+INVALID_AUDIT_STATUSES = frozenset({"Canceled", "Withdrawn"})
 INVALID_AUDIT_TYPES = frozenset({"Additional", "Appeal", "SA-NYC", "Preassessment"})
 
 _CASE_WHERE = (
@@ -88,7 +89,7 @@ _CASE_WHERE = (
 )
 
 _AUDIT_WHERE = (
-    "(Cert_Audit_Status__c NOT IN ('Cancelled', 'Withdrawn') "
+    "(Cert_Audit_Status__c NOT IN ('Canceled', 'Withdrawn') "
     "OR Cert_Audit_Status__c = NULL) "
     "AND (Cert_Audit_Type__c NOT IN "
     "('Additional', 'Appeal', 'SA-NYC', 'Preassessment') "
@@ -116,29 +117,22 @@ class ApplicationSnapshotService:
         self.client = client
         self.today = today or datetime.now(ZoneInfo("America/Chicago")).date()
 
-    def build(
-        self,
-        *,
-        output_fn: Callable[[str], None] | None = None,
-    ) -> ApplicationSnapshotResult:
+    def build(self) -> ApplicationSnapshotResult:
         """Query Cases and Audits through the paginated Salesforce client."""
         cases = self.client.query_records(
             "Case",
             list(CASE_FIELDS),
             where=_CASE_WHERE,
         )
-        _emit(output_fn, f"Application snapshot: queried Cases: {len(cases)}")
         audits = self.client.query_records(
             "Cert_Audit__c",
             list(AUDIT_FIELDS),
             where=_AUDIT_WHERE,
         )
-        _emit(output_fn, f"Application snapshot: queried Audits: {len(audits)}")
         return aggregate_application_snapshot(
             cases,
             audits,
             today=self.today,
-            output_fn=output_fn,
         )
 
 
@@ -192,26 +186,28 @@ def application_stage(
     audit_date_value = audit.get("Cert_Audit_Date__c") if audit else None
     case_stage = case.get("Cert_Stage__c")
 
-    if audit_status == "Pending Assignment":
-        return "Awaiting Audit Assignment"
     if case_stage is None:
         return "Initial Review"
 
     normalized_stage = str(case_stage).replace("_", " ")
     if normalized_stage == "New Application":
         return "Initial Review"
-    if case_stage != "Doc_Audit":
+    if case_stage == "Doc_Audit" and audit_date_value is not None:
+        return _stage_for_audit_date(audit_date_value, today=today)
+    if audit_status == "Pending Acceptance":
+        return "Awaiting Audit Assignment"
+    if case_stage != "Pending_AuditAssignment":
         return normalized_stage
-    if audit_status == "Reschedule" or audit_date_value is None:
+    if audit_status == "Reschedule in Progress" or audit_date_value is None:
         return "Awaiting Audit Assignment"
 
-    audit_date = _salesforce_date(
-        audit_date_value,
-        field_name="Cert_Audit_Date__c",
-    )
-    if audit_date >= today:
-        return "Awaiting Audit"
-    return "Awaiting CRG Decision"
+    return _stage_for_audit_date(audit_date_value, today=today)
+
+
+def _stage_for_audit_date(audit_date_value: Any, *, today: date) -> str:
+    """Return the application stage determined by an Audit's date."""
+    audit_date = _salesforce_date(audit_date_value, field_name="Cert_Audit_Date__c")
+    return "Awaiting Audit" if audit_date >= today else "Awaiting CRG Decision"
 
 
 def classify_application_type(case: Mapping[str, Any]) -> str:
@@ -232,49 +228,8 @@ def aggregate_application_snapshot(
     audits: Sequence[Mapping[str, Any]],
     *,
     today: date,
-    output_fn: Callable[[str], None] | None = None,
 ) -> ApplicationSnapshotResult:
     """Filter and count Cases into the fixed application snapshot cross-tab."""
-    _emit(output_fn, f"Application snapshot: Cases received: {len(cases)}")
-    account_status_cases = [
-        case
-        for case in cases
-        if isinstance(case.get("Account"), Mapping)
-        and case["Account"].get("Cert_Certification_Status__c") == "Initials"
-    ]
-    _emit(
-        output_fn,
-        "Application snapshot: Cases after Account certification status "
-        f"filter: {len(account_status_cases)}",
-    )
-    stage_cases = [
-        case
-        for case in account_status_cases
-        if case.get("Cert_Stage__c") != CASE_CANCELLED_STAGE
-    ]
-    _emit(
-        output_fn,
-        f"Application snapshot: Cases after Case stage filter: {len(stage_cases)}",
-    )
-    scope_cases = [
-        case
-        for case in stage_cases
-        if case.get("Cert_Is_this_a_scope_change__c") != "Yes"
-    ]
-    _emit(
-        output_fn,
-        f"Application snapshot: Cases after Scope Change filter: {len(scope_cases)}",
-    )
-    record_type_cases = [
-        case
-        for case in scope_cases
-        if case.get("RecordTypeId") in APPLICATION_RECORD_TYPE_IDS
-    ]
-    _emit(
-        output_fn,
-        "Application snapshot: Cases after Application record type filter: "
-        f"{len(record_type_cases)}",
-    )
 
     qualifying_cases: list[Mapping[str, Any]] = []
     seen_case_ids: set[str] = set()
@@ -296,75 +251,31 @@ def aggregate_application_snapshot(
         account_ids.add(account_id)
         qualifying_cases.append(case)
 
-    _emit(
-        output_fn,
-        f"Application snapshot: unique qualifying Cases: {len(qualifying_cases)}",
-    )
     status_audits = [
         audit
         for audit in audits
         if audit.get("Cert_Audit_Status__c") not in INVALID_AUDIT_STATUSES
     ]
-    _emit(
-        output_fn,
-        f"Application snapshot: Audits after status filter: {len(status_audits)}",
-    )
     valid_audits = [
         audit
         for audit in status_audits
         if audit.get("Cert_Audit_Type__c") not in INVALID_AUDIT_TYPES
     ]
-    _emit(
-        output_fn,
-        f"Application snapshot: Audits after type filter: {len(valid_audits)}",
-    )
-    _emit(output_fn, f"Application snapshot: valid Audits: {len(valid_audits)}")
     relevant_audits = [
         audit for audit in valid_audits if audit.get("Cert_Account__c") in account_ids
     ]
-    _emit(
-        output_fn,
-        "Application snapshot: valid Audits matched to qualifying Accounts: "
-        f"{len(relevant_audits)}",
-    )
-    audits_by_account = select_latest_valid_audits(relevant_audits)
-    _emit(
-        output_fn,
-        f"Application snapshot: latest Audits selected: {len(audits_by_account)}",
-    )
-    matched_cases = sum(
-        case["AccountId"] in audits_by_account for case in qualifying_cases
-    )
-    _emit(
-        output_fn,
-        f"Application snapshot: Cases matched to a latest Audit: {matched_cases}",
-    )
-    _emit(
-        output_fn,
-        "Application snapshot: Cases without a matching latest Audit: "
-        f"{len(qualifying_cases) - matched_cases}",
+    audits_by_case = _select_latest_valid_audits_by_case(
+        qualifying_cases,
+        relevant_audits,
     )
     counts: dict[str, Counter[str]] = {}
     for case in qualifying_cases:
         stage = application_stage(
             case,
-            audits_by_account.get(case["AccountId"]),
+            audits_by_case[case["Id"]],
             today=today,
         )
         counts.setdefault(stage, Counter())[classify_application_type(case)] += 1
-
-    _emit(output_fn, f"Application snapshot: Cases classified: {len(qualifying_cases)}")
-    for column in CSV_COLUMNS[1:]:
-        _emit(
-            output_fn,
-            f"Application snapshot: {column} classifications: "
-            f"{sum(stage_counts[column] for stage_counts in counts.values())}",
-        )
-    for stage, stage_counts in sorted(counts.items()):
-        _emit(
-            output_fn,
-            f"Application snapshot: stage '{stage}' count: {sum(stage_counts.values())}",
-        )
 
     unexpected_labels = sorted(set(counts) - set(APPLICATION_STAGES))
     stage_labels = [*APPLICATION_STAGES, *unexpected_labels]
@@ -387,6 +298,39 @@ def aggregate_application_snapshot(
         qualifying_case_count=len(qualifying_cases),
         unexpected_stages=unexpected_stages,
     )
+
+
+def _select_latest_valid_audits_by_case(
+    cases: Sequence[Mapping[str, Any]],
+    audits: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any] | None]:
+    """Select each Case's newest Audit created on or after the Case."""
+    audits_by_account: dict[str, list[Mapping[str, Any]]] = {}
+    for audit in audits:
+        account_id = audit.get("Cert_Account__c")
+        if isinstance(account_id, str) and account_id:
+            audits_by_account.setdefault(account_id, []).append(audit)
+
+    selected: dict[str, Mapping[str, Any] | None] = {}
+    for case in cases:
+        case_id = case["Id"]
+        case_created = _salesforce_datetime(
+            case.get("CreatedDate"),
+            field_name="Case CreatedDate",
+        )
+        matching_audits = [
+            audit
+            for audit in audits_by_account.get(case["AccountId"], [])
+            if _salesforce_datetime(
+                audit.get("CreatedDate"),
+                field_name="Audit CreatedDate",
+            )
+            >= case_created
+        ]
+        selected[case_id] = select_latest_valid_audits(matching_audits).get(
+            case["AccountId"]
+        )
+    return selected
 
 
 def write_application_snapshot(
@@ -481,8 +425,3 @@ def _write_application_csv(
         writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
         writer.writeheader()
         writer.writerows(rows)
-
-
-def _emit(output_fn: Callable[[str], None] | None, message: str) -> None:
-    if output_fn is not None:
-        output_fn(message)

--- a/src/aisc_salesforce/application_snapshot.py
+++ b/src/aisc_salesforce/application_snapshot.py
@@ -73,6 +73,8 @@ CSV_COLUMNS = (
     "international_regular",
 )
 
+# Keep Salesforce picklist values in one place so query and Python filters agree.
+CASE_CANCELLED_STAGE = "Cancel"
 INVALID_AUDIT_STATUSES = frozenset({"Cancelled", "Withdrawn"})
 INVALID_AUDIT_TYPES = frozenset({"Additional", "Appeal", "SA-NYC", "Preassessment"})
 
@@ -80,7 +82,7 @@ _CASE_WHERE = (
     "RecordTypeId IN "
     "('0125w0000013incAAA', '0125w0000013inhAAA', '0125w0000013inrAAA') "
     "AND Account.Cert_Certification_Status__c = 'Initials' "
-    "AND (Cert_Stage__c != 'Cancelled' OR Cert_Stage__c = NULL) "
+    f"AND (Cert_Stage__c != '{CASE_CANCELLED_STAGE}' OR Cert_Stage__c = NULL) "
     "AND (Cert_Is_this_a_scope_change__c != 'Yes' "
     "OR Cert_Is_this_a_scope_change__c = NULL)"
 )
@@ -146,7 +148,7 @@ def is_qualifying_case(record: Mapping[str, Any]) -> bool:
     return (
         isinstance(account, Mapping)
         and account.get("Cert_Certification_Status__c") == "Initials"
-        and record.get("Cert_Stage__c") != "Cancelled"
+        and record.get("Cert_Stage__c") != CASE_CANCELLED_STAGE
         and record.get("Cert_Is_this_a_scope_change__c") != "Yes"
         and record.get("RecordTypeId") in APPLICATION_RECORD_TYPE_IDS
     )
@@ -248,7 +250,7 @@ def aggregate_application_snapshot(
     stage_cases = [
         case
         for case in account_status_cases
-        if case.get("Cert_Stage__c") != "Cancelled"
+        if case.get("Cert_Stage__c") != CASE_CANCELLED_STAGE
     ]
     _emit(
         output_fn,

--- a/tests/test_application_snapshot.py
+++ b/tests/test_application_snapshot.py
@@ -6,6 +6,7 @@ import pytest
 from aisc_salesforce.application_snapshot import (
     APPLICATION_RECORD_TYPE_IDS,
     APPLICATION_STAGES,
+    CASE_CANCELLED_STAGE,
     RECORD_TYPE_ALIASES,
     ApplicationSnapshotError,
     ApplicationSnapshotService,
@@ -80,7 +81,7 @@ def test_record_type_aliases_include_all_supplied_values():
         ({}, True),
         ({"Account": {"Cert_Certification_Status__c": "Certified"}}, False),
         ({"Account": {"Cert_Certification_Status__c": None}}, False),
-        ({"Cert_Stage__c": "Cancelled"}, False),
+        ({"Cert_Stage__c": CASE_CANCELLED_STAGE}, False),
         ({"Cert_Stage__c": None}, True),
         ({"Cert_Is_this_a_scope_change__c": "Yes"}, False),
         ({"Cert_Is_this_a_scope_change__c": None}, True),
@@ -284,7 +285,7 @@ def test_aggregation_counts_each_case_once_and_keeps_all_official_rows():
             AccountId="unexpected-account",
             Cert_Stage__c="Zebra_Review",
         ),
-        case_record(Id="filtered", Cert_Stage__c="Cancelled"),
+        case_record(Id="filtered", Cert_Stage__c=CASE_CANCELLED_STAGE),
     ]
     result = aggregate_application_snapshot(cases, [], today=TODAY)
 
@@ -352,7 +353,7 @@ def test_diagnostics_report_filter_and_audit_matching_counts():
     messages = []
     cases = [
         case_record(Id="kept"),
-        case_record(Id="cancelled", Cert_Stage__c="Cancelled"),
+        case_record(Id="cancelled", Cert_Stage__c=CASE_CANCELLED_STAGE),
     ]
     audits = [
         audit_record(Id="matched"),

--- a/tests/test_application_snapshot.py
+++ b/tests/test_application_snapshot.py
@@ -342,6 +342,51 @@ def test_service_queries_relationship_case_fields_and_minimal_audit_fields():
     assert "Cert_Audit_Date__c" in audit_call[1]
     assert len(calls) == 2
 
+    messages = []
+    ApplicationSnapshotService(Client(), today=TODAY).build(output_fn=messages.append)
+    assert "queried Cases: 0" in messages[0]
+    assert "queried Audits: 0" in messages[1]
+
+
+def test_diagnostics_report_filter_and_audit_matching_counts():
+    messages = []
+    cases = [
+        case_record(Id="kept"),
+        case_record(Id="cancelled", Cert_Stage__c="Cancelled"),
+    ]
+    audits = [
+        audit_record(Id="matched"),
+        audit_record(Id="invalid", Cert_Audit_Status__c="Withdrawn"),
+    ]
+
+    aggregate_application_snapshot(
+        cases,
+        audits,
+        today=TODAY,
+        output_fn=messages.append,
+    )
+
+    expected_messages = [
+        "Cases received: 2",
+        "Cases after Account certification status filter: 2",
+        "Cases after Case stage filter: 1",
+        "Cases after Scope Change filter: 1",
+        "Cases after Application record type filter: 1",
+        "unique qualifying Cases: 1",
+        "Audits after status filter: 1",
+        "Audits after type filter: 1",
+        "valid Audits: 1",
+        "valid Audits matched to qualifying Accounts: 1",
+        "latest Audits selected: 1",
+        "Cases matched to a latest Audit: 1",
+        "Cases without a matching latest Audit: 0",
+        "Cases classified: 1",
+    ]
+    assert all(
+        any(expected in message for message in messages)
+        for expected in expected_messages
+    )
+
 
 def test_writer_publishes_csv_atomically_and_suffixes_same_second(tmp_path):
     result = aggregate_application_snapshot([], [], today=TODAY)

--- a/tests/test_application_snapshot.py
+++ b/tests/test_application_snapshot.py
@@ -29,6 +29,7 @@ def case_record(**changes):
     record = {
         "Id": "case-1",
         "AccountId": "account-1",
+        "CreatedDate": "2026-07-01T00:00:00Z",
         "RecordTypeId": FABRICATOR,
         "Cert_Stage__c": "Doc_Audit",
         "Cert_Is_this_a_scope_change__c": "No",
@@ -107,7 +108,7 @@ def test_each_application_record_type_is_allowed(record_type_id):
     ("changes", "expected"),
     [
         ({}, True),
-        ({"Cert_Audit_Status__c": "Cancelled"}, False),
+        ({"Cert_Audit_Status__c": "Canceled"}, False),
         ({"Cert_Audit_Status__c": "Withdrawn"}, False),
         ({"Cert_Audit_Status__c": None}, True),
         ({"Cert_Audit_Type__c": "Additional"}, False),
@@ -141,7 +142,7 @@ def test_latest_valid_audit_uses_effective_date_created_date_and_id_tiebreakers(
         audit_record(
             Id="ignored",
             Cert_Audit_Date__c="2026-08-01",
-            Cert_Audit_Status__c="Cancelled",
+            Cert_Audit_Status__c="Canceled",
         ),
     ]
     assert select_latest_valid_audits(audits)["account-1"]["Id"] == "undated-b"
@@ -166,18 +167,43 @@ def test_latest_valid_audit_breaks_effective_date_tie_with_created_date():
     [
         (
             "Eligibility_Review",
-            "Pending Assignment",
+            "Pending Acceptance",
             "2026-08-01",
             "Awaiting Audit Assignment",
         ),
         (None, None, None, "Initial Review"),
         ("New_Application", None, None, "Initial Review"),
         ("Eligibility_Review", "Scheduled", "2026-08-01", "Eligibility Review"),
-        ("Doc_Audit", "Reschedule", "2026-08-01", "Awaiting Audit Assignment"),
-        ("Doc_Audit", "Scheduled", None, "Awaiting Audit Assignment"),
-        ("Doc_Audit", "Scheduled", "2026-07-23", "Awaiting Audit"),
+        ("Doc_Audit", "Scheduled", None, "Doc Audit"),
         ("Doc_Audit", "Scheduled", "2026-07-22", "Awaiting CRG Decision"),
-        ("Doc_Audit", "Scheduled", "2026-07-24", "Awaiting Audit"),
+        ("Doc_Audit", "Scheduled", "2026-08-01", "Awaiting Audit"),
+        (
+            "Doc_Audit",
+            "Reschedule in Progress",
+            "2026-08-01",
+            "Awaiting Audit",
+        ),
+        ("Pending_AuditAssignment", None, None, "Awaiting Audit Assignment"),
+        (
+            "Pending_AuditAssignment",
+            "Reschedule in Progress",
+            "2026-08-01",
+            "Awaiting Audit Assignment",
+        ),
+        (
+            "Pending_AuditAssignment",
+            "Scheduled",
+            None,
+            "Awaiting Audit Assignment",
+        ),
+        ("Pending_AuditAssignment", "Scheduled", "2026-07-23", "Awaiting Audit"),
+        (
+            "Pending_AuditAssignment",
+            "Scheduled",
+            "2026-07-22",
+            "Awaiting CRG Decision",
+        ),
+        ("Pending_AuditAssignment", "Scheduled", "2026-07-24", "Awaiting Audit"),
         ("Awaiting_Custom_Step", "Scheduled", "2026-08-01", "Awaiting Custom Step"),
     ],
 )
@@ -199,7 +225,7 @@ def test_application_stage_reproduces_tableau_branches(
 def test_malformed_salesforce_dates_fail_clearly():
     with pytest.raises(ApplicationSnapshotError, match="Cert_Audit_Date__c"):
         application_stage(
-            case_record(),
+            case_record(Cert_Stage__c="Pending_AuditAssignment"),
             audit_record(Cert_Audit_Date__c="not-a-date"),
             today=TODAY,
         )
@@ -231,7 +257,7 @@ def test_origin_and_speed_use_exact_country_and_boolean_rules(
 
 
 def test_invalid_audit_never_influences_application_stage():
-    cases = [case_record(Cert_Stage__c="Doc_Audit")]
+    cases = [case_record(Cert_Stage__c="Pending_AuditAssignment")]
     audits = [
         audit_record(
             Id="valid-past",
@@ -241,7 +267,7 @@ def test_invalid_audit_never_influences_application_stage():
         audit_record(
             Id="invalid-future",
             Cert_Audit_Date__c="2026-08-20",
-            Cert_Audit_Status__c="Cancelled",
+            Cert_Audit_Status__c="Canceled",
         ),
     ]
 
@@ -253,6 +279,65 @@ def test_invalid_audit_never_influences_application_stage():
         if row["application_stage"] == "Awaiting CRG Decision"
     )
     assert crg_row["domestic_regular"] == 1
+
+
+def test_audit_must_be_created_on_or_after_its_application_case():
+    cases = [
+        case_record(
+            Id="earlier-case",
+            CreatedDate="2026-07-01T00:00:00Z",
+            Cert_Stage__c="Pending_AuditAssignment",
+        ),
+        case_record(
+            Id="later-case",
+            CreatedDate="2026-07-02T00:00:00Z",
+            Cert_Stage__c="Pending_AuditAssignment",
+        ),
+    ]
+    audits = [
+        audit_record(
+            Id="between-cases",
+            CreatedDate="2026-07-01T12:00:00Z",
+            Cert_Audit_Date__c="2026-07-20",
+        ),
+        audit_record(
+            Id="same-time-as-later-case",
+            CreatedDate="2026-07-02T00:00:00Z",
+            Cert_Audit_Date__c="2026-07-24",
+        ),
+    ]
+
+    result = aggregate_application_snapshot(cases, audits, today=TODAY)
+
+    awaiting_audit = next(
+        row for row in result.rows if row["application_stage"] == "Awaiting Audit"
+    )
+    assert awaiting_audit["domestic_regular"] == 2
+
+
+def test_audit_created_before_its_only_application_case_is_not_matched():
+    result = aggregate_application_snapshot(
+        [
+            case_record(
+                CreatedDate="2026-07-02T00:00:00Z",
+                Cert_Stage__c="Pending_AuditAssignment",
+            )
+        ],
+        [
+            audit_record(
+                CreatedDate="2026-07-01T23:59:59Z",
+                Cert_Audit_Date__c="2026-07-24",
+            )
+        ],
+        today=TODAY,
+    )
+
+    awaiting_audit_assignment = next(
+        row
+        for row in result.rows
+        if row["application_stage"] == "Awaiting Audit Assignment"
+    )
+    assert awaiting_audit_assignment["domestic_regular"] == 1
 
 
 def test_aggregation_counts_each_case_once_and_keeps_all_official_rows():
@@ -342,51 +427,6 @@ def test_service_queries_relationship_case_fields_and_minimal_audit_fields():
     assert "Cert_Account__c" in audit_call[1]
     assert "Cert_Audit_Date__c" in audit_call[1]
     assert len(calls) == 2
-
-    messages = []
-    ApplicationSnapshotService(Client(), today=TODAY).build(output_fn=messages.append)
-    assert "queried Cases: 0" in messages[0]
-    assert "queried Audits: 0" in messages[1]
-
-
-def test_diagnostics_report_filter_and_audit_matching_counts():
-    messages = []
-    cases = [
-        case_record(Id="kept"),
-        case_record(Id="cancelled", Cert_Stage__c=CASE_CANCELLED_STAGE),
-    ]
-    audits = [
-        audit_record(Id="matched"),
-        audit_record(Id="invalid", Cert_Audit_Status__c="Withdrawn"),
-    ]
-
-    aggregate_application_snapshot(
-        cases,
-        audits,
-        today=TODAY,
-        output_fn=messages.append,
-    )
-
-    expected_messages = [
-        "Cases received: 2",
-        "Cases after Account certification status filter: 2",
-        "Cases after Case stage filter: 1",
-        "Cases after Scope Change filter: 1",
-        "Cases after Application record type filter: 1",
-        "unique qualifying Cases: 1",
-        "Audits after status filter: 1",
-        "Audits after type filter: 1",
-        "valid Audits: 1",
-        "valid Audits matched to qualifying Accounts: 1",
-        "latest Audits selected: 1",
-        "Cases matched to a latest Audit: 1",
-        "Cases without a matching latest Audit: 0",
-        "Cases classified: 1",
-    ]
-    assert all(
-        any(expected in message for message in messages)
-        for expected in expected_messages
-    )
 
 
 def test_writer_publishes_csv_atomically_and_suffixes_same_second(tmp_path):

--- a/tests/test_application_snapshot.py
+++ b/tests/test_application_snapshot.py
@@ -1,0 +1,376 @@
+import csv
+from datetime import UTC, date, datetime
+
+import pytest
+
+from aisc_salesforce.application_snapshot import (
+    APPLICATION_RECORD_TYPE_IDS,
+    APPLICATION_STAGES,
+    RECORD_TYPE_ALIASES,
+    ApplicationSnapshotError,
+    ApplicationSnapshotService,
+    aggregate_application_snapshot,
+    application_stage,
+    classify_application_type,
+    is_qualifying_case,
+    is_valid_audit,
+    select_latest_valid_audits,
+    write_application_snapshot,
+)
+
+TODAY = date(2026, 7, 23)
+FABRICATOR = "0125w0000013inhAAA"
+ERECTOR = "0125w0000013incAAA"
+INTERNATIONAL = "0125w0000013inrAAA"
+
+
+def case_record(**changes):
+    record = {
+        "Id": "case-1",
+        "AccountId": "account-1",
+        "RecordTypeId": FABRICATOR,
+        "Cert_Stage__c": "Doc_Audit",
+        "Cert_Is_this_a_scope_change__c": "No",
+        "Cert_Expedited_Application__c": False,
+        "Account": {
+            "BillingCountry": "United States",
+            "Cert_Certification_Status__c": "Initials",
+        },
+    }
+    account_changes = changes.pop("Account", None)
+    record.update(changes)
+    if account_changes is not None:
+        record["Account"].update(account_changes)
+    return record
+
+
+def audit_record(**changes):
+    record = {
+        "Id": "audit-1",
+        "Cert_Account__c": "account-1",
+        "Cert_Audit_Date__c": "2026-07-23",
+        "CreatedDate": "2026-07-01T12:00:00.000+0000",
+        "Cert_Audit_Status__c": "Scheduled",
+        "Cert_Audit_Type__c": "Initial",
+    }
+    record.update(changes)
+    return record
+
+
+def test_record_type_aliases_include_all_supplied_values():
+    assert RECORD_TYPE_ALIASES == {
+        "0125w000000BaAdAAK": "Scope Change",
+        "0125w000000BVTTAA4": "Web Question",
+        "0125w000000BXdEAAW": "Audit Date",
+        "0125w000000BZyIAAG": "Membership",
+        "0125w0000013incAAA": "Erector Application",
+        "0125w0000013inhAAA": "Fabricator Application",
+        "0125w0000013inrAAA": "International Application",
+        "012f20000012CCDAA2": "Certification",
+        "012f20000012CCEAA2": "Solutions Center",
+    }
+    assert APPLICATION_RECORD_TYPE_IDS == frozenset(
+        {FABRICATOR, ERECTOR, INTERNATIONAL}
+    )
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({}, True),
+        ({"Account": {"Cert_Certification_Status__c": "Certified"}}, False),
+        ({"Account": {"Cert_Certification_Status__c": None}}, False),
+        ({"Cert_Stage__c": "Cancelled"}, False),
+        ({"Cert_Stage__c": None}, True),
+        ({"Cert_Is_this_a_scope_change__c": "Yes"}, False),
+        ({"Cert_Is_this_a_scope_change__c": None}, True),
+        ({"RecordTypeId": "0125w000000BaAdAAK"}, False),
+        ({"Account": None}, False),
+    ],
+)
+def test_case_filter_includes_only_qualifying_applications(changes, expected):
+    if changes.get("Account", ...) is None:
+        record = case_record()
+        record["Account"] = None
+    else:
+        record = case_record(**changes)
+    assert is_qualifying_case(record) is expected
+
+
+@pytest.mark.parametrize("record_type_id", [FABRICATOR, ERECTOR, INTERNATIONAL])
+def test_each_application_record_type_is_allowed(record_type_id):
+    assert is_qualifying_case(case_record(RecordTypeId=record_type_id))
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({}, True),
+        ({"Cert_Audit_Status__c": "Cancelled"}, False),
+        ({"Cert_Audit_Status__c": "Withdrawn"}, False),
+        ({"Cert_Audit_Status__c": None}, True),
+        ({"Cert_Audit_Type__c": "Additional"}, False),
+        ({"Cert_Audit_Type__c": "Appeal"}, False),
+        ({"Cert_Audit_Type__c": "SA-NYC"}, False),
+        ({"Cert_Audit_Type__c": "Preassessment"}, False),
+        ({"Cert_Audit_Type__c": None}, True),
+    ],
+)
+def test_audit_filter_retains_null_status_and_type(changes, expected):
+    assert is_valid_audit(audit_record(**changes)) is expected
+
+
+def test_latest_valid_audit_uses_effective_date_created_date_and_id_tiebreakers():
+    audits = [
+        audit_record(
+            Id="dated",
+            Cert_Audit_Date__c="2026-07-10",
+            CreatedDate="2026-07-20T12:00:00Z",
+        ),
+        audit_record(
+            Id="undated-a",
+            Cert_Audit_Date__c=None,
+            CreatedDate="2026-07-21T12:00:00Z",
+        ),
+        audit_record(
+            Id="undated-b",
+            Cert_Audit_Date__c=None,
+            CreatedDate="2026-07-21T12:00:00Z",
+        ),
+        audit_record(
+            Id="ignored",
+            Cert_Audit_Date__c="2026-08-01",
+            Cert_Audit_Status__c="Cancelled",
+        ),
+    ]
+    assert select_latest_valid_audits(audits)["account-1"]["Id"] == "undated-b"
+
+
+def test_latest_valid_audit_breaks_effective_date_tie_with_created_date():
+    audits = [
+        audit_record(
+            Id="older-created",
+            CreatedDate="2026-07-01T12:00:00Z",
+        ),
+        audit_record(
+            Id="newer-created",
+            CreatedDate="2026-07-02T12:00:00Z",
+        ),
+    ]
+    assert select_latest_valid_audits(audits)["account-1"]["Id"] == "newer-created"
+
+
+@pytest.mark.parametrize(
+    ("case_stage", "audit_status", "audit_date", "expected"),
+    [
+        (
+            "Eligibility_Review",
+            "Pending Assignment",
+            "2026-08-01",
+            "Awaiting Audit Assignment",
+        ),
+        (None, None, None, "Initial Review"),
+        ("New_Application", None, None, "Initial Review"),
+        ("Eligibility_Review", "Scheduled", "2026-08-01", "Eligibility Review"),
+        ("Doc_Audit", "Reschedule", "2026-08-01", "Awaiting Audit Assignment"),
+        ("Doc_Audit", "Scheduled", None, "Awaiting Audit Assignment"),
+        ("Doc_Audit", "Scheduled", "2026-07-23", "Awaiting Audit"),
+        ("Doc_Audit", "Scheduled", "2026-07-22", "Awaiting CRG Decision"),
+        ("Doc_Audit", "Scheduled", "2026-07-24", "Awaiting Audit"),
+        ("Awaiting_Custom_Step", "Scheduled", "2026-08-01", "Awaiting Custom Step"),
+    ],
+)
+def test_application_stage_reproduces_tableau_branches(
+    case_stage, audit_status, audit_date, expected
+):
+    record = case_record(Cert_Stage__c=case_stage)
+    audit = (
+        audit_record(
+            Cert_Audit_Status__c=audit_status,
+            Cert_Audit_Date__c=audit_date,
+        )
+        if audit_status is not None or audit_date is not None
+        else None
+    )
+    assert application_stage(record, audit, today=TODAY) == expected
+
+
+def test_malformed_salesforce_dates_fail_clearly():
+    with pytest.raises(ApplicationSnapshotError, match="Cert_Audit_Date__c"):
+        application_stage(
+            case_record(),
+            audit_record(Cert_Audit_Date__c="not-a-date"),
+            today=TODAY,
+        )
+    with pytest.raises(ApplicationSnapshotError, match="CreatedDate"):
+        select_latest_valid_audits(
+            [audit_record(Cert_Audit_Date__c=None, CreatedDate="not-a-date")]
+        )
+
+
+@pytest.mark.parametrize(
+    ("country", "expedited", "expected"),
+    [
+        ("United States", False, "domestic_regular"),
+        ("United States", None, "domestic_regular"),
+        ("United States", "true", "domestic_regular"),
+        ("United States", True, "domestic_expedited"),
+        ("Canada", True, "international_regular"),
+        (None, True, "international_regular"),
+    ],
+)
+def test_origin_and_speed_use_exact_country_and_boolean_rules(
+    country, expedited, expected
+):
+    record = case_record(
+        Cert_Expedited_Application__c=expedited,
+        Account={"BillingCountry": country},
+    )
+    assert classify_application_type(record) == expected
+
+
+def test_invalid_audit_never_influences_application_stage():
+    cases = [case_record(Cert_Stage__c="Doc_Audit")]
+    audits = [
+        audit_record(
+            Id="valid-past",
+            Cert_Audit_Date__c="2026-07-20",
+            Cert_Audit_Status__c="Complete",
+        ),
+        audit_record(
+            Id="invalid-future",
+            Cert_Audit_Date__c="2026-08-20",
+            Cert_Audit_Status__c="Cancelled",
+        ),
+    ]
+
+    result = aggregate_application_snapshot(cases, audits, today=TODAY)
+
+    crg_row = next(
+        row
+        for row in result.rows
+        if row["application_stage"] == "Awaiting CRG Decision"
+    )
+    assert crg_row["domestic_regular"] == 1
+
+
+def test_aggregation_counts_each_case_once_and_keeps_all_official_rows():
+    cases = [
+        case_record(
+            Id="domestic-regular",
+            AccountId="regular",
+            Cert_Stage__c=None,
+        ),
+        case_record(
+            Id="domestic-fast",
+            AccountId="fast",
+            Cert_Stage__c=None,
+            Cert_Expedited_Application__c=True,
+        ),
+        case_record(
+            Id="international",
+            AccountId="international-account",
+            Cert_Stage__c=None,
+            Cert_Expedited_Application__c=True,
+            Account={"BillingCountry": "Canada"},
+        ),
+        case_record(
+            Id="unexpected",
+            AccountId="unexpected-account",
+            Cert_Stage__c="Zebra_Review",
+        ),
+        case_record(
+            Id="unexpected",
+            AccountId="unexpected-account",
+            Cert_Stage__c="Zebra_Review",
+        ),
+        case_record(Id="filtered", Cert_Stage__c="Cancelled"),
+    ]
+    result = aggregate_application_snapshot(cases, [], today=TODAY)
+
+    assert result.qualifying_case_count == 4
+    assert [row["application_stage"] for row in result.rows[:6]] == list(
+        APPLICATION_STAGES
+    )
+    assert result.rows[0] == {
+        "application_stage": "Initial Review",
+        "domestic_regular": 1,
+        "domestic_expedited": 1,
+        "international_regular": 1,
+    }
+    assert all(
+        row["domestic_regular"]
+        + row["domestic_expedited"]
+        + row["international_regular"]
+        == 0
+        for row in result.rows[1:6]
+    )
+    assert result.rows[-1]["application_stage"] == "Zebra Review"
+    assert result.rows[-1]["domestic_regular"] == 1
+    assert result.unexpected_stages == {"Zebra Review": 1}
+
+
+def test_unexpected_application_stages_are_sorted():
+    cases = [
+        case_record(Id="z", AccountId="z", Cert_Stage__c="Zeta"),
+        case_record(Id="a", AccountId="a", Cert_Stage__c="Alpha"),
+    ]
+    result = aggregate_application_snapshot(cases, [], today=TODAY)
+    assert [row["application_stage"] for row in result.rows[-2:]] == [
+        "Alpha",
+        "Zeta",
+    ]
+
+
+def test_service_queries_relationship_case_fields_and_minimal_audit_fields():
+    calls = []
+
+    class Client:
+        def query_records(self, object_name, fields, *, where=None, order_by=None):
+            calls.append((object_name, fields, where, order_by))
+            return []
+
+    result = ApplicationSnapshotService(Client(), today=TODAY).build()
+
+    assert result.qualifying_case_count == 0
+    case_call, audit_call = calls
+    assert case_call[0] == "Case"
+    assert "Account.BillingCountry" in case_call[1]
+    assert "Account.Cert_Certification_Status__c" in case_call[1]
+    assert "RecordTypeId" in case_call[1]
+    assert "Cert_Account__c" in audit_call[1]
+    assert "Cert_Audit_Date__c" in audit_call[1]
+    assert len(calls) == 2
+
+
+def test_writer_publishes_csv_atomically_and_suffixes_same_second(tmp_path):
+    result = aggregate_application_snapshot([], [], today=TODAY)
+    now = datetime(2026, 7, 23, 15, 30, tzinfo=UTC)
+
+    first = write_application_snapshot(result, tmp_path, now=now)
+    second = write_application_snapshot(result, tmp_path, now=now)
+
+    assert first.name == "2026-07-23T15-30-00Z"
+    assert second.name == "2026-07-23T15-30-00Z-01"
+    with (first / "application_snapshot.csv").open(newline="") as input_file:
+        rows = list(csv.DictReader(input_file))
+    assert len(rows) == 6
+    assert rows[0] == {
+        "application_stage": "Initial Review",
+        "domestic_regular": "0",
+        "domestic_expedited": "0",
+        "international_regular": "0",
+    }
+
+
+def test_writer_failure_leaves_no_partial_snapshot(tmp_path, monkeypatch):
+    result = aggregate_application_snapshot([], [], today=TODAY)
+    monkeypatch.setattr(
+        "aisc_salesforce.application_snapshot._write_application_csv",
+        lambda *args: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        write_application_snapshot(result, tmp_path)
+
+    assert not list(tmp_path.iterdir())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,7 @@ def test_application_snapshot_cli_uses_custom_output_and_prints_summary(
         def __init__(self, client):
             assert client == "client"
 
-        def build(self, *, output_fn):
-            output_fn("diagnostic")
+        def build(self):
             return result
 
     monkeypatch.setattr(app, "ApplicationSnapshotService", Service)
@@ -52,10 +51,9 @@ def test_application_snapshot_cli_uses_custom_output_and_prints_summary(
         )
         == 0
     )
-    assert output[0] == "diagnostic"
-    assert output[1] == "Warning: unexpected application stages: Surprise Stage (2)"
-    assert str(tmp_path / "run" / "application_snapshot.csv") in output[2]
-    assert output[3] == "qualifying Cases: 3"
+    assert output[0] == "Warning: unexpected application stages: Surprise Stage (2)"
+    assert str(tmp_path / "run" / "application_snapshot.csv") in output[1]
+    assert output[2] == "qualifying Cases: 3"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,8 @@ def test_application_snapshot_cli_uses_custom_output_and_prints_summary(
         def __init__(self, client):
             assert client == "client"
 
-        def build(self):
+        def build(self, *, output_fn):
+            output_fn("diagnostic")
             return result
 
     monkeypatch.setattr(app, "ApplicationSnapshotService", Service)
@@ -51,9 +52,10 @@ def test_application_snapshot_cli_uses_custom_output_and_prints_summary(
         )
         == 0
     )
-    assert output[0] == "Warning: unexpected application stages: Surprise Stage (2)"
-    assert str(tmp_path / "run" / "application_snapshot.csv") in output[1]
-    assert output[2] == "qualifying Cases: 3"
+    assert output[0] == "diagnostic"
+    assert output[1] == "Warning: unexpected application stages: Surprise Stage (2)"
+    assert str(tmp_path / "run" / "application_snapshot.csv") in output[2]
+    assert output[3] == "qualifying Cases: 3"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,78 @@
 from types import SimpleNamespace
 
+import pytest
+
 from aisc_salesforce import app
+from aisc_salesforce.application_snapshot import (
+    ApplicationSnapshotError,
+    ApplicationSnapshotResult,
+)
 from aisc_salesforce.dictionary import ExportField
 from aisc_salesforce.imis_contacts import ContactConsolidationError
 from aisc_salesforce.profile_updates import AutomationCounts
 from aisc_salesforce.rename_profile_update_cases import RenameCounts
+
+
+def test_application_snapshot_cli_uses_custom_output_and_prints_summary(
+    monkeypatch, tmp_path
+):
+    output = []
+    result = ApplicationSnapshotResult(
+        rows=(),
+        qualifying_case_count=3,
+        unexpected_stages={"Surprise Stage": 2},
+    )
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app, "get_credentials", lambda environment: {"ok": "yes"})
+    monkeypatch.setattr(app, "get_oauth_url", lambda environment: "token-url")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: "auth"
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: "client")
+
+    class Service:
+        def __init__(self, client):
+            assert client == "client"
+
+        def build(self):
+            return result
+
+    monkeypatch.setattr(app, "ApplicationSnapshotService", Service)
+    monkeypatch.setattr(
+        app,
+        "write_application_snapshot",
+        lambda report, output_dir: output_dir / "run",
+    )
+
+    assert (
+        app.main(
+            ["application-snapshot", "--output-dir", str(tmp_path)],
+            output_fn=output.append,
+        )
+        == 0
+    )
+    assert output[0] == "Warning: unexpected application stages: Surprise Stage (2)"
+    assert str(tmp_path / "run" / "application_snapshot.csv") in output[1]
+    assert output[2] == "qualifying Cases: 3"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ApplicationSnapshotError("bad date"),
+        app.SalesforceError("unavailable"),
+        OSError("disk full"),
+    ],
+)
+def test_application_snapshot_cli_reports_expected_failures(monkeypatch, capsys, error):
+    monkeypatch.setattr(
+        app,
+        "_run_application_snapshot",
+        lambda output_dir, **kwargs: (_ for _ in ()).throw(error),
+    )
+
+    assert app.main(["application-snapshot"]) == 1
+    assert f"Application snapshot failed: {error}" in capsys.readouterr().err
 
 
 def test_cli_success_uses_custom_output_dir(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Add a read-only application-snapshot CLI command for qualifying certification applications.
- Query Cases and Audits with pagination, apply application-stage and classification rules, and write atomic timestamped CSV reports.
- Add comprehensive tests and user/API documentation.

Closes #14

Tests: uv run pytest (235 passed)