### PR TITLE
Add resilient Contact resolution workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,11 @@ uv run aisc_salesforce stage-profile-updates \
   --output-dir /secure/staged-profile-updates
 ```
 
-Submissions are grouped by Account ID and the submitter email after trimming
-and case-insensitive comparison. Later nonblank values replace earlier values,
+Submissions are grouped by Account ID and a normalized submitter-email
+comparison key. Email values are trimmed and lowercased, then dots are removed
+from the local-part for comparison on every domain. Invalid basic email
+structures are preserved for review and produce a warning. Later nonblank
+values replace earlier values,
 except that every nonblank Comments and Other Personnel Notes value is
 preserved in submission order and joined with a newline. Different emails stay
 separate, and every blank-email submission stays separate and receives a
@@ -304,11 +307,28 @@ The CSV has shared submission and Account columns, Key Data columns, and
 prefixed role columns for `certification_`, `principal_`, `accounting_`,
 `quality_`, and `new_york_`. Role columns preserve submitted values and record
 the proposed resolution action, Contact ID, resolution source, source
-submission/role, and any role-specific warning. New York does not have a title
-column. When an existing Contact is resolved, a missing title or phone is
+submission/role, and any role-specific warning. These readable columns remain
+for compatibility. The authoritative `contact_resolutions` column is a JSON
+list with one entry per distinct comparison key. Each entry records its
+`classification` (`use_existing`, `create_new`, `likely_typo`, or `ambiguous`),
+normalized email, comparison key, submitter/role sources, candidate and
+selected Contacts, reason, confidence, warnings, and submitted details.
+New York does not have a title column. When an existing Contact is resolved, a
+missing title or phone is
 filled from that Contact where possible. Repeating the same contact information
 in several roles does not create a warning, but conflicting emails for the same
 submitted name are treated as ambiguous.
+
+Contact searches prefer the Account's **family accounts**: the target Account,
+its parent Account, and its **sibling accounts** that have the same parent. A
+root Account with no parent has only itself in its family. Exact normalized and
+unique dot-insensitive email matches are safe. Name-derived local-parts use
+normalized first/last names and initials. Differing domains, generic mailboxes,
+multiple candidates, external Contacts, and other weak evidence require an
+operator choice. Only one insertion, deletion, substitution, or adjacent
+transposition is presented as a likely typo, and it still requires
+confirmation. A trailing square-bracket suffix on a Salesforce Contact name is
+ignored only while comparing; the original value remains visible and audited.
 
 `has_key_updates` is `true` only when at least one source has the exact
 Salesforce `Type__c` value `"Key Data"`. Populated Key Data fields remain
@@ -361,7 +381,8 @@ when the combined update has no submitted update content. At the Continue/Quit
 checkpoint, press Enter, type `C`, or type `Continue` to review that row. Type
 `Q` or `Quit` to stop safely. Only this checkpoint has a default; change
 decisions always require an explicit answer. Published CSV files must include
-both new metadata columns; older staged files fail validation.
+the complete current contract, including `contact_resolutions`; older staged
+files fail validation.
 
 Each real field change accepts a shortcut or its complete decision phrase:
 
@@ -373,21 +394,36 @@ Each real field change accepts a shortcut or its complete decision phrase:
 Shortcuts and phrases are case-insensitive. Audit entries always store the
 complete phrase.
 
-Already-current values are recorded as no-ops and do not prompt. For each
-submitted Contact role, the command searches all Salesforce Contacts for the
-exact submitted email address. One match is fetched and each mismatched
-submitted field is reviewed separately. No match leads to an explicit Contact
-creation decision. In both cases, assigning the resolved Contact to the
-Account role is a separate decision. Potential-contact lists are never shown.
-More than one exact-email match is audited as an error; the Case stays Pending
-and its source submissions remain open for a safe retry. A Contact without the
-Salesforce-required Last Name cannot be created automatically.
+All staged-row checkpoints are completed before Salesforce changes begin.
+Every distinct submitter or role email is then resolved once for the whole Case
+batch. Ambiguous matches show candidates and allow the reviewer to select one,
+create a new Contact, or ignore only that email. Likely typos show the suggested
+Contact and comparison key and require confirmation. Approved Contact creates
+and field updates finish first, non-role Account changes follow, and Account
+role assignments happen last. Several rows or roles with the same comparison
+key reuse the same result. A role without an email keeps its current
+Account-role Contact and cannot create one automatically.
+
+When a submitter email is also used by a role, the richer role details are used
+for Contact work. Otherwise the submitter name is split at its final space.
+Creating a submitter Contact still requires the normal explicit decision. A
+Contact created by that decision is assigned to `Case.ContactId` and both
+writes are audited separately. Merely matching an existing submitter Contact
+does not change `Case.ContactId`.
 
 Before individual fields are reviewed, an existing Contact's name, title,
 email, and phone are shown together. The submitted values are shown together
 before a new-Contact decision. Account-role proposals show current and proposed
 Contact names and emails; Salesforce Contact IDs remain internal to writes and
 the audit trail instead of appearing in decision prompts.
+
+If a Contact create is blocked by Salesforce with `DUPLICATES_DETECTED`, the
+structured error is retained and the reviewer can create manually, update an
+existing Contact manually, use a Contact with another email, or ignore that
+entry. Manual recovery is verified by querying the normalized submitted email;
+the alternate-email choice queries the entered email. Multiple results always
+require an explicit candidate selection. Unrelated Salesforce errors remain
+fatal and leave the Case retryable.
 
 Comments, Other Personnel notes, Key Update answers, effective dates, warnings,
 and same-day Account History are shown once at the beginning of each Case
@@ -403,6 +439,10 @@ response_emails.txt
 ```
 
 The JSON Lines audit is flushed after every decision and Salesforce result.
+Contact events include classification, comparison key, candidates, selected
+Contact, reason, confidence, and warnings. Operator selections, duplicate
+recovery, ignored entries, Contact writes, Case Contact assignment, and role
+assignments are separate events.
 The response file contains one generated paragraph per submitter email.
 Account-information changes keep the `ITEM: NEW INFORMATION` and
 `Replaces OLD INFORMATION` format. Each submitted Contact role is consolidated

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ uncataloged queried picklist) are informational and return `0`. Authentication,
 metadata, or query failures return `1`. The command writes no files and makes
 no Salesforce changes.
 
+### Salesforce picklist values in code
+
+When changing a Salesforce picklist value in Python, use the matching enum from
+`aisc_salesforce.salesforce_enums` rather than repeating the quoted value.
+New picklist fields must be added to both their enum and `SALESFORCE_ENUMS`,
+then covered by a focused test. See the [developer enum-catalog
+rule](docs/usage.md#developer-rule-use-the-salesforce-enum-catalog) for the
+complete workflow.
+
 ### Application snapshot
 
 `application-snapshot` reads Salesforce but does not create or update Salesforce

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,6 +143,26 @@ the resulting rows atomically in a timestamped directory. Rows include
 blocking-safe Case match fields plus Key Update presence and earliest-date
 metadata.
 
+## Contact resolution
+
+::: aisc_salesforce.contact_resolution
+    options:
+      show_root_heading: true
+      members:
+        - ContactResolutionClassification
+        - ContactSource
+        - ContactResolution
+        - normalize_email
+        - family_account_ids
+        - name_local_part_patterns
+        - is_single_edit_or_transposition
+        - resolve_contact
+
+The Contact-resolution helpers contain the deterministic matching rules used
+by both staging and interactive review. They do not access Salesforce directly,
+which keeps normalization, family matching, and likely-typo behavior easy to
+test.
+
 ## Interactive Profile Update processing
 
 ::: aisc_salesforce.process_profile_updates

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,5 @@ audited interactive review command for approved Account and Contact changes.
 ## Quick Links
 
 - [Usage Guide](usage.md) — installation and running instructions
+- [Enum catalog rule](usage.md#developer-rule-use-the-salesforce-enum-catalog) — required approach for Salesforce picklist values
 - [API Reference](api.md) — auto-generated from source code

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,38 @@ cp .env.example .env
 The CLI loads `.env` without replacing environment variables that are already
 set.
 
+## Developer rule: use the Salesforce enum catalog
+
+When adding or changing code that uses a Salesforce **picklist** value, use
+the matching `StrEnum` from `aisc_salesforce.salesforce_enums` instead of
+putting the value in quotes in the script. This applies to values used in
+SOQL filters, Python comparisons, and payloads sent to Salesforce.
+
+```python
+from .salesforce_enums import CaseStatus
+
+# Good: one named, reusable definition of the Salesforce value.
+where = f"Status = '{CaseStatus.PENDING}'"
+payload = {"Status": CaseStatus.CLOSED}
+
+# Avoid: a second, easy-to-mistype copy of the Salesforce value.
+where = "Status = 'Pending'"
+```
+
+If Salesforce has a picklist field that is not yet cataloged:
+
+1. Add a clearly named member to the appropriate enum in
+   `src/aisc_salesforce/salesforce_enums.py`.
+2. Add the `(object_name, field_name)` entry to `SALESFORCE_ENUMS` so the
+   audit can check it.
+3. Use that enum member in the workflow and add or update a focused test.
+4. Run `uv run pytest` and, when Salesforce credentials are available,
+   `uv run aisc_salesforce audit-picklist-enums`.
+
+This rule is for Salesforce picklist values, such as `"Pending"` or
+`"Participant Portal"`. Field API names (such as `"Status"`) and ordinary
+display text are not picklist values, so they do not belong in this catalog.
+
 ## Picklist enum audit command
 
 Run the manual, read-only audit with the standard Salesforce credentials:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -471,9 +471,13 @@ failed. A failed write leaves no partially published snapshot.
 
 ### Merge rules
 
-Rows are grouped by Account ID plus a trimmed, case-insensitive submitter email.
-Submissions with different Account IDs or emails stay separate. Each submission
-with a blank email also stays separate and receives a warning.
+Rows are grouped by Account ID plus a submitter-email comparison key. Email
+values are trimmed and lowercased, and dots are removed from the local-part for
+comparison on every domain. For example, `a.smith@example.com` and
+`asmith@example.com` share a key. Submissions with different Account IDs or
+comparison keys stay separate. Each submission with a blank email also stays
+separate and receives a warning. A nonblank value that fails the basic email
+structure check is preserved and warned about instead of being silently fixed.
 
 Within a group, submissions are ordered by `CreatedDate` and `Id`. Later
 nonblank values replace earlier values, while blank later values do not erase
@@ -494,6 +498,7 @@ Each row contains these groups of columns:
 |---|---|
 | Source and dates | `source_submission_ids`, `source_submission_names`, `earliest_submission_date`, `latest_submission_date` |
 | Account and submitter | `account_id`, `account_name`, `certification_id`, `submitter_name`, `submitter_email`, `submitter_phone` |
+| Contact resolution | `contact_resolutions` JSON list |
 | Notes and review | `comments`, `personnel_notes`, `has_contact_derived_values`, `has_no_update_content`, `has_warnings`, `warnings` |
 | Key Data | `effective_date`, revised company name/owner, five revised address columns, and `key_answers` |
 | Contact roles | Columns prefixed with `certification_`, `principal_`, `accounting_`, `quality_`, and `new_york_` |
@@ -509,7 +514,19 @@ contains its submitted name, title, email, and phone fields, followed by:
 - `warning`
 
 New York has no submitted title field. Completely blank roles have completely
-blank role columns.
+blank role columns. The prefixed resolution columns are readable projections
+kept for compatibility; `contact_resolutions` is the authoritative contract.
+
+Each JSON entry represents one distinct comparison key shared by any submitter
+and role occurrences. It contains:
+
+- `classification`: `use_existing`, `create_new`, `likely_typo`, or
+  `ambiguous`
+- `normalized_email` and `comparison_key`
+- `sources`, identifying submitter and role occurrences
+- `candidates` and `selected_contact`
+- `reason`, `confidence`, and `warnings`
+- `submitted`, containing the best available Contact details
 
 Resolution actions are `update_contact` for an exact match or a title/phone
 update, `change_email` for a new email applied to the Account's current role
@@ -520,18 +537,23 @@ warning for human review. Resolution sources show whether the match came from
 another submitted role, submitted data for a new Contact, an Account Contact, a
 sibling Account Contact, or the Account's current role lookup.
 
-Contact text is compared after trimming and case folding. The resolver does not
-guess nicknames. Name searches stop at the first tier containing candidates:
-other submitted roles, the current Account's Contacts, then Contacts belonging
-to sibling Accounts with the same Parent. Multiple candidates at that first
-tier are reported as ambiguous. Repeated identical contact information in
-several submitted roles counts as one candidate; the same name paired with
-conflicting emails remains ambiguous. When a Contact is resolved, missing title
-and phone values are filled from that Contact where possible. Missing title or
-phone alone does not cause a warning. `has_contact_derived_values` is `true`
-only when a nonblank title or phone was actually copied from another submitted
-role or a Salesforce Contact. Values submitted directly for that role do not
-set the flag.
+The target Account's **family accounts** are the target itself, its parent, and
+its **sibling accounts** with the same parent. A root Account without a parent
+has a family containing only itself. Contacts from this family are preferred.
+One exact normalized or dot-insensitive family match can resolve directly.
+Ties, matches mixed with external Accounts, generic/shared mailbox names,
+differing domains, and weaker name-only evidence require operator review.
+
+Name-derived local-parts use normalized first and last names and initials. A
+trailing square-bracket suffix on a Salesforce Contact name is removed only
+for comparison; the original Salesforce text stays in displays and audit
+events. The only likely-typo rule is one insertion, deletion, substitution, or
+adjacent transposition. Even that classification requires confirmation; the
+resolver does not guess nicknames or use a broad fuzzy-score threshold.
+Repeated occurrences with the same comparison key resolve once. When a Contact
+is resolved, missing title and phone values are filled where possible.
+`has_contact_derived_values` is `true` only when a nonblank title or phone was
+actually copied from another submitted role or a Salesforce Contact.
 
 `has_no_update_content` is `true` when the grouped raw submissions contain no
 Key Data fields, role fields, Comments, or Other Personnel Notes. Account,
@@ -543,12 +565,11 @@ flag off.
 
 !!! warning
 
-    The interactive processor requires `has_contact_derived_values` and
-    `has_no_update_content` in addition to the existing CSV columns. Older
-    staged CSV files fail validation. It also inspects `has_warnings` and
-    `warnings` before acting on a row. The `warnings` field is readable,
-    newline-separated text; role warnings are also copied into the matching
-    prefixed `warning` column.
+    The interactive processor validates the complete current CSV contract,
+    including `contact_resolutions`, `has_contact_derived_values`, and
+    `has_no_update_content`. It also inspects `has_warnings` and `warnings`
+    before acting on a row. Generate a fresh CSV for each processing run rather
+    than migrating an older staged file.
 
 Case preparation adds `case_id`, `case_number`, `case_status`, and
 `case_match_status`. A row is processable only when its match status is
@@ -632,21 +653,28 @@ audit always stores the complete phrase.
 An already-current value is an audited no-op. It does not prompt and does not
 appear in response-email text.
 
-For every submitted Contact role with an email address, the command searches
-all Salesforce Contacts using that exact email:
+All row checkpoints are shown before the first Salesforce write. Processing
+then uses these ordered phases:
 
-- With one match, it fetches that Contact and compares every submitted
-  nonblank field. Each mismatch is a separate three-decision proposal.
-- With no match, it asks for one explicit decision about creating a Contact
-  under the Account. Automatic creation requires a Last Name; incomplete data
-  must be completed manually or declined.
-- With more than one match, it does not guess. The ambiguity is written as a
-  failed audit entry, processing for the Case stops, the Case stays Pending,
-  and the source Profile Updates stay open.
+1. Resolve every distinct submitter and role comparison key for the Case.
+2. Show ambiguous candidates and collect all operator choices. A reviewer may
+   select one, create a Contact, or ignore only that email. A likely typo shows
+   its suggested Contact and corrected comparison and requires confirmation.
+3. Finish all approved Contact creates and field updates.
+4. Process non-role Account changes.
+5. Assign resolved Contacts to Account roles.
 
-No candidate list or Contact-selection prompt is shown. After a Contact is
-created or an exact match is reviewed, assigning that Contact to the Account
-role is always handled as a separate proposal.
+The same resolved Contact is reused when several roles or rows share a key.
+Roles without email keep their current Account-role Contact; they cannot create
+a new Contact automatically. Ignoring an email skips only its resolutions and
+roles.
+
+When submitter and role email keys match, richer role details take precedence.
+Otherwise `Name__c` is split at the final space for possible Contact creation.
+Creation still requires an explicit decision. If that decision creates the
+submitter Contact, its ID is assigned to `Case.ContactId`; the Contact create
+and Case update are audited separately. Matching an existing submitter Contact
+alone never changes `Case.ContactId`.
 
 For an exact match, the Contact's current name, title, email, and phone are
 displayed together before its individual fields. For a new Contact, all
@@ -654,6 +682,26 @@ submitted details are displayed together before the creation decision.
 Account-role proposals use friendly Contact names and emails for the current
 and proposed values. Salesforce IDs remain available internally for record
 writes and audit entries, but are not exposed in decision prompts.
+
+### Duplicate-create recovery
+
+Salesforce [duplicate rules](https://help.salesforce.com/s/articleView?id=sales.duplicate_rules_overview.htm&language=en_US&type=5)
+can block an API create with `DUPLICATES_DETECTED`. The error code and
+Salesforce message are retained.
+Instead of ending the Case immediately, the reviewer chooses one of four
+actions:
+
+1. Create the Contact manually.
+2. Update an existing Contact manually.
+3. Use a Contact with another email.
+4. Ignore this entry.
+
+Manual create and update choices are verified by querying the normalized
+submitted email. The alternate-email choice queries the entered email.
+Multiple matches show candidates and require an explicit selection. The
+verified Contact can continue to later role assignment. Ignore affects only
+the shared email key. Other Salesforce errors are still fatal and leave the
+Case and source submissions retryable.
 
 ### Output and finalization
 
@@ -687,7 +735,12 @@ After a resolved batch, source Profile Updates are set to `Closed`. Answering
 so the Case is also set to `Closed`. If a response is not sent, the source
 records are closed and the Case stays `Pending`.
 
-On interruption, a Salesforce failure, or a manual value that does not verify,
+Contact audit objects include classification, comparison key, candidates,
+selected Contact, reason, confidence, and warnings. Operator selections,
+duplicate recovery, ignored entries, Contact writes, Case Contact assignment,
+and later Account-role assignments are separate, immediately flushed events.
+
+On interruption, an unrelated Salesforce failure, or a manual value that does not verify,
 the audit is flushed, unfinalized source Profile Updates stay open, the Case is
 kept Pending, and the command exits nonzero. Retrying restages open records.
 Values applied before the interruption are fetched again and recorded as

--- a/src/aisc_salesforce/contact_resolution.py
+++ b/src/aisc_salesforce/contact_resolution.py
@@ -1,0 +1,511 @@
+"""Conservative, reusable Contact matching for Profile Update submissions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+BRACKET_SUFFIX_PATTERN = re.compile(r"\s*\[[^\[\]]*\]\s*$")
+NON_NAME_PATTERN = re.compile(r"[^a-z0-9]+")
+
+GENERIC_LOCAL_PARTS = frozenset(
+    {
+        "admin",
+        "administration",
+        "accounting",
+        "ap",
+        "billing",
+        "certification",
+        "contact",
+        "customerservice",
+        "finance",
+        "hello",
+        "info",
+        "mail",
+        "office",
+        "quality",
+        "reception",
+        "sales",
+        "service",
+        "support",
+        "team",
+    }
+)
+
+
+class ContactResolutionClassification(StrEnum):
+    """The four outcomes produced by conservative Contact matching."""
+
+    USE_EXISTING = "use_existing"
+    CREATE_NEW = "create_new"
+    LIKELY_TYPO = "likely_typo"
+    AMBIGUOUS = "ambiguous"
+
+
+# Short public alias for callers that do not need the longer domain name.
+ContactClassification = ContactResolutionClassification
+
+
+@dataclass(frozen=True)
+class ContactSource:
+    """One place where an email appeared in a staged row."""
+
+    kind: str
+    role: str = ""
+    submission_id: str = ""
+
+    def as_dict(self) -> dict[str, str]:
+        """Return a JSON-safe representation."""
+        return {
+            "kind": self.kind,
+            "role": self.role,
+            "submission_id": self.submission_id,
+        }
+
+
+@dataclass
+class ContactResolution:
+    """A complete, auditable decision about one comparison email."""
+
+    classification: ContactResolutionClassification
+    normalized_email: str
+    comparison_key: str
+    sources: list[ContactSource] = field(default_factory=list)
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+    selected_contact: dict[str, Any] | None = None
+    reason: str = ""
+    confidence: str = ""
+    warnings: list[str] = field(default_factory=list)
+    submitted: dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the stable JSON contract used in staging and audit files."""
+        return {
+            "classification": self.classification.value,
+            "normalized_email": self.normalized_email,
+            "comparison_key": self.comparison_key,
+            "sources": [source.as_dict() for source in self.sources],
+            "candidates": [contact_snapshot(item) for item in self.candidates],
+            "selected_contact": (
+                contact_snapshot(self.selected_contact)
+                if self.selected_contact is not None
+                else None
+            ),
+            "reason": self.reason,
+            "confidence": self.confidence,
+            "warnings": list(self.warnings),
+            "submitted": dict(self.submitted),
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> ContactResolution:
+        """Rebuild a resolution read from the staging CSV."""
+        return cls(
+            classification=ContactResolutionClassification(value["classification"]),
+            normalized_email=str(value.get("normalized_email", "")),
+            comparison_key=str(value.get("comparison_key", "")),
+            sources=[
+                ContactSource(
+                    kind=str(item.get("kind", "")),
+                    role=str(item.get("role", "")),
+                    submission_id=str(item.get("submission_id", "")),
+                )
+                for item in value.get("sources", [])
+                if isinstance(item, dict)
+            ],
+            candidates=[
+                dict(item)
+                for item in value.get("candidates", [])
+                if isinstance(item, dict)
+            ],
+            selected_contact=(
+                dict(value["selected_contact"])
+                if isinstance(value.get("selected_contact"), dict)
+                else None
+            ),
+            reason=str(value.get("reason", "")),
+            confidence=str(value.get("confidence", "")),
+            warnings=[str(item) for item in value.get("warnings", [])],
+            submitted={
+                str(key): str(item) for key, item in value.get("submitted", {}).items()
+            },
+        )
+
+
+def normalize_email(value: Any) -> tuple[str, str, list[str]]:
+    """Normalize an email and build its dot-insensitive comparison key.
+
+    The comparison rule deliberately removes dots from every local-part, not
+    only Gmail addresses. The normalized email keeps the dots for display and
+    Salesforce writes.
+    """
+    normalized = str(value or "").strip().casefold()
+    warnings: list[str] = []
+    if not normalized:
+        return "", "", warnings
+    if not EMAIL_PATTERN.fullmatch(normalized):
+        warnings.append(f"Invalid email address: {normalized!r}.")
+        return normalized, "", warnings
+    local_part, domain = normalized.rsplit("@", 1)
+    return normalized, f"{local_part.replace('.', '')}@{domain}", warnings
+
+
+def is_generic_mailbox(email: str) -> bool:
+    """Return whether an address looks shared rather than person-specific."""
+    normalized, _, _ = normalize_email(email)
+    if not normalized:
+        return False
+    local_part = NON_NAME_PATTERN.sub("", normalized.rsplit("@", 1)[0])
+    return local_part in GENERIC_LOCAL_PARTS
+
+
+def comparison_name(value: Any) -> str:
+    """Normalize a name after removing one trailing ``[suffix]`` marker."""
+    without_suffix = BRACKET_SUFFIX_PATTERN.sub("", str(value or "").strip())
+    return NON_NAME_PATTERN.sub("", without_suffix.casefold())
+
+
+def name_local_part_patterns(first_name: Any, last_name: Any) -> set[str]:
+    """Build deterministic email local-part patterns from names and initials."""
+    first = comparison_name(first_name)
+    last = comparison_name(last_name)
+    if not first and not last:
+        return set()
+    if not first:
+        return {last}
+    if not last:
+        return {first}
+    return {
+        first,
+        last,
+        first + last,
+        last + first,
+        first[0] + last,
+        first + last[0],
+        last + first[0],
+        first[0] + last[0],
+    }
+
+
+def is_single_edit_or_transposition(left: str, right: str) -> bool:
+    """Return whether two strings differ by exactly one simple typo."""
+    if left == right:
+        return False
+    if len(left) == len(right):
+        differences = [
+            index
+            for index, pair in enumerate(zip(left, right, strict=True))
+            if pair[0] != pair[1]
+        ]
+        if len(differences) == 1:
+            return True
+        return (
+            len(differences) == 2
+            and differences[1] == differences[0] + 1
+            and left[differences[0]] == right[differences[1]]
+            and left[differences[1]] == right[differences[0]]
+        )
+    if abs(len(left) - len(right)) != 1:
+        return False
+    shorter, longer = (left, right) if len(left) < len(right) else (right, left)
+    for index in range(len(longer)):
+        if longer[:index] + longer[index + 1 :] == shorter:
+            return True
+    return False
+
+
+def family_account_ids(
+    target_account: dict[str, Any] | None,
+    accounts: list[dict[str, Any]],
+) -> set[str]:
+    """Return IDs for the target Account, its parent, and its siblings."""
+    if not target_account:
+        return set()
+    target_id = str(target_account.get("Id") or "").strip()
+    parent_id = str(target_account.get("ParentId") or "").strip()
+    if not target_id:
+        return set()
+    result = {target_id}
+    if not parent_id:
+        return result
+    result.add(parent_id)
+    result.update(
+        str(account.get("Id") or "").strip()
+        for account in accounts
+        if str(account.get("ParentId") or "").strip() == parent_id
+    )
+    result.discard("")
+    return result
+
+
+def resolve_contact(
+    email: Any,
+    contacts: list[dict[str, Any]],
+    family_ids: set[str],
+    *,
+    sources: list[ContactSource] | None = None,
+    submitted: dict[str, str] | None = None,
+) -> ContactResolution:
+    """Classify one submitted email using cautious family-first matching."""
+    normalized, key, warnings = normalize_email(email)
+    details = dict(submitted or {})
+    source_values = list(sources or [])
+    if not normalized or not key:
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            reason="The submitted email is blank or invalid and needs operator review.",
+            confidence="none",
+            warnings=warnings,
+            submitted=details,
+        )
+
+    prepared = [
+        (
+            contact,
+            normalize_email(contact.get("Email")),
+            str(contact.get("AccountId") or "").strip() in family_ids,
+        )
+        for contact in contacts
+    ]
+    if is_generic_mailbox(normalized):
+        warnings.append("The email appears to be a generic or shared mailbox.")
+        generic_candidates = [
+            contact
+            for contact, (candidate_email, candidate_key, _), _ in prepared
+            if candidate_email == normalized or candidate_key == key
+        ]
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            candidates=_unique_contacts(generic_candidates),
+            reason="Generic mailbox names require an operator choice.",
+            confidence="operator_required",
+            warnings=warnings,
+            submitted=details,
+        )
+
+    family_exact = [
+        contact
+        for contact, (candidate_email, _, _), in_family in prepared
+        if in_family and candidate_email == normalized
+    ]
+    external_exact = [
+        contact
+        for contact, (candidate_email, _, _), in_family in prepared
+        if not in_family and candidate_email == normalized
+    ]
+    if len(family_exact) == 1 and not external_exact:
+        return _existing_resolution(
+            normalized,
+            key,
+            source_values,
+            details,
+            family_exact,
+            family_exact[0],
+            "A family Contact has the exact normalized email.",
+            "exact",
+            warnings,
+        )
+    if family_exact or external_exact:
+        candidates = [*family_exact, *external_exact]
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            candidates=candidates,
+            reason="Exact matches are tied or mixed between family and external Accounts.",
+            confidence="operator_required",
+            warnings=warnings,
+            submitted=details,
+        )
+
+    family_key = [
+        contact
+        for contact, (_, candidate_key, _), in_family in prepared
+        if in_family and candidate_key and candidate_key == key
+    ]
+    external_key = [
+        contact
+        for contact, (_, candidate_key, _), in_family in prepared
+        if not in_family and candidate_key and candidate_key == key
+    ]
+    if len(family_key) == 1 and not external_key:
+        return _existing_resolution(
+            normalized,
+            key,
+            source_values,
+            details,
+            family_key,
+            family_key[0],
+            "A family Contact has the same dot-insensitive comparison key.",
+            "exact_comparison_key",
+            warnings,
+        )
+    if family_key or external_key:
+        candidates = [*family_key, *external_key]
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            candidates=candidates,
+            reason="Comparison-key matches are tied or include an external Account.",
+            confidence="operator_required",
+            warnings=warnings,
+            submitted=details,
+        )
+
+    local_part, domain = key.rsplit("@", 1)
+    strong: list[dict[str, Any]] = []
+    typo: list[dict[str, Any]] = []
+    differing_domain: list[dict[str, Any]] = []
+    for contact, (candidate_email, _, _), in_family in prepared:
+        if not in_family:
+            continue
+        patterns = name_local_part_patterns(
+            contact.get("FirstName"), contact.get("LastName")
+        )
+        if not patterns:
+            continue
+        candidate_domain = (
+            candidate_email.rsplit("@", 1)[1] if "@" in candidate_email else ""
+        )
+        if local_part in patterns:
+            if candidate_domain == domain:
+                strong.append(contact)
+            else:
+                differing_domain.append(contact)
+        elif candidate_domain == domain and any(
+            is_single_edit_or_transposition(local_part, pattern) for pattern in patterns
+        ):
+            typo.append(contact)
+
+    name_candidates = _unique_contacts([*strong, *differing_domain])
+    if name_candidates:
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            candidates=name_candidates,
+            reason=(
+                "Name-derived evidence or a differing email domain is not strong "
+                "enough for automatic selection."
+            ),
+            confidence="operator_required",
+            warnings=warnings,
+            submitted=details,
+        )
+    typo = _unique_contacts(typo)
+    if len(typo) == 1:
+        return ContactResolution(
+            ContactResolutionClassification.LIKELY_TYPO,
+            normalized,
+            key,
+            source_values,
+            candidates=typo,
+            selected_contact=typo[0],
+            reason="The local-part is one edit or one adjacent transposition from a name pattern.",
+            confidence="likely_typo",
+            warnings=warnings,
+            submitted=details,
+        )
+    if len(typo) > 1:
+        return ContactResolution(
+            ContactResolutionClassification.AMBIGUOUS,
+            normalized,
+            key,
+            source_values,
+            candidates=typo,
+            reason="More than one family Contact is a likely one-character typo match.",
+            confidence="operator_required",
+            warnings=warnings,
+            submitted=details,
+        )
+    return ContactResolution(
+        ContactResolutionClassification.CREATE_NEW,
+        normalized,
+        key,
+        source_values,
+        reason="No safe existing Contact match was found.",
+        confidence="no_match",
+        warnings=warnings,
+        submitted=details,
+    )
+
+
+def merge_resolution(
+    existing: ContactResolution,
+    incoming: ContactResolution,
+) -> ContactResolution:
+    """Merge repeated appearances of the same comparison email."""
+    existing.sources.extend(
+        source for source in incoming.sources if source not in existing.sources
+    )
+    for key, value in incoming.submitted.items():
+        if value and not existing.submitted.get(key):
+            existing.submitted[key] = value
+    existing.warnings.extend(
+        warning for warning in incoming.warnings if warning not in existing.warnings
+    )
+    return existing
+
+
+def contact_snapshot(contact: dict[str, Any] | None) -> dict[str, Any]:
+    """Keep the small set of Contact fields needed for review and audit."""
+    if contact is None:
+        return {}
+    return {
+        name: contact.get(name)
+        for name in (
+            "Id",
+            "AccountId",
+            "FirstName",
+            "LastName",
+            "Title",
+            "Email",
+            "Phone",
+        )
+    }
+
+
+def _existing_resolution(
+    normalized: str,
+    key: str,
+    sources: list[ContactSource],
+    submitted: dict[str, str],
+    candidates: list[dict[str, Any]],
+    selected: dict[str, Any],
+    reason: str,
+    confidence: str,
+    warnings: list[str],
+) -> ContactResolution:
+    return ContactResolution(
+        ContactResolutionClassification.USE_EXISTING,
+        normalized,
+        key,
+        sources,
+        candidates=candidates,
+        selected_contact=selected,
+        reason=reason,
+        confidence=confidence,
+        warnings=warnings,
+        submitted=submitted,
+    )
+
+
+def _unique_contacts(contacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for contact in contacts:
+        identity = str(contact.get("Id") or "").strip() or repr(contact)
+        by_id.setdefault(identity, contact)
+    return list(by_id.values())

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -13,6 +13,16 @@ from pathlib import Path
 from typing import Any, TextIO
 from zoneinfo import ZoneInfo
 
+from .contact_resolution import (
+    ContactResolution,
+    ContactResolutionClassification,
+    ContactSource,
+    contact_snapshot,
+    family_account_ids,
+    merge_resolution,
+    normalize_email,
+    resolve_contact,
+)
 from .profile_updates import AutomationCounts, escape_soql_string
 from .queried_fields import (
     ACCOUNT_HISTORY_FIELDS,
@@ -139,6 +149,12 @@ class ChangeProposal:
     case_number: str = ""
     context: str = ""
     warnings: str = ""
+    classification: str = ""
+    comparison_key: str = ""
+    candidates: tuple[dict[str, Any], ...] = ()
+    selected_contact: dict[str, Any] | None = None
+    reason: str = ""
+    confidence: str = ""
 
 
 @dataclass(frozen=True)
@@ -150,6 +166,8 @@ class ActionResult:
     status: ActionStatus
     action: str = ""
     error: str = ""
+    error_code: str = ""
+    salesforce_message: str = ""
 
 
 @dataclass
@@ -197,6 +215,16 @@ class _RoleResponse:
     contact_details: str
     previous_details: str
     changed: bool
+
+
+@dataclass
+class _ResolvedContact:
+    """The runtime outcome for one batch-wide email resolution."""
+
+    resolution: ContactResolution
+    contact_id: str = ""
+    ignored: bool = False
+    contact_results: list[ActionResult] | None = None
 
 
 class ProfileUpdateProcessingWorkflow:
@@ -281,6 +309,20 @@ def read_staged_profile_updates(path: Path) -> list[dict[str, str]]:
             raise ProcessingError(
                 f"Staging CSV row {number} has no source submission IDs."
             )
+        contact_resolutions = row.get("contact_resolutions", "").strip()
+        if contact_resolutions:
+            try:
+                raw_resolutions = json.loads(contact_resolutions)
+                if not isinstance(raw_resolutions, list):
+                    raise TypeError
+                for raw_resolution in raw_resolutions:
+                    if not isinstance(raw_resolution, dict):
+                        raise TypeError
+                    ContactResolution.from_dict(raw_resolution)
+            except (AttributeError, KeyError, TypeError, ValueError) as error:
+                raise ProcessingError(
+                    f"Staging CSV row {number} has invalid Contact resolutions."
+                ) from error
     return rows
 
 
@@ -382,10 +424,18 @@ class _AuditWriter:
             "proposed_value": proposal.proposed_value,
             "context": proposal.context,
             "warnings": proposal.warnings,
+            "classification": proposal.classification,
+            "comparison_key": proposal.comparison_key,
+            "candidates": list(proposal.candidates),
+            "selected_contact": proposal.selected_contact,
+            "reason": proposal.reason,
+            "confidence": proposal.confidence,
             "decision": result.decision.value if result.decision else "",
             "action": result.action,
             "result": result.status.value,
             "error": result.error,
+            "error_code": result.error_code,
+            "salesforce_message": result.salesforce_message,
             "timestamp": self.now().astimezone(UTC).isoformat(),
         }
         self.output.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
@@ -491,6 +541,14 @@ class InteractiveProfileUpdateProcessor:
         )
 
     def _review_batch(self, batch: CaseBatch, response_writer: _ResponseWriter) -> bool:
+        if any(row.get("contact_resolutions", "").strip() for row in batch.rows):
+            return self._review_resilient_batch(batch, response_writer)
+        return self._review_legacy_batch(batch, response_writer)
+
+    def _review_legacy_batch(
+        self, batch: CaseBatch, response_writer: _ResponseWriter
+    ) -> bool:
+        """Process staging files from before the Contact-resolution contract."""
         account_name = next(
             (
                 row.get("account_name", "").strip()
@@ -576,6 +634,824 @@ class InteractiveProfileUpdateProcessor:
         )
         return not all_sent
 
+    def _review_resilient_batch(
+        self, batch: CaseBatch, response_writer: _ResponseWriter
+    ) -> bool:
+        """Resolve all Contacts first, then apply Account and role changes."""
+        account_name = next(
+            (
+                row.get("account_name", "").strip()
+                for row in batch.rows
+                if row.get("account_name", "").strip()
+            ),
+            batch.account_id,
+        )
+        self.output_fn(
+            _section_heading(
+                f"Case {batch.case_number or batch.case_id}: {account_name}"
+            )
+        )
+        fresh_by_id = self._fresh_case_submissions(batch)
+        self._show_case_context(batch, fresh_by_id)
+        self._show_account_history(batch, list(fresh_by_id.values()))
+
+        # Every row checkpoint happens before the first Salesforce write.
+        for row in batch.rows:
+            self._checkpoint_row(row)
+
+        resolutions = self._fresh_batch_resolutions(batch, fresh_by_id)
+        resolved: dict[str, _ResolvedContact] = {}
+        for key, resolution in resolutions.items():
+            row = self._row_for_resolution(batch, resolution)
+            resolved[key] = self._review_resolution_choice(batch, row, resolution)
+
+        self._update_status_with_audit(
+            batch,
+            batch.case_id,
+            "Case",
+            "Status",
+            CaseStatus.PENDING,
+            action="prepare batch",
+        )
+
+        results: list[ActionResult] = []
+        for state in resolved.values():
+            row = self._row_for_resolution(batch, state.resolution)
+            contact_results = self._complete_contact_work(batch, row, state)
+            state.contact_results = contact_results
+            results.extend(contact_results)
+
+        no_email_results = self._review_no_email_role_contacts(batch, fresh_by_id)
+        results.extend(no_email_results)
+
+        account_results: list[ActionResult] = []
+        for row in batch.rows:
+            fresh_submissions = [
+                fresh_by_id[source_id]
+                for source_id in _json_string_list(row["source_submission_ids"])
+            ]
+            reviewed = self._review_account_proposals(batch, row, fresh_submissions)
+            account_results.extend(reviewed)
+            results.extend(reviewed)
+
+        role_responses: list[_RoleResponse] = []
+        for row in batch.rows:
+            fresh_submissions = [
+                fresh_by_id[source_id]
+                for source_id in _json_string_list(row["source_submission_ids"])
+            ]
+            reviewed, responses = self._assign_resolved_roles(
+                batch,
+                row,
+                fresh_submissions,
+                resolved,
+            )
+            results.extend(reviewed)
+            role_responses.extend(responses)
+
+        return self._finish_batch(
+            batch,
+            response_writer,
+            results,
+            account_results,
+            role_responses,
+        )
+
+    def _fresh_batch_resolutions(
+        self,
+        batch: CaseBatch,
+        fresh_by_id: dict[str, dict[str, Any]],
+    ) -> dict[str, ContactResolution]:
+        """Reload staged decisions against fresh family and exact-email Contacts."""
+        staged: dict[str, ContactResolution] = {}
+        invalid_index = 0
+        for row in batch.rows:
+            try:
+                raw_items = json.loads(row.get("contact_resolutions", "") or "[]")
+            except (TypeError, ValueError) as error:
+                raise ProcessingError(
+                    "A staged contact_resolutions value is not valid JSON."
+                ) from error
+            if not isinstance(raw_items, list):
+                raise ProcessingError(
+                    "A staged contact_resolutions value must contain a JSON list."
+                )
+            for raw_item in raw_items:
+                if not isinstance(raw_item, dict):
+                    raise ProcessingError(
+                        "A staged Contact resolution must be a JSON object."
+                    )
+                try:
+                    resolution = ContactResolution.from_dict(raw_item)
+                except (
+                    AttributeError,
+                    KeyError,
+                    TypeError,
+                    ValueError,
+                ) as error:
+                    raise ProcessingError(
+                        "A staged Contact resolution has invalid fields."
+                    ) from error
+                key = resolution.comparison_key
+                if not key:
+                    invalid_index += 1
+                    key = f"invalid:{invalid_index}:{resolution.normalized_email}"
+                if key in staged:
+                    merge_resolution(staged[key], resolution)
+                    if any(source.kind == "role" for source in resolution.sources):
+                        staged[key].submitted.update(
+                            {
+                                field_name: value
+                                for field_name, value in resolution.submitted.items()
+                                if value
+                            }
+                        )
+                else:
+                    staged[key] = resolution
+
+        refreshed: dict[str, ContactResolution] = {}
+        invalid_index = 0
+        for staged_resolution in staged.values():
+            sources = staged_resolution.sources or [ContactSource("unknown")]
+            for source in sources:
+                details = self._fresh_source_contact_details(
+                    source,
+                    fresh_by_id,
+                    staged_resolution.submitted,
+                )
+                email = details.get("email") or staged_resolution.normalized_email
+                normalized, comparison_key, _ = normalize_email(email)
+                key = comparison_key
+                if not comparison_key:
+                    invalid_index += 1
+                    key = f"invalid:{invalid_index}:{normalized}"
+                if key not in refreshed:
+                    refreshed[key] = ContactResolution(
+                        staged_resolution.classification,
+                        normalized,
+                        comparison_key,
+                        sources=[source],
+                        reason=staged_resolution.reason,
+                        confidence=staged_resolution.confidence,
+                        warnings=list(staged_resolution.warnings),
+                        submitted=details,
+                    )
+                else:
+                    refreshed[key].sources.append(source)
+                    refreshed[key].warnings.extend(
+                        warning
+                        for warning in staged_resolution.warnings
+                        if warning not in refreshed[key].warnings
+                    )
+                    if source.kind == "role":
+                        refreshed[key].submitted.update(
+                            {
+                                field_name: value
+                                for field_name, value in details.items()
+                                if value
+                            }
+                        )
+        staged = refreshed
+
+        family_ids = self._fresh_family_account_ids(batch)
+        contacts: list[dict[str, Any]] = []
+        for resolution in staged.values():
+            if not resolution.normalized_email:
+                continue
+            contacts.extend(
+                self.client.query_records(
+                    "Contact",
+                    CONTACT_REVIEW_FIELDS,
+                    where=(
+                        f"Email = '{escape_soql_string(resolution.normalized_email)}'"
+                    ),
+                    order_by="Id ASC",
+                )
+            )
+        if family_ids:
+            quoted_ids = ", ".join(
+                f"'{escape_soql_string(account_id)}'"
+                for account_id in sorted(family_ids)
+            )
+            contacts.extend(
+                self.client.query_records(
+                    "Contact",
+                    CONTACT_REVIEW_FIELDS,
+                    where=f"AccountId IN ({quoted_ids})",
+                    order_by="AccountId ASC, Id ASC",
+                )
+            )
+        contacts = list(
+            {
+                _display(contact.get("Id")) or repr(contact): dict(contact)
+                for contact in contacts
+            }.values()
+        )
+
+        fresh: dict[str, ContactResolution] = {}
+        for key, staged_resolution in staged.items():
+            resolution = resolve_contact(
+                staged_resolution.normalized_email,
+                contacts,
+                family_ids,
+                sources=staged_resolution.sources,
+                submitted=staged_resolution.submitted,
+            )
+            resolution.warnings = list(
+                dict.fromkeys([*staged_resolution.warnings, *resolution.warnings])
+            )
+            fresh[key] = resolution
+        return fresh
+
+    @staticmethod
+    def _fresh_source_contact_details(
+        source: ContactSource,
+        fresh_by_id: dict[str, dict[str, Any]],
+        fallback: dict[str, str],
+    ) -> dict[str, str]:
+        """Overlay fresh submission values on staged Contact details."""
+        details = dict(fallback)
+        record = fresh_by_id.get(source.submission_id)
+        if record is None:
+            return details
+        if source.kind == "submitter":
+            first_name, last_name = _split_person_name(_display(record.get("Name__c")))
+            fresh_values = {
+                "first_name": first_name,
+                "last_name": last_name,
+                "email": _display(record.get("Email__c")),
+                "phone": _display(record.get("Phone__c")),
+            }
+        else:
+            role = next(
+                (
+                    definition
+                    for definition in ROLE_DEFINITIONS
+                    if definition.prefix == source.role
+                ),
+                None,
+            )
+            if role is None:
+                return details
+            fresh_values = {
+                suffix: _display(record.get(source_field))
+                for suffix, source_field in role.submitted_fields
+            }
+        details.update(
+            {field_name: value for field_name, value in fresh_values.items() if value}
+        )
+        return details
+
+    def _fresh_family_account_ids(self, batch: CaseBatch) -> set[str]:
+        target = self.client.get_record("Account", batch.account_id, ["Id", "ParentId"])
+        parent_id = _display(target.get("ParentId"))
+        family_accounts = [target]
+        if parent_id:
+            family_accounts.extend(
+                self.client.query_records(
+                    "Account",
+                    ["Id", "ParentId"],
+                    where=(
+                        f"Id = '{escape_soql_string(parent_id)}' OR "
+                        f"ParentId = '{escape_soql_string(parent_id)}'"
+                    ),
+                    order_by="Id ASC",
+                )
+            )
+        return family_account_ids(target, family_accounts)
+
+    def _row_for_resolution(
+        self, batch: CaseBatch, resolution: ContactResolution
+    ) -> dict[str, str]:
+        source_ids = {
+            source.submission_id
+            for source in resolution.sources
+            if source.submission_id
+        }
+        return next(
+            (
+                row
+                for row in batch.rows
+                if source_ids.intersection(
+                    _json_string_list(row["source_submission_ids"])
+                )
+            ),
+            batch.rows[0],
+        )
+
+    def _review_resolution_choice(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        resolution: ContactResolution,
+    ) -> _ResolvedContact:
+        """Finish all operator choices without changing Salesforce."""
+        if resolution.classification is ContactResolutionClassification.USE_EXISTING:
+            self._audit_resolution(
+                batch,
+                row,
+                resolution,
+                ActionStatus.NOOP,
+                "automatic exact Contact selection",
+            )
+            return _ResolvedContact(
+                resolution,
+                contact_id=_display((resolution.selected_contact or {}).get("Id")),
+            )
+
+        if resolution.classification is ContactResolutionClassification.CREATE_NEW:
+            self._audit_resolution(
+                batch,
+                row,
+                resolution,
+                ActionStatus.NOOP,
+                "no safe existing Contact match",
+            )
+            return _ResolvedContact(resolution)
+
+        if resolution.classification is ContactResolutionClassification.LIKELY_TYPO:
+            candidate = resolution.selected_contact or resolution.candidates[0]
+            self._show_contact_details("Suggested Contact", candidate)
+            candidate_email, candidate_key, _ = normalize_email(candidate.get("Email"))
+            self.output_fn(
+                "Likely email typo: "
+                f"{resolution.normalized_email} was compared as "
+                f"{resolution.comparison_key}. The suggested correction is "
+                f"{candidate_email or '(blank)'} ({candidate_key or 'no valid key'})."
+            )
+            try:
+                confirmed = self._prompt_yes_no(
+                    "Use this suggested Contact? [yes/no]: "
+                )
+            except StopIteration as error:
+                raise ProcessingError(
+                    "A likely typo Contact requires operator confirmation."
+                ) from error
+            if confirmed:
+                resolution.selected_contact = candidate
+                self._audit_resolution(
+                    batch,
+                    row,
+                    resolution,
+                    ActionStatus.VERIFIED_MANUAL,
+                    "confirm likely typo Contact",
+                )
+                return _ResolvedContact(
+                    resolution, contact_id=_display(candidate.get("Id"))
+                )
+            resolution.classification = ContactResolutionClassification.AMBIGUOUS
+            resolution.reason = "The operator rejected the likely typo suggestion."
+
+        return self._prompt_ambiguous_resolution(batch, row, resolution)
+
+    def _prompt_ambiguous_resolution(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        resolution: ContactResolution,
+    ) -> _ResolvedContact:
+        self.output_fn(
+            _section_heading(
+                f"Contact resolution for "
+                f"{resolution.normalized_email or '(invalid email)'}",
+                ITEM_SEPARATOR,
+            )
+        )
+        for index, candidate in enumerate(resolution.candidates, start=1):
+            self._show_contact_details(f"Candidate {index}", candidate)
+        while True:
+            candidate_range = (
+                f"1-{len(resolution.candidates)}, " if resolution.candidates else ""
+            )
+            try:
+                answer = (
+                    self.input_fn(f"Contact choice [{candidate_range}create/ignore]: ")
+                    .strip()
+                    .casefold()
+                )
+            except StopIteration as error:
+                raise ProcessingError(
+                    "Multiple Salesforce Contacts require an explicit "
+                    "operator selection."
+                ) from error
+            if answer in {"create", "c"}:
+                resolution.classification = ContactResolutionClassification.CREATE_NEW
+                resolution.selected_contact = None
+                resolution.reason = "The operator chose to create a new Contact."
+                self._audit_resolution(
+                    batch,
+                    row,
+                    resolution,
+                    ActionStatus.NOOP,
+                    "operator selected create new Contact",
+                )
+                return _ResolvedContact(resolution)
+            if answer in {"ignore", "i"}:
+                resolution.selected_contact = None
+                resolution.reason = "The operator ignored this email entry."
+                self._audit_resolution(
+                    batch,
+                    row,
+                    resolution,
+                    ActionStatus.REJECTED,
+                    "operator ignored Contact resolution",
+                )
+                return _ResolvedContact(resolution, ignored=True)
+            if answer.isdigit() and 1 <= int(answer) <= len(resolution.candidates):
+                selected = resolution.candidates[int(answer) - 1]
+                resolution.selected_contact = selected
+                resolution.reason = "The operator selected an existing Contact."
+                self._audit_resolution(
+                    batch,
+                    row,
+                    resolution,
+                    ActionStatus.VERIFIED_MANUAL,
+                    "operator selected existing Contact",
+                )
+                return _ResolvedContact(
+                    resolution, contact_id=_display(selected.get("Id"))
+                )
+            self.output_fn("Choose a candidate number, create, or ignore.")
+
+    def _audit_resolution(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        resolution: ContactResolution,
+        status: ActionStatus,
+        action: str,
+    ) -> None:
+        proposal = self._proposal(
+            batch,
+            row,
+            target_object="Contact",
+            target_record_id=_display((resolution.selected_contact or {}).get("Id")),
+            field_name="resolution",
+            label="Contact resolution",
+            original_value="",
+            proposed_value=resolution.normalized_email,
+            resolution=resolution,
+        )
+        self._append_audit(ActionResult(proposal, None, status, action=action))
+
+    def _complete_contact_work(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        state: _ResolvedContact,
+    ) -> list[ActionResult]:
+        resolution = state.resolution
+        if state.ignored:
+            return []
+        if state.contact_id:
+            results = self._review_existing_contact_fields(
+                batch,
+                row,
+                resolution,
+                state.contact_id,
+            )
+        else:
+            label = self._resolution_label(resolution)
+            created = self._review_new_contact(
+                batch,
+                row,
+                label,
+                resolution.submitted,
+                resolution=resolution,
+            )
+            results = [created]
+            if created.status in {
+                ActionStatus.APPLIED,
+                ActionStatus.VERIFIED_MANUAL,
+            }:
+                state.contact_id = created.proposal.target_record_id
+                resolution.selected_contact = self.client.get_record(
+                    "Contact", state.contact_id, CONTACT_REVIEW_FIELDS
+                )
+
+        created_contact = any(
+            result.proposal.target_record_id == state.contact_id
+            and result.proposal.field_name == "Contact"
+            and (
+                result.action == "create Contact"
+                or "manual Contact creation" in result.action
+            )
+            and result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
+            for result in results
+        )
+        is_submitter = any(source.kind == "submitter" for source in resolution.sources)
+        if created_contact and is_submitter and state.contact_id:
+            results.append(
+                self._assign_created_submitter_to_case(
+                    batch, row, resolution, state.contact_id
+                )
+            )
+        return results
+
+    def _review_existing_contact_fields(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        resolution: ContactResolution,
+        contact_id: str,
+    ) -> list[ActionResult]:
+        contact = self.client.get_record("Contact", contact_id, CONTACT_REVIEW_FIELDS)
+        self._show_contact_details(
+            f"Resolved {self._resolution_label(resolution)}",
+            contact,
+        )
+        results: list[ActionResult] = []
+        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+            proposed = resolution.submitted.get(suffix, "")
+            if not proposed:
+                continue
+            if (
+                suffix == "email"
+                and resolution.classification
+                is ContactResolutionClassification.LIKELY_TYPO
+            ):
+                continue
+            proposal = self._proposal(
+                batch,
+                row,
+                target_object="Contact",
+                target_record_id=contact_id,
+                field_name=contact_field,
+                label=f"{self._resolution_label(resolution)} {field_label}",
+                proposed_value=proposed,
+                resolution=resolution,
+            )
+            results.append(self._review_proposal(proposal))
+        return results
+
+    def _review_no_email_role_contacts(
+        self,
+        batch: CaseBatch,
+        fresh_by_id: dict[str, dict[str, Any]],
+    ) -> list[ActionResult]:
+        """Apply partial role updates to the current role Contact only."""
+        results: list[ActionResult] = []
+        reviewed: set[tuple[str, str, str]] = set()
+        for row in batch.rows:
+            submissions = [
+                fresh_by_id[source_id]
+                for source_id in _json_string_list(row["source_submission_ids"])
+            ]
+            for role in ROLE_DEFINITIONS:
+                submitted = {
+                    suffix: (
+                        _latest_nonblank(submissions, source_field)
+                        or row.get(f"{role.prefix}_{suffix}", "").strip()
+                    )
+                    for suffix, source_field in role.submitted_fields
+                }
+                if not any(submitted.values()) or submitted.get("email"):
+                    continue
+                contact_id, contact = self._fresh_role_contact(
+                    batch, role.account_lookup
+                )
+                if not contact_id or contact is None:
+                    resolution = ContactResolution(
+                        ContactResolutionClassification.AMBIGUOUS,
+                        "",
+                        "",
+                        sources=[ContactSource("role", role=role.prefix)],
+                        reason=(
+                            "A role without email has no current Account-role "
+                            "Contact and cannot create one automatically."
+                        ),
+                        confidence="none",
+                        warnings=[
+                            "Role without email was ignored because its current "
+                            "Account-role Contact is blank."
+                        ],
+                        submitted=submitted,
+                    )
+                    self._audit_resolution(
+                        batch,
+                        row,
+                        resolution,
+                        ActionStatus.REJECTED,
+                        "ignore role without email and current Contact",
+                    )
+                    continue
+                for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+                    proposed = submitted.get(suffix, "")
+                    identity = (contact_id, contact_field, proposed)
+                    if not proposed or identity in reviewed:
+                        continue
+                    reviewed.add(identity)
+                    results.append(
+                        self._review_proposal(
+                            self._proposal(
+                                batch,
+                                row,
+                                target_object="Contact",
+                                target_record_id=contact_id,
+                                field_name=contact_field,
+                                label=f"{role.label} Contact {field_label}",
+                                proposed_value=proposed,
+                            )
+                        )
+                    )
+        return results
+
+    def _assign_created_submitter_to_case(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        resolution: ContactResolution,
+        contact_id: str,
+    ) -> ActionResult:
+        proposal = self._proposal(
+            batch,
+            row,
+            target_object="Case",
+            target_record_id=batch.case_id,
+            field_name="ContactId",
+            label="Case Submitter Contact",
+            original_value="",
+            proposed_value=contact_id,
+            resolution=resolution,
+        )
+        try:
+            self.client.update_record("Case", batch.case_id, {"ContactId": contact_id})
+        except SalesforceError as error:
+            result = ActionResult(
+                proposal,
+                None,
+                ActionStatus.FAILED,
+                action="assign created submitter Contact to Case",
+                error=str(error),
+            )
+            self._append_audit(result)
+            raise ProcessingError(str(error)) from error
+        result = ActionResult(
+            proposal,
+            None,
+            ActionStatus.APPLIED,
+            action="assign created submitter Contact to Case",
+        )
+        self._append_audit(result)
+        return result
+
+    def _assign_resolved_roles(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        submissions: list[dict[str, Any]],
+        resolved: dict[str, _ResolvedContact],
+    ) -> tuple[list[ActionResult], list[_RoleResponse]]:
+        results: list[ActionResult] = []
+        responses: list[_RoleResponse] = []
+        for role in ROLE_DEFINITIONS:
+            submitted = {
+                suffix: (
+                    _latest_nonblank(submissions, source_field)
+                    or row.get(f"{role.prefix}_{suffix}", "").strip()
+                )
+                for suffix, source_field in role.submitted_fields
+            }
+            if not any(submitted.values()):
+                continue
+            original_id, original_contact = self._fresh_role_contact(
+                batch, role.account_lookup
+            )
+            email = submitted.get("email", "")
+            if not email:
+                final_contact = (
+                    self.client.get_record(
+                        "Contact", original_id, CONTACT_REVIEW_FIELDS
+                    )
+                    if original_id
+                    else None
+                )
+                responses.append(
+                    self._build_role_response(
+                        row,
+                        role.label,
+                        final_contact,
+                        original_contact,
+                        changed=final_contact != original_contact,
+                    )
+                )
+                continue
+            normalized, key, _ = normalize_email(email)
+            state = resolved.get(key)
+            if state is None and normalized:
+                state = next(
+                    (
+                        candidate
+                        for candidate in resolved.values()
+                        if candidate.resolution.normalized_email == normalized
+                    ),
+                    None,
+                )
+            if state is None or state.ignored or not state.contact_id:
+                responses.append(
+                    self._build_role_response(
+                        row,
+                        role.label,
+                        original_contact,
+                        original_contact,
+                        changed=False,
+                    )
+                )
+                continue
+            final_contact = self.client.get_record(
+                "Contact", state.contact_id, CONTACT_REVIEW_FIELDS
+            )
+            result = self._review_proposal(
+                self._proposal(
+                    batch,
+                    row,
+                    target_object="Account",
+                    target_record_id=batch.account_id,
+                    field_name=role.account_lookup,
+                    label=f"{role.label} Account Role",
+                    proposed_value=state.contact_id,
+                    resolution=state.resolution,
+                ),
+                original_display=_contact_name_email(original_contact),
+                proposed_display=_contact_name_email(final_contact),
+            )
+            results.append(result)
+            changed = result.status in {
+                ActionStatus.APPLIED,
+                ActionStatus.VERIFIED_MANUAL,
+            }
+            responses.append(
+                self._build_role_response(
+                    row,
+                    role.label,
+                    final_contact
+                    if result.status is not ActionStatus.REJECTED
+                    else original_contact,
+                    original_contact,
+                    changed=changed,
+                )
+            )
+        return results, responses
+
+    @staticmethod
+    def _resolution_label(resolution: ContactResolution) -> str:
+        role_names = [
+            source.role.replace("_", " ").title()
+            for source in resolution.sources
+            if source.kind == "role" and source.role
+        ]
+        if role_names:
+            return "/".join(dict.fromkeys(role_names)) + " Contact"
+        return "Submitter Contact"
+
+    def _finish_batch(
+        self,
+        batch: CaseBatch,
+        response_writer: _ResponseWriter,
+        results: list[ActionResult],
+        account_results: list[ActionResult],
+        role_responses: list[_RoleResponse],
+    ) -> bool:
+        emails = format_response_emails(account_results, role_responses)
+        all_sent = True
+        for email, text in emails.items():
+            response_writer.append(batch.case_id, email, text)
+            self.output_fn(
+                f"{_section_heading(f'Response email for {email}', ITEM_SEPARATOR)}"
+                f"\n{text}"
+            )
+            sent = self._prompt_yes_no(
+                f"Was the response email to {email} sent? [yes/no]: "
+            )
+            all_sent = all_sent and sent
+
+        successful_without_email = any(
+            result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
+            and not result.proposal.submitter_email.strip()
+            for result in results
+        )
+        missing_role_email = any(
+            not response.submitter_email.strip() for response in role_responses
+        )
+        all_sent = all_sent and not successful_without_email and not missing_role_email
+        for source_id in batch.source_submission_ids:
+            self._update_status_with_audit(
+                batch,
+                source_id,
+                "Company_Profile_Change__c",
+                "Status__c",
+                ProfileChangeStatus.CLOSED,
+            )
+        case_status = CaseStatus.CLOSED if all_sent else CaseStatus.PENDING
+        self._update_status_with_audit(
+            batch,
+            batch.case_id,
+            "Case",
+            "Status",
+            case_status,
+        )
+        return not all_sent
+
     def _checkpoint_row(self, row: dict[str, str]) -> None:
         account_name = (
             row.get("account_name", "").strip() or row.get("account_id", "").strip()
@@ -600,8 +1476,7 @@ class InteractiveProfileUpdateProcessor:
             )
         if row.get("has_no_update_content") == "true":
             heading += (
-                "\nNote: this combined profile update has no submitted "
-                "update content."
+                "\nNote: this combined profile update has no submitted update content."
             )
         self.output_fn(_section_heading(heading, ITEM_SEPARATOR))
         while True:
@@ -970,6 +1845,8 @@ class InteractiveProfileUpdateProcessor:
         row: dict[str, str],
         role_label: str,
         submitted: dict[str, str],
+        *,
+        resolution: ContactResolution | None = None,
     ) -> ActionResult:
         last_name = submitted.get("last_name", "")
         payload: dict[str, str] = {"AccountId": batch.account_id}
@@ -986,6 +1863,7 @@ class InteractiveProfileUpdateProcessor:
             label=f"{role_label} Contact",
             proposed_value=payload,
             original_value="",
+            resolution=resolution,
         )
         submitted_contact = {
             contact_field: submitted.get(suffix, "")
@@ -1006,7 +1884,8 @@ class InteractiveProfileUpdateProcessor:
         )
         decision = self._review_decision(
             proposal,
-            automatic_allowed=bool(last_name),
+            automatic_allowed=bool(last_name)
+            and (resolution is None or bool(resolution.comparison_key)),
             action="create Contact",
         )
 
@@ -1087,6 +1966,7 @@ class InteractiveProfileUpdateProcessor:
                 **{
                     **proposal.__dict__,
                     "target_record_id": contact_id,
+                    "selected_contact": contact_snapshot(fresh),
                 }
             )
             result = ActionResult(
@@ -1101,6 +1981,14 @@ class InteractiveProfileUpdateProcessor:
         try:
             contact_id = self.client.create_record("Contact", payload)
         except SalesforceError as error:
+            if resolution is not None and _is_duplicate_contact_error(error):
+                return self._recover_duplicate_contact(
+                    batch,
+                    row,
+                    proposal,
+                    resolution,
+                    error,
+                )
             result = ActionResult(
                 proposal,
                 decision,
@@ -1114,6 +2002,7 @@ class InteractiveProfileUpdateProcessor:
             **{
                 **proposal.__dict__,
                 "target_record_id": contact_id,
+                "selected_contact": contact_snapshot({"Id": contact_id, **payload}),
             }
         )
         result = ActionResult(
@@ -1124,6 +2013,142 @@ class InteractiveProfileUpdateProcessor:
         )
         self._append_audit(result)
         return result
+
+    def _recover_duplicate_contact(
+        self,
+        batch: CaseBatch,
+        row: dict[str, str],
+        proposal: ChangeProposal,
+        resolution: ContactResolution,
+        error: SalesforceError,
+    ) -> ActionResult:
+        """Recover a Contact create that Salesforce's duplicate rule blocked."""
+        self._append_audit(
+            ActionResult(
+                proposal,
+                ReviewDecision.APPLY_AUTOMATICALLY,
+                ActionStatus.FAILED,
+                action="Salesforce duplicate rule blocked Contact create",
+                error=str(error),
+                error_code=error.error_code or "",
+                salesforce_message=error.salesforce_message or "",
+            )
+        )
+        self.output_fn(
+            "Salesforce blocked this Contact create as a possible duplicate."
+        )
+        choices = {
+            "1": "create_manually",
+            "create manually": "create_manually",
+            "2": "update_manually",
+            "update an existing contact manually": "update_manually",
+            "3": "alternate_email",
+            "use a contact with another email": "alternate_email",
+            "4": "ignore",
+            "ignore this entry": "ignore",
+        }
+        while True:
+            answer = (
+                self.input_fn(
+                    "Duplicate recovery [1/create manually, "
+                    "2/update an existing Contact manually, "
+                    "3/use a Contact with another email, "
+                    "4/ignore this entry]: "
+                )
+                .strip()
+                .casefold()
+            )
+            choice = choices.get(answer)
+            if choice is None:
+                self.output_fn("Choose 1, 2, 3, or 4.")
+                continue
+            if choice == "ignore":
+                resolution.reason = (
+                    "The operator ignored a Salesforce duplicate-rule failure."
+                )
+                ignored_proposal = ChangeProposal(
+                    **{
+                        **proposal.__dict__,
+                        "reason": resolution.reason,
+                    }
+                )
+                ignored = ActionResult(
+                    ignored_proposal,
+                    ReviewDecision.WILL_NOT_BE_MADE,
+                    ActionStatus.REJECTED,
+                    action="ignore duplicate Contact entry",
+                    error=str(error),
+                    error_code=error.error_code or "",
+                    salesforce_message=error.salesforce_message or "",
+                )
+                self._append_audit(ignored)
+                return ignored
+
+            if choice == "alternate_email":
+                alternate = self.input_fn("Enter the existing Contact's other email: ")
+                normalized, _, warnings = normalize_email(alternate)
+                if warnings or not normalized:
+                    self.output_fn("Enter a valid email address.")
+                    continue
+                contact = self._select_contact_by_email(normalized)
+                action = "use alternate-email Contact after duplicate failure"
+            else:
+                instruction = (
+                    "Create the Contact manually"
+                    if choice == "create_manually"
+                    else "Update an existing Contact manually"
+                )
+                self.input_fn(f"{instruction}, then press Enter to verify by email: ")
+                contact = self._select_contact_by_email(resolution.normalized_email)
+                action = (
+                    "verify manual Contact creation after duplicate failure"
+                    if choice == "create_manually"
+                    else "verify manual Contact update after duplicate failure"
+                )
+            if contact is None:
+                self.output_fn(
+                    "No Contact was found with that email; choose a recovery "
+                    "option again."
+                )
+                continue
+            contact_id = _display(contact.get("Id"))
+            resolution.selected_contact = contact
+            resolution.reason = "The operator completed duplicate-create recovery."
+            verified_proposal = ChangeProposal(
+                **{
+                    **proposal.__dict__,
+                    "target_record_id": contact_id,
+                    "selected_contact": contact_snapshot(contact),
+                    "reason": resolution.reason,
+                }
+            )
+            result = ActionResult(
+                verified_proposal,
+                ReviewDecision.MAKE_MANUALLY,
+                ActionStatus.VERIFIED_MANUAL,
+                action=action,
+            )
+            self._append_audit(result)
+            return result
+
+    def _select_contact_by_email(self, email: str) -> dict[str, Any] | None:
+        contacts = self.client.query_records(
+            "Contact",
+            CONTACT_REVIEW_FIELDS,
+            where=f"Email = '{escape_soql_string(email)}'",
+            order_by="Id ASC",
+        )
+        if not contacts:
+            return None
+        if len(contacts) == 1:
+            return dict(contacts[0])
+        for index, contact in enumerate(contacts, start=1):
+            self._show_contact_details(f"Candidate {index}", contact)
+        while True:
+            answer = self.input_fn(f"Select Contact [1-{len(contacts)}]: ").strip()
+            if answer.isdigit() and 1 <= int(answer) <= len(contacts):
+                return dict(contacts[int(answer) - 1])
+            self.output_fn("Choose one candidate number.")
 
     def _proposal(
         self,
@@ -1136,6 +2161,7 @@ class InteractiveProfileUpdateProcessor:
         label: str,
         proposed_value: Any,
         original_value: Any | None = None,
+        resolution: ContactResolution | None = None,
     ) -> ChangeProposal:
         return ChangeProposal(
             source_submission_ids=tuple(
@@ -1153,7 +2179,32 @@ class InteractiveProfileUpdateProcessor:
             original_value=original_value,
             proposed_value=proposed_value,
             context=_proposal_context(row),
-            warnings=row.get("warnings", ""),
+            warnings="\n".join(
+                value
+                for value in (
+                    row.get("warnings", ""),
+                    ("\n".join(resolution.warnings) if resolution is not None else ""),
+                )
+                if value
+            ),
+            classification=(
+                resolution.classification.value if resolution is not None else ""
+            ),
+            comparison_key=(
+                resolution.comparison_key if resolution is not None else ""
+            ),
+            candidates=(
+                tuple(contact_snapshot(item) for item in resolution.candidates)
+                if resolution is not None
+                else ()
+            ),
+            selected_contact=(
+                contact_snapshot(resolution.selected_contact)
+                if resolution is not None and resolution.selected_contact is not None
+                else None
+            ),
+            reason=resolution.reason if resolution is not None else "",
+            confidence=resolution.confidence if resolution is not None else "",
         )
 
     def _review_proposal(
@@ -1660,8 +2711,36 @@ def _display(value: Any) -> str:
     return str(value).strip()
 
 
+def _split_person_name(value: Any) -> tuple[str, str]:
+    """Split a submitter name at the final space."""
+    parts = _display(value).rsplit(maxsplit=1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    if parts:
+        return "", parts[0]
+    return "", ""
+
+
 def _values_equal(current: Any, proposed: Any) -> bool:
     return _display(current) == _display(proposed)
+
+
+def _is_duplicate_contact_error(error: SalesforceError) -> bool:
+    """Recognize duplicate-rule responses without hiding unrelated failures."""
+    if error.error_code == "DUPLICATES_DETECTED":
+        return True
+    duplicate_messages = {
+        "use one of these records?",
+        (
+            "you're creating a duplicate record. we recommend you use an "
+            "existing record instead."
+        ),
+    }
+    salesforce_message = (error.salesforce_message or "").strip().casefold()
+    if salesforce_message in duplicate_messages:
+        return True
+    readable = str(error).strip().casefold()
+    return any(message in readable for message in duplicate_messages)
 
 
 def _section_heading(title: str, separator: str = STAGE_SEPARATOR) -> str:

--- a/src/aisc_salesforce/salesforce.py
+++ b/src/aisc_salesforce/salesforce.py
@@ -21,6 +21,17 @@ REQUIRED_CREDENTIALS = (
 class SalesforceError(RuntimeError):
     """Salesforce rejected a request or could not be reached."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str | None = None,
+        salesforce_message: str | None = None,
+    ):
+        super().__init__(message)
+        self.error_code = error_code
+        self.salesforce_message = salesforce_message
+
 
 @dataclass(frozen=True)
 class SalesforceSession:
@@ -304,8 +315,11 @@ class SalesforceClient:
         except requests.RequestException as error:
             raise SalesforceError(f"Could not {action}: {error}") from error
         if not response.ok:
+            details, error_code, salesforce_message = _response_error(response)
             raise SalesforceError(
-                f"Salesforce failed to {action}: {_response_details(response)}"
+                f"Salesforce failed to {action}: {details}",
+                error_code=error_code,
+                salesforce_message=salesforce_message,
             )
         return response
 
@@ -318,14 +332,23 @@ class SalesforceClient:
 
 
 def _response_details(response: Any) -> str:
+    return _response_error(response)[0]
+
+
+def _response_error(response: Any) -> tuple[str, str | None, str | None]:
+    """Return readable and structured details from a Salesforce error response."""
     try:
         details = response.json()
     except ValueError:
-        return response.text or f"HTTP {response.status_code}"
+        return response.text or f"HTTP {response.status_code}", None, None
     if isinstance(details, list) and details:
         details = details[0]
     if isinstance(details, dict):
-        return str(
-            details.get("message") or details.get("error_description") or details
+        salesforce_message = details.get("message") or details.get("error_description")
+        error_code = details.get("errorCode") or details.get("error")
+        return (
+            str(salesforce_message or details),
+            str(error_code) if error_code else None,
+            str(salesforce_message) if salesforce_message else None,
         )
-    return str(details)
+    return str(details), None, None

--- a/src/aisc_salesforce/salesforce_enums.py
+++ b/src/aisc_salesforce/salesforce_enums.py
@@ -14,6 +14,51 @@ class AccountCertificationStatus(StrEnum):
     """Certification statuses used by the application."""
 
     INITIALS = "Initials"
+    CERTIFIED = "Certified"
+    DROPPED = "Dropped"
+    SUSPENDED = "Suspended" #It is unclear what our best practice is for using this option -MB 7/24/26
+
+
+class AccountHistoryField(StrEnum):
+    """Account fields that can appear in AccountHistory records."""
+
+    BILLING_CITY = "BillingCity"
+    BILLING_COUNTRY = "BillingCountry"
+    BILLING_GEOCODE_ACCURACY = "BillingGeocodeAccuracy"
+    BILLING_LATITUDE = "BillingLatitude"
+    BILLING_LONGITUDE = "BillingLongitude"
+    BILLING_POSTAL_CODE = "BillingPostalCode"
+    BILLING_STATE = "BillingState"
+    BILLING_STREET = "BillingStreet"
+    CERT_ACCOUNTING_CONTACT = "Cert_Accounting_Contact__c"
+    CERT_AUDIT_DURATION = "Cert_Audit_Duration__c"
+    CERT_AUDIT_PACKAGE = "Cert_Audit_Package__c"
+    CERT_CERTIFICATION_CONTACT = "Cert_Certification_Contact__c"
+    CERT_CERTIFICATION_STATUS = "Cert_Certification_Status__c"
+    CERT_MARKETING_CONTACT = "Cert_Marketing_Contact__c"
+    CERT_NOTES = "Cert_Notes__c"
+    CERT_PRINCIPAL_CONTACT = "Cert_Principal_Contact__c"
+    CERT_SCHEDULING_2_0_CERT_MONTH = "Cert_Scheduling_2_0_Cert_Month__c"
+    ENGAGEMENT_STAGE = "Engagement_Stage__c"
+    IMISID = "IMISID__c"
+    INDUSTRY = "Industry"
+    IS_ACTIVE_IN_IMIS_FOR_MEMBER_DISCOUNT = (
+        "Is_active_in_IMIS_for_Member_Discount__c"
+    )
+    NY_PROGRAM_PARTICIPANT = "NY_Program_Participant__c"
+    NUMBER_OF_EMPLOYEES = "NumberOfEmployees"
+    OWNER = "Owner"
+    SHIPPING_CITY = "ShippingCity"
+    SHIPPING_COUNTRY = "ShippingCountry"
+    SHIPPING_POSTAL_CODE = "ShippingPostalCode"
+    SHIPPING_STATE = "ShippingState"
+    SHIPPING_STREET = "ShippingStreet"
+    TEXT_NAME = "TextName"
+    WEBSITE = "Website"
+    ACCOUNT_CREATED_FROM_LEAD = "accountCreatedFromLead"
+    ACCOUNT_MERGED = "accountMerged"
+    ACCOUNT_UPDATED_BY_LEAD = "accountUpdatedByLead"
+    CREATED = "created"
 
 
 class CaseCertificationStage(StrEnum):
@@ -23,12 +68,16 @@ class CaseCertificationStage(StrEnum):
     NEW_APPLICATION = "New_Application"
     DOC_AUDIT = "Doc_Audit"
     PENDING_AUDIT_ASSIGNMENT = "Pending_AuditAssignment"
+    DOC_AUDIT_LABEL = "Doc Audit"
+    ELIGIBILITY_REVIEW = "Eligibility Review"
+    INITIAL_REVIEW = "Initial Review"
 
 
 class ScopeChangeAnswer(StrEnum):
     """Scope-change answers used by the application filter."""
 
     YES = "Yes"
+    NO = "No"
 
 
 class AuditStatus(StrEnum):
@@ -38,6 +87,14 @@ class AuditStatus(StrEnum):
     WITHDRAWN = "Withdrawn"
     PENDING_ACCEPTANCE = "Pending Acceptance"
     RESCHEDULE_IN_PROGRESS = "Reschedule in Progress"
+    COMPLETED_CONDITIONAL = "Completed - Conditional"
+    COMPLETED_DENIED = "Completed - Denied"
+    COMPLETED_GRANTED = "Completed - Granted"
+    COMPLETED_UNDER_REVIEW = "Completed - Under Review"
+    LEGACY = "Legacy"
+    NEW = "New"
+    RESCHEDULE_NEEDED = "Reschedule Needed"
+    SCHEDULED_APPROVED = "Scheduled - Approved"
 
 
 class AuditType(StrEnum):
@@ -47,6 +104,18 @@ class AuditType(StrEnum):
     APPEAL = "Appeal"
     SA_NYC = "SA-NYC"
     PREASSESSMENT = "Preassessment"
+    B_AUDIT_CAR = "B Audit CAR"
+    B_AUDIT_WORK = "B Audit Work"
+    INITIAL = "Initial"
+    LEGACY = "Legacy"
+    MULTI_SITE_CSE = "Multi-Site CSE"
+    MULTI_SITE_CX = "Multi-Site CX"
+    MULTI_SITE_DUAL = "Multi-Site Dual"
+    MULTI_SITE_FA = "Multi-Site FA"
+    RENEWAL = "Renewal"
+    RESCHEDULE = "Reschedule"
+    SCOPE_CHANGE = "Scope Change"
+    SPLIT = "Split"
 
 
 class ProfileChangeStatus(StrEnum):
@@ -62,11 +131,32 @@ class ProfileChangeType(StrEnum):
     KEY_DATA = "Key Data"
 
 
+class CompanyProfileChangeYesNo(StrEnum):
+    """Yes/no answers on Company Profile Change records."""
+
+    YES = "Yes"
+    NO = "No"
+
+
 class CaseStatus(StrEnum):
     """Case statuses written by the Profile Update workflows."""
 
     PENDING = "Pending"
     CLOSED = "Closed"
+    AISC_STAFF = "AISC Staff"
+    CARLO = "Carlo"
+    CARLO_TO_REVIEW = "Carlo to Review"
+    DESCH = "Desch"
+    DRURY_TO_REVIEW = "Drury to Review"
+    INBOX = "Inbox"
+    LARRY = "Larry"
+    NEW = "New"
+    OPEN = "Open"
+    RESOLVED = "Resolved"
+    RESOLVED_INTERNAL = "Resolved - Internal"
+    TRAVIS = "Travis"
+    YASMIN = "Yasmin"
+    YASMIN_TO_REVIEW = "Yasmin to Review"
 
 
 class CaseOrigin(StrEnum):
@@ -74,6 +164,8 @@ class CaseOrigin(StrEnum):
 
     WEB = "Web"
     PARTICIPANT_PORTAL = "Participant Portal"
+    EMAIL = "Email"
+    PHONE = "Phone"
 
 
 class CaseLabel(StrEnum):
@@ -81,17 +173,230 @@ class CaseLabel(StrEnum):
 
     AUDITING = "Auditing"
     PARTICIPANT_PORTAL = "Participant Portal"
+    AESS = "AESS"
+    APPLICATION = "Application"
+    APPLICATION_PERIOD = "Application."
+    APPROVAL = "Approval"
+    AUDIT = "Audit"
+    AUDIT_PERIOD = "Audit."
+    AWNINGS_AND_CANOPIES = "Awnings and Canopies"
+    BENDING_STRAIGHTENING_AND_CAMBER = "Bending, Straightening and Camber"
+    BLAST = "Blast"
+    BOLTS_AND_WELDS_IN_COMBINATION = "Bolts and Welds in Combination"
+    BRIDGES = "Bridges"
+    BUILT_UP_MEMBERS = "Built-Up Members"
+    COSP = "COSP"
+    CASTING = "Casting"
+    CERTIFICATE = "Certificate"
+    CERTIFICATE_OF_INSURANCE = "Certificate of Insurance"
+    CERTIFICATION = "Certification"
+    COMBINED_STRESSES = "Combined Stresses"
+    CONNECTIONS = "Connections"
+    CONSTRUCTION = "Construction"
+    CONSTRUCTION_AND_CONTROL_JOINTS = "Construction and Control Joints"
+    CONTINUING_EDUCATION = "Continuing Education"
+    CORROSION = "Corrosion"
+    DETAILER_TRAINING = "Detailer Training"
+    DETAILING = "Detailing"
+    EMBEDS = "Embeds"
+    ERECTION_BRACING = "Erection Bracing"
+    FABRICATION = "Fabrication"
+    FATIGUE = "Fatigue"
+    FAÇADE = "Façade"
+    FIELD_FIXES = "Field Fixes"
+    FIRE = "Fire"
+    HISTORICAL = "Historical"
+    HOLLOW_CORE = "Hollow Core"
+    I_DONT_KNOW = "I don't know."
+    INSPECTION = "Inspection"
+    INVOICING = "Invoicing"
+    JOISTS = "Joists"
+    LEED = "LEED"
+    LADDERS = "Ladders"
+    LATTICE_TOWERS = "Lattice Towers"
+    LIFTING = "Lifting"
+    LOGIN_ISSUES = "Login Issues"
+    MAGAZINE_SUBSCRIPTIONS = "Magazine Subscriptions"
+    MARKING = "Marking"
+    MATERIALS = "Materials"
+    MEMBER_DESIGN = "Member Design"
+    MEMBERSHIP = "Membership"
+    MEMBERSHIP_APPLICATION = "Membership Application"
+    MEMBERSHIP_CANCELLATION = "Membership Cancellation"
+    MEMBERSHIP_RENEWAL = "Membership Renewal"
+    MEMBERSHIP_RENEWALS = "Membership Renewals"
+    METAL_BUILDINGS = "Metal Buildings"
+    MISC_METALS = "Misc Metals"
+    NRN = "NRN"
+    NRN_PERIOD = "NRN."
+    NO_RESPONSE_NEEDED = "No Response Needed"
+    NO_RESPONSE_NEEDED_PERIOD = "No Response Needed."
+    NUCLEAR = "Nuclear"
+    OSHA = "OSHA"
+    OTHER_HIGH = "Other - high"
+    OTHER_HIGH_PERIOD = "Other - high."
+    OTHER_HIGH_COMPACT = "OtherHigh"
+    PAINTING_AND_SURFACE_PREP = "Painting and Surface Prep"
+    PARKING_STRUCTURES = "Parking Structures"
+    PHONE_CALLS = "Phone Calls"
+    PONDING = "Ponding"
+    PROFILE_CHANGE = "Profile Change"
+    PROGRAM_INQUIRY = "Program Inquiry"
+    PROTECTED_ZONE = "Protected Zone"
+    PUBLICATIONS = "Publications"
+    REQUEST_FOR_SPEAKERS = "Request for Speakers"
+    ROSTER_UPDATES = "Roster Updates"
+    SAFETY = "Safety"
+    SCHEDULING = "Scheduling"
+    SHIPPING = "Shipping"
+    SILOS_BINS_HOPPERS = "Silos, Bins, Hoppers"
+    SLAB_EDGE = "Slab Edge"
+    SOFTWARE_ISSUES = "Software Issues"
+    SOUND = "Sound"
+    SPEEDCORE = "Speedcore"
+    STABILITY = "Stability"
+    STAIRS = "Stairs"
+    STEEL_DECK = "Steel Deck"
+    STEEL_MAKING = "Steel Making"
+    STEEL_PRICES = "Steel Prices"
+    SUBSCRIPTION = "Subscription"
+    SUBSCRIPTION_INQUIRY = "Subscription Inquiry"
+    TECHNICAL_INQUIRY = "Technical Inquiry"
+    TOLERANCES = "Tolerances"
+    TONNAGE = "Tonnage"
+    VIBRATION = "Vibration"
+    WEBSITE_ISSUES = "Website Issues"
+    WELDING = "Welding"
 
 
 class CaseSubLabel(StrEnum):
     """Case sub-labels written by the Profile Update automation."""
 
     PROFILE_CHANGE = "Profile Change"
+    ADDAMEMBER = "Addamember"
+    ADDSUBSCRIPTION = "Addsubscription"
+    ANGLES_IN_FLEXURE = "Angles in Flexure"
+    ANNUAL_DUES = "Annual Dues"
+    APPLICATION_CERTIFICATION = "Application Certification"
+    AUDIT_DATE = "Audit Date"
+    BASE_METAL_STRENGTH = "Base Metal Strength"
+    BEARING_JOINTS = "Bearing Joints"
+    BENT_ANCHOR_RODS = "Bent Anchor Rods"
+    BOLT_BANGING = "Bolt Banging"
+    BOLTING = "Bolting"
+    BOX_GIRDERS = "Box Girders"
+    BUILT_UP_COMPRESSION = "Built-Up Compression"
+    BUILT_UP_FLEXURAL = "Built-Up Flexural"
+    COVID = "COVID"
+    CRG_REVIEW = "CRG Review"
+    CVN = "CVN"
+    CABLES = "Cables"
+    CAST_IRON = "Cast Iron"
+    CASTELLATED_BEAMS = "Castellated Beams"
+    CERT_LOGO_REQUEST = "Cert Logo Request"
+    CERTIFICATE_OF_INSURANCE = "Certificate of Insurance"
+    CHAPTER_N = "Chapter N"
+    CLEARANCES = "Clearances"
+    COLUMN = "Column"
+    COMPACTNESS = "Compactness"
+    COMPOSITE_BEAMS = "Composite Beams"
+    CONTACT_CHANGE = "ContactChange"
+    COPES = "Copes"
+    COVER_PLATES = "Cover Plates"
+    CRUCIFORM = "Cruciform"
+    CURVED_MEMBERS = "Curved Members"
+    D1_8 = "D1.8"
+    DEFLECTIONS = "Deflections"
+    DISTORTION = "Distortion"
+    DUCT_WORK = "Duct Work"
+    ECCENTRICITY = "Eccentricity"
+    ELEVATED_TEMPERATURE = "Elevated Temperature"
+    EMBEDS = "Embeds"
+    EXPANSION_JOINTS = "Expansion Joints"
+    FEA = "FEA"
+    FEEDBACK = "Feedback"
+    FLANGE_BENDING = "Flange Bending"
+    FOREIGN_STEEL = "Foreign Steel"
+    FULL_MEMBERSHIP = "FullMembership"
+    GALVANIZED = "Galvanized"
+    GIRTS = "Girts"
+    HSS = "HSS"
+    HISTORICAL = "Historical"
+    HISTORY = "History"
+    HOLE_SIZES = "Hole Sizes"
+    IAS = "IAS"
+    LADDERS = "Ladders"
+    LEVELLING_NUTS = "Levelling Nuts"
+    LIFTING_BEAMS = "Lifting Beams"
+    LINTELS = "Lintels"
+    LOCK_WASHERS = "Lock Washers"
+    LOGIN_ISSUES = "LoginIssues"
+    LOW_TEMPERATURE = "Low Temperature"
+    MAXIMUM_SPACING = "Maximum Spacing"
+    MAXIMUM_WELD_SIZE = "Maximum Weld Size"
+    MISLOCATED_HOLES = "Mislocated Holes"
+    MOMENT_CONNECTIONS = "Moment Connections"
+    N690 = "N690"
+    NAVIGATING_PORTAL = "Navigating Portal"
+    ONE_SIDED = "One sided"
+    PAY_INVOICE = "PayInvoice"
+    PILING = "Piling"
+    PIN_CONNECTIONS = "Pin Connections"
+    PINS = "Pins"
+    PIPE_SUPPORT = "Pipe Support"
+    PLATE_GIRDERS = "Plate Girders"
+    PREINSTALLATION_VERIFICATION = "Preinstallation Verification"
+    PRETENSION = "Pretension"
+    PROFESSIONAL_MEMBERSHIP = "ProfessionalMembership"
+    PRYING = "Prying"
+    QUALIFICATION = "Qualification"
+    REBAR = "Rebar"
+    RECYCLED_CONTENT = "Recycled Content"
+    REINFORCING = "Reinforcing"
+    RESCHEDULE_REQUEST = "Reschedule Request"
+    RESEND_INVOICES = "ResendInvoices"
+    RESET_CREDENTIALS = "ResetCredentials"
+    RIVETS = "Rivets"
+    ROTATIONAL_DUCTILITY = "Rotational Ductility"
+    SAFETY = "Safety"
+    SEAL_WELDING = "Seal Welding"
+    SEISMIC = "Seismic"
+    SHEAR_CONNECTIONS = "Shear Connections"
+    SILICON_STEEL = "Silicon Steel"
+    SINGLE_ANGLES = "Single Angles"
+    SPRAY_ON = "Spray On"
+    STABILITY_BRACING = "Stability Bracing"
+    STAGE_1_2_AND_CRG_REVIEW = "Stage 1, 2, & CRG Review"
+    STAGE_2_REVIEW = "Stage 2 Review"
+    STAINLESS = "Stainless"
+    STANDARD = "Standard"
+    STEEL_PLATE_SHEAR_WALLS = "Steel Plate Shear Walls"
+    STRUCTURAL_INTEGRITY = "Structural Integrity"
+    STUDS = "Studs"
+    SUBMIT_TONNAGE_REPORT = "Submittonnagereport"
+    TABLE_B4 = "Table B4"
+    TENSION_ONLY = "Tension Only"
+    THERMAL_BREAKS = "Thermal Breaks"
+    THICK_PLATES = "Thick Plates"
+    THREAD_ENGAGEMENT = "Thread Engagement"
+    THREADS_EXCLUDED = "Threads Excluded"
+    TORSION = "Torsion"
+    TRACEABILITY = "Traceability"
+    TRUSSES = "Trusses"
+    U_BOLTS = "U Bolts"
+    UFM = "UFM"
+    UNCOPED_BEAMS = "Uncoped Beams"
+    VERTICAL_BRACE_CONNECTION = "Vertical Brace Connection"
+    WASHERS = "Washers"
+    WEATHERING_STEEL = "Weathering Steel"
+    WEB_OPENINGS = "Web Openings"
+    X_BRACE = "X Brace"
 
 
 # An explicit mapping makes catalog coverage easy to review in one place.
 SALESFORCE_ENUMS: dict[tuple[str, str], type[StrEnum]] = {
     ("Account", "Cert_Certification_Status__c"): AccountCertificationStatus,
+    ("AccountHistory", "Field"): AccountHistoryField,
     ("Case", "Cert_Stage__c"): CaseCertificationStage,
     ("Case", "Cert_Is_this_a_scope_change__c"): ScopeChangeAnswer,
     ("Case", "Status"): CaseStatus,
@@ -102,4 +407,36 @@ SALESFORCE_ENUMS: dict[tuple[str, str], type[StrEnum]] = {
     ("Cert_Audit__c", "Cert_Audit_Type__c"): AuditType,
     ("Company_Profile_Change__c", "Status__c"): ProfileChangeStatus,
     ("Company_Profile_Change__c", "Type__c"): ProfileChangeType,
+    (
+        "Company_Profile_Change__c",
+        "Did_the_Cert_contact_change__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Did_the_executive_manager_change__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Existing_equipment_moved_to_new_facility__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Will_QMS_or_documentation_change__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Will_new_equipment_be_purchased__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Will_old_equipment_be_removed__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Will_software_change__c",
+    ): CompanyProfileChangeYesNo,
+    (
+        "Company_Profile_Change__c",
+        "Will_you_change_personnel__c",
+    ): CompanyProfileChangeYesNo,
 }

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -12,6 +12,14 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from .contact_resolution import (
+    ContactResolution,
+    ContactSource,
+    family_account_ids,
+    merge_resolution,
+    normalize_email,
+    resolve_contact,
+)
 from .profile_update_subjects import subject_has_profile_update
 from .profile_updates import escape_soql_string
 from .queried_fields import (
@@ -155,6 +163,7 @@ SHARED_COLUMNS = [
     "submitter_name",
     "submitter_email",
     "submitter_phone",
+    "contact_resolutions",
     "comments",
     "personnel_notes",
     "has_contact_derived_values",
@@ -246,12 +255,13 @@ class ProfileUpdateStagingService:
         parent_ids = _unique_text_values(
             account.get("ParentId") for account in accounts
         )
+        parents = self._query_accounts("Id", parent_ids)
         siblings = self._query_accounts("ParentId", parent_ids)
         all_accounts_by_id = dict(accounts_by_id)
-        for sibling in siblings:
-            sibling_id = _clean_text(sibling.get("Id"))
-            if sibling_id:
-                all_accounts_by_id.setdefault(sibling_id, sibling)
+        for family_account in [*parents, *siblings]:
+            family_account_id = _clean_text(family_account.get("Id"))
+            if family_account_id:
+                all_accounts_by_id.setdefault(family_account_id, family_account)
 
         contacts = self._query_contacts(list(all_accounts_by_id.values()))
         cases = self._query_cases(requested_account_ids)
@@ -422,6 +432,14 @@ class ProfileUpdateStagingService:
                 has_contact_derived_values or role_has_derived_values
             )
 
+        row["contact_resolutions"] = _build_contact_resolutions(
+            row,
+            merged_roles,
+            account,
+            list(all_accounts_by_id.values()),
+            contacts,
+            warnings,
+        )
         row["has_contact_derived_values"] = (
             "true" if has_contact_derived_values else "false"
         )
@@ -563,13 +581,99 @@ class ProfileUpdateStagingService:
         return has_derived_values
 
 
+def _build_contact_resolutions(
+    row: dict[str, str],
+    roles: list[MergedRole],
+    account: dict[str, Any] | None,
+    family_accounts: list[dict[str, Any]],
+    contacts: list[dict[str, Any]],
+    row_warnings: list[str],
+) -> str:
+    """Build the authoritative email-keyed Contact-resolution staging value."""
+    account_ids = family_account_ids(account, family_accounts)
+    source_ids = json.loads(row["source_submission_ids"])
+    entries: list[tuple[str, ContactSource, dict[str, str]]] = []
+
+    submitter_first, submitter_last = _split_person_name(row["submitter_name"])
+    if row["submitter_email"]:
+        entries.append(
+            (
+                row["submitter_email"],
+                ContactSource(
+                    "submitter",
+                    submission_id=_clean_text(source_ids[-1] if source_ids else ""),
+                ),
+                {
+                    "first_name": submitter_first,
+                    "last_name": submitter_last,
+                    "email": row["submitter_email"],
+                    "phone": row["submitter_phone"],
+                },
+            )
+        )
+
+    for role in roles:
+        email = role.values.get("email", "")
+        if not email:
+            continue
+        entries.append(
+            (
+                email,
+                ContactSource(
+                    "role",
+                    role=role.definition.prefix,
+                    submission_id=role.source_submission_id,
+                ),
+                dict(role.values),
+            )
+        )
+
+    resolutions: dict[str, ContactResolution] = {}
+    invalid_index = 0
+    for email, source, submitted in entries:
+        normalized, comparison_key, _ = normalize_email(email)
+        resolution = resolve_contact(
+            normalized,
+            contacts,
+            account_ids,
+            sources=[source],
+            submitted=submitted,
+        )
+        row_warnings.extend(
+            warning for warning in resolution.warnings if warning not in row_warnings
+        )
+        key = comparison_key
+        if not key:
+            invalid_index += 1
+            key = f"invalid:{invalid_index}:{normalized}"
+        if key in resolutions:
+            merge_resolution(resolutions[key], resolution)
+            if source.kind == "role":
+                resolutions[key].submitted.update(
+                    {
+                        field_name: value
+                        for field_name, value in submitted.items()
+                        if value
+                    }
+                )
+        else:
+            resolutions[key] = resolution
+
+    return json.dumps(
+        [resolution.as_dict() for resolution in resolutions.values()],
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
 def _group_submissions(
     submissions: list[dict[str, Any]],
 ) -> list[list[dict[str, Any]]]:
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for index, record in enumerate(submissions):
         account_id = _clean_text(record.get("Account__c"))
-        email = _normalized(record.get("Email__c"))
+        normalized_email, comparison_key, _ = normalize_email(record.get("Email__c"))
+        email = comparison_key or normalized_email
         record_id = _clean_text(record.get("Id")) or str(index)
         account_key = account_id or f"blank-account:{record_id}"
         email_key = email or f"blank-email:{record_id}"
@@ -586,9 +690,7 @@ def _merge_records(records: list[dict[str, Any]]) -> dict[str, Any]:
     return merged
 
 
-def _collect_submitted_values(
-    records: list[dict[str, Any]], field_name: str
-) -> str:
+def _collect_submitted_values(records: list[dict[str, Any]], field_name: str) -> str:
     """Join every nonblank submitted value in deterministic submission order."""
     return "\n".join(
         _display_value(record.get(field_name))
@@ -1048,6 +1150,16 @@ def _display_value(value: Any) -> str:
 
 def _clean_text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
+
+
+def _split_person_name(value: Any) -> tuple[str, str]:
+    """Split a submitter name at the final space."""
+    parts = _clean_text(value).rsplit(maxsplit=1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    if parts:
+        return "", parts[0]
+    return "", ""
 
 
 def _normalized(value: Any) -> str:

--- a/tests/test_contact_resolution.py
+++ b/tests/test_contact_resolution.py
@@ -1,0 +1,109 @@
+from aisc_salesforce.contact_resolution import (
+    ContactResolutionClassification,
+    comparison_name,
+    family_account_ids,
+    is_single_edit_or_transposition,
+    name_local_part_patterns,
+    normalize_email,
+    resolve_contact,
+)
+
+
+def contact(contact_id, email, *, account_id="account-1", first="Alex", last="Smith"):
+    return {
+        "Id": contact_id,
+        "AccountId": account_id,
+        "FirstName": first,
+        "LastName": last,
+        "Email": email,
+    }
+
+
+def test_email_normalization_is_trimmed_lowercase_and_dot_insensitive():
+    assert normalize_email("  Alex.Smith@Example.COM ") == (
+        "alex.smith@example.com",
+        "alexsmith@example.com",
+        [],
+    )
+
+
+def test_invalid_email_has_warning_and_no_comparison_key():
+    normalized, key, warnings = normalize_email("not an email")
+
+    assert normalized == "not an email"
+    assert key == ""
+    assert "Invalid email" in warnings[0]
+
+
+def test_family_is_target_parent_and_siblings_but_root_is_only_itself():
+    target = {"Id": "child-1", "ParentId": "parent-1"}
+    accounts = [
+        target,
+        {"Id": "parent-1", "ParentId": ""},
+        {"Id": "child-2", "ParentId": "parent-1"},
+        {"Id": "unrelated", "ParentId": "other"},
+    ]
+
+    assert family_account_ids(target, accounts) == {
+        "child-1",
+        "parent-1",
+        "child-2",
+    }
+    assert family_account_ids({"Id": "root", "ParentId": ""}, accounts) == {"root"}
+
+
+def test_family_exact_match_wins_but_mixed_external_match_is_ambiguous():
+    family = contact("family", "alex@example.com")
+    external = contact("external", "alex@example.com", account_id="external-account")
+
+    exact = resolve_contact(" ALEX@example.com ", [family], {"account-1"})
+    mixed = resolve_contact("alex@example.com", [family, external], {"account-1"})
+
+    assert exact.classification is ContactResolutionClassification.USE_EXISTING
+    assert exact.selected_contact == family
+    assert mixed.classification is ContactResolutionClassification.AMBIGUOUS
+    assert {item["Id"] for item in mixed.candidates} == {"family", "external"}
+
+
+def test_dot_only_difference_is_an_exact_comparison_key_match():
+    existing = contact("contact-1", "alexsmith@example.com")
+
+    result = resolve_contact("alex.smith@example.com", [existing], {"account-1"})
+
+    assert result.classification is ContactResolutionClassification.USE_EXISTING
+    assert result.confidence == "exact_comparison_key"
+
+
+def test_name_evidence_with_different_domain_requires_operator():
+    existing = contact("contact-1", "alex.smith@old.example")
+
+    result = resolve_contact("alexsmith@new.example", [existing], {"account-1"})
+
+    assert result.classification is ContactResolutionClassification.AMBIGUOUS
+    assert result.candidates == [existing]
+    assert "differing" in result.reason
+
+
+def test_generic_mailbox_never_creates_automatically():
+    existing = contact("shared", "info@example.com")
+    result = resolve_contact("info@example.com", [existing], {"account-1"})
+
+    assert result.classification is ContactResolutionClassification.AMBIGUOUS
+    assert result.candidates == [existing]
+    assert "generic" in result.warnings[0].casefold()
+
+
+def test_bracket_suffix_is_only_removed_for_name_comparison():
+    assert comparison_name("Smith [Former]") == "smith"
+    assert "alexsmith" in name_local_part_patterns("Alex", "Smith [Former]")
+
+
+def test_only_one_edit_or_adjacent_transposition_is_a_likely_typo():
+    assert is_single_edit_or_transposition("alexsmith", "alexsmit")
+    assert is_single_edit_or_transposition("alexsmith", "alexsimth")
+    assert not is_single_edit_or_transposition("alexsmith", "alecjones")
+
+    existing = contact("contact-1", "alex.smith@example.com")
+    result = resolve_contact("alexsimth@example.com", [existing], {"account-1"})
+    assert result.classification is ContactResolutionClassification.LIKELY_TYPO
+    assert result.selected_contact == existing

--- a/tests/test_picklist_audit.py
+++ b/tests/test_picklist_audit.py
@@ -133,7 +133,7 @@ def test_history_objects_filter_on_created_date(object_name):
             self, queried_object, fields, *, where, order_by
         ):
             self.query = (queried_object, fields, where, order_by)
-            return [{"Field": "BillingCountry"}]
+            return [{"Field": "UnknownHistoryField"}]
 
     client = HistoryClient()
     result = PicklistEnumAuditService(
@@ -147,7 +147,7 @@ def test_history_objects_filter_on_created_date(object_name):
         "CreatedDate >= 2024-07-24T15:30:00Z",
         "Id ASC",
     )
-    assert result.findings[0].values == ("BillingCountry",)
+    assert result.findings[0].values == ("UnknownHistoryField",)
 
 
 def test_non_history_objects_filter_on_last_modified_date():

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -4,6 +4,11 @@ from datetime import UTC, datetime
 
 import pytest
 
+from aisc_salesforce.contact_resolution import (
+    ContactResolution,
+    ContactResolutionClassification,
+    ContactSource,
+)
 from aisc_salesforce.process_profile_updates import (
     ActionResult,
     ActionStatus,
@@ -46,6 +51,31 @@ def staged_row(**changes):
     )
     row.update(changes)
     return row
+
+
+def staged_resolution(
+    *,
+    email="sam@example.com",
+    sources=None,
+    submitted=None,
+    classification=ContactResolutionClassification.CREATE_NEW,
+    candidates=None,
+    selected=None,
+):
+    normalized = email.strip().casefold()
+    local, domain = normalized.rsplit("@", 1)
+    resolution = ContactResolution(
+        classification,
+        normalized,
+        f"{local.replace('.', '')}@{domain}",
+        sources=list(sources or []),
+        candidates=list(candidates or []),
+        selected_contact=selected,
+        reason="test resolution",
+        confidence="test",
+        submitted=dict(submitted or {}),
+    )
+    return json.dumps([resolution.as_dict()])
 
 
 def source_record(**changes):
@@ -133,6 +163,7 @@ class FakeClient:
         self.created = []
         self.updated = []
         self.fail_update = None
+        self.fail_create = None
 
     def query_records(self, object_name, fields, *, where=None, order_by=None):
         self.queries.append((object_name, fields, where, order_by))
@@ -158,6 +189,10 @@ class FakeClient:
         return dict(self.records[key])
 
     def create_record(self, object_name, values):
+        if self.fail_create is not None:
+            error = self.fail_create
+            self.fail_create = None
+            raise error
         record_id = f"created-{len(self.created) + 1}"
         self.created.append((object_name, dict(values)))
         self.records[(object_name, record_id)] = {"Id": record_id, **values}
@@ -256,9 +291,7 @@ def test_workflow_creates_cases_then_stages_and_reads_the_published_csv(tmp_path
     "missing_column",
     ["has_contact_derived_values", "has_no_update_content"],
 )
-def test_published_csv_requires_new_staging_metadata_columns(
-    tmp_path, missing_column
-):
+def test_published_csv_requires_new_staging_metadata_columns(tmp_path, missing_column):
     columns = [column for column in CSV_COLUMNS if column != missing_column]
     csv_path = tmp_path / "profile_updates.csv"
     with csv_path.open("w", newline="", encoding="utf-8") as output:
@@ -403,10 +436,7 @@ def test_each_staged_row_has_a_continue_checkpoint_and_heading(tmp_path, answer)
                     "Note: contact details were supplemented from available "
                     "contact information."
                 ),
-                (
-                    "Note: this combined profile update has no submitted "
-                    "update content."
-                ),
+                ("Note: this combined profile update has no submitted update content."),
             ],
         ),
         ({}, []),
@@ -858,6 +888,151 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
         "Email: new.person@example.com\n"
         "Phone: (blank)"
     ) in "\n".join(output)
+
+
+def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
+    client = FakeClient()
+    feeder = Feeder(["apply automatically", "apply automatically", "yes"])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    sources = [
+        ContactSource("submitter", submission_id="submission-1"),
+        ContactSource("role", role="certification", submission_id="submission-1"),
+    ]
+    submitted = {
+        "first_name": "Sam",
+        "last_name": "Submitter",
+        "email": "sam@example.com",
+        "phone": "312-555-0101",
+    }
+    row = staged_row(
+        certification_first_name="Sam",
+        certification_last_name="Submitter",
+        certification_email="sam@example.com",
+        certification_phone="312-555-0101",
+        contact_resolutions=staged_resolution(
+            sources=sources,
+            submitted=submitted,
+        ),
+    )
+
+    result = processor.review([row], tmp_path)
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "Sam",
+                "LastName": "Submitter",
+                "Email": "sam@example.com",
+                "Phone": "312-555-0101",
+            },
+        )
+    ]
+    assert ("Case", "case-1", {"ContactId": "created-1"}) in client.updated
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "created-1"},
+    ) in client.updated
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    contact_create = next(
+        entry for entry in entries if entry["action"] == "create Contact"
+    )
+    case_assignment = next(
+        entry
+        for entry in entries
+        if entry["action"] == "assign created submitter Contact to Case"
+    )
+    role_assignment = next(
+        entry for entry in entries if entry["field"] == "Cert_Certification_Contact__c"
+    )
+    assert contact_create["comparison_key"] == "sam@example.com"
+    assert case_assignment["target_record_id"] == "case-1"
+    assert role_assignment["selected_contact"]["Id"] == "created-1"
+
+
+def test_duplicate_create_can_recover_with_an_alternate_email_contact(tmp_path):
+    alternate = {
+        "Id": "alternate-contact",
+        "AccountId": "different-account",
+        "FirstName": "Existing",
+        "LastName": "Person",
+        "Title": "",
+        "Email": "other@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(contacts=[alternate])
+    client.fail_create = SalesforceError(
+        "Salesforce failed to create Contact: Use one of these records?",
+        error_code="DUPLICATES_DETECTED",
+        salesforce_message="Use one of these records?",
+    )
+    feeder = Feeder(
+        [
+            "apply automatically",
+            "3",
+            "other@example.com",
+            "apply automatically",
+            "yes",
+        ]
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    row = staged_row(
+        certification_first_name="New",
+        certification_last_name="Person",
+        certification_email="new.person@example.com",
+        contact_resolutions=staged_resolution(
+            email="new.person@example.com",
+            sources=[
+                ContactSource(
+                    "role",
+                    role="certification",
+                    submission_id="submission-1",
+                )
+            ],
+            submitted={
+                "first_name": "New",
+                "last_name": "Person",
+                "email": "new.person@example.com",
+            },
+        ),
+    )
+
+    result = processor.review([row], tmp_path)
+
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "alternate-contact"},
+    ) in client.updated
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        entry["action"] == "Salesforce duplicate rule blocked Contact create"
+        for entry in entries
+    )
+    recovered = next(
+        entry
+        for entry in entries
+        if entry["action"] == "use alternate-email Contact after duplicate failure"
+    )
+    assert recovered["selected_contact"]["Id"] == "alternate-contact"
 
 
 def test_duplicate_exact_email_matches_are_audited_and_keep_case_retryable(tmp_path):

--- a/tests/test_salesforce.py
+++ b/tests/test_salesforce.py
@@ -303,3 +303,26 @@ def test_write_and_feed_http_errors_are_wrapped():
     )
     with pytest.raises(SalesforceError, match="post Chatter.*server broke"):
         feed_client.post_feed_message("500-case", "Test")
+
+
+def test_salesforce_error_preserves_duplicate_rule_details():
+    session = Session(
+        [
+            Response(
+                [
+                    {
+                        "message": "Use one of these records?",
+                        "errorCode": "DUPLICATES_DETECTED",
+                    }
+                ],
+                ok=False,
+            )
+        ]
+    )
+    client = SalesforceClient(SalesforceSession("https://example", "token"), session)
+
+    with pytest.raises(SalesforceError, match="Use one of these") as caught:
+        client.create_record("Contact", {"LastName": "Smith"})
+
+    assert caught.value.error_code == "DUPLICATES_DETECTED"
+    assert caught.value.salesforce_message == "Use one of these records?"

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -144,6 +144,44 @@ def test_merges_same_account_and_email_with_later_nonblank_values():
     assert contact_query[1] == CONTACT_FIELDS
 
 
+def test_staging_publishes_deduplicated_contact_resolution_contract():
+    record = submission(
+        Email__c=" Alex.Smith@Example.com ",
+        Name__c="Submitter Name",
+        Cert_First_Name__c="Alex",
+        Cert_Last_Name__c="Smith",
+        Cert_Email__c="alexsmith@example.com",
+        Principal_Email__c="ALEX.SMITH@example.com",
+    )
+
+    result, _ = stage([record], accounts=[account(ParentId="")])
+
+    resolutions = json.loads(result.rows[0]["contact_resolutions"])
+    assert len(resolutions) == 1
+    resolution = resolutions[0]
+    assert resolution["normalized_email"] == "alex.smith@example.com"
+    assert resolution["comparison_key"] == "alexsmith@example.com"
+    assert resolution["classification"] == "create_new"
+    assert {source["kind"] for source in resolution["sources"]} == {
+        "submitter",
+        "role",
+    }
+    assert {source["role"] for source in resolution["sources"]} >= {
+        "certification",
+        "principal",
+    }
+    assert resolution["submitted"]["first_name"] == "Alex"
+    assert resolution["submitted"]["last_name"] == "Smith"
+
+
+def test_staging_queries_the_parent_account_as_part_of_the_family():
+    _, client = stage([submission()], accounts=[account()])
+
+    account_queries = [query for query in client.queries if query[0] == "Account"]
+    assert any(query[2] == "Id IN ('parent-1')" for query in account_queries)
+    assert any(query[2] == "ParentId IN ('parent-1')" for query in account_queries)
+
+
 def test_merges_all_nonblank_notes_in_submission_order():
     records = [
         submission(
@@ -215,6 +253,22 @@ def test_keeps_different_emails_separate_and_blank_emails_independent():
     assert len(blank_rows) == 2
     assert all(row["has_warnings"] == "true" for row in blank_rows)
     assert all("blank submitter email" in row["warnings"].lower() for row in blank_rows)
+
+
+def test_submitter_emails_that_only_differ_by_dots_share_one_group():
+    records = [
+        submission(Id="one", Email__c="alex.smith@example.com"),
+        submission(
+            Id="two",
+            CreatedDate="2026-07-16T14:30:00.000+0000",
+            Email__c="ALEXSMITH@example.com",
+        ),
+    ]
+
+    result, _ = stage(records, accounts=[account(ParentId="")])
+
+    assert len(result.rows) == 1
+    assert json.loads(result.rows[0]["source_submission_ids"]) == ["one", "two"]
 
 
 def test_different_accounts_stay_separate_and_merged_row_can_have_key_and_role_data():

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -396,9 +396,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add deterministic Contact matching across Account families, submitted roles, and submitters.
- Add review flows for ambiguous matches, likely typos, duplicate-create recovery, and Contact/Case/role auditing.
- Update staging, interactive processing, tests, README, and documentation.
- Update MkDocs Material dependency security release.

Closes #17

Tests: `uv run pytest` (270 passed)
Docs: `uv run mkdocs build --strict`