### PR TITLE
Normalize submitted contact values

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,22 @@ separate, and every blank-email submission stays separate and receives a
 warning. Each CSV row preserves all source submission IDs and names as JSON
 arrays.
 
+Submitted contact values are canonicalized before role matching and
+`contact_resolutions` creation. Submitter and role emails are trimmed and
+lowercased, names and titles use Proper Case with project-defined exceptions,
+and recognizable North American phone numbers use `###.###.####` plus an
+optional ` x#` extension. For example, `jane mcdonald`, `chief qa officer`,
+and `+1 (312) 555-0100 ext. 123` become `Jane McDonald`,
+`Chief QA Officer`, and `312.555.0100 x123`. Blank values stay blank.
+International, malformed, and otherwise unrecognized phones are only trimmed;
+for example, `+44 20 7946 0958` remains unchanged.
+
+This applies only to submitted contact data. Existing Salesforce Contact
+values and non-contact submission fields are not reformatted, and staging
+remains query-only. The interactive processor applies the same rules when it
+reloads fresh submissions before comparisons. See the
+[detailed normalization rules and exception-list maintenance](docs/usage.md#submitted-contact-normalization).
+
 The CSV has shared submission and Account columns, Key Data columns, and
 prefixed role columns for `certification_`, `principal_`, `accounting_`,
 `quality_`, and `new_york_`. Role columns preserve submitted values and record

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -490,6 +490,54 @@ When at least one revised address component is present, the output contains all
 five components. Missing submitted components are filled from the Account
 billing address where possible.
 
+### Submitted contact normalization
+
+Staging canonicalizes only values submitted for the submitter and the five
+Contact roles. It does this before role resolution, CSV projection, and
+`contact_resolutions` JSON construction:
+
+- Every email is trimmed and lowercased, including an invalid address that must
+  remain available for human review.
+- Submitter names, role first and last names, and role titles are trimmed and
+  changed to Proper Case. Punctuation is preserved.
+- Case-insensitive whole-token exceptions preserve these spellings: `CEO`,
+  `CFO`, `COO`, `CTO`, `VP`, `HR`, `QA`, `QC`, `QMS`, `IT`, `ISO`, `AWS`,
+  `API`, `AI`, `PhD`, `MBA`, `iOS`, `macOS`, `McDonald`, `MacKenzie`, and
+  `O'Connor`.
+- A recognizable ten-digit North American phone, optionally prefixed by `1` or
+  `+1`, becomes `###.###.####`.
+- An extension introduced by `x`, `ext`, `ext.`, `extension`, or `#` becomes
+  ` x#`. Every extension digit is kept, including leading zeroes.
+- Blank phones stay blank. International, malformed, partial, and otherwise
+  unrecognized phones keep their submitted text after outer whitespace is
+  trimmed.
+
+Examples:
+
+| Submitted | Staged |
+|---|---|
+| `ALEX.SMITH@Example.COM` | `alex.smith@example.com` |
+| `jane mcdonald` | `Jane McDonald` |
+| `chief qa officer` | `Chief QA Officer` |
+| `+1 (312) 555-0100 ext. 123` | `312.555.0100 x123` |
+| `+44 20 7946 0958` | `+44 20 7946 0958` |
+
+Existing Salesforce Contact values are not normalized. Values copied from an
+existing Contact to provide review context retain their Salesforce spelling
+and formatting, and non-contact submission fields are unchanged. The staging
+command is still query-only. During interactive processing, fresh submission
+records are loaded as before and these same rules are applied to their contact
+values before comparisons or proposals.
+
+To add another capitalization exception, edit
+`CONTACT_CASE_EXCEPTIONS` in
+`src/aisc_salesforce/contact_normalization.py`. Add the desired canonical
+spelling to that tuple and add a parameterized test case if the existing
+all-exceptions test does not already cover the scenario. Do not add another
+branch to the Proper Case algorithm: the lookup is automatically
+case-insensitive and whole-token-only. Then run the focused normalization
+tests and the full verification commands.
+
 ### CSV contract
 
 Each row contains these groups of columns:

--- a/src/aisc_salesforce/contact_normalization.py
+++ b/src/aisc_salesforce/contact_normalization.py
@@ -1,0 +1,102 @@
+"""Canonical formatting for submitted Profile Update contact values."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Add a new spelling here when it must keep non-Title-Case capitalization.
+# Matching is case-insensitive and applies only to a complete word/token, so
+# changing this tuple never requires changing the normalization algorithm.
+CONTACT_CASE_EXCEPTIONS = (
+    "CEO",
+    "CFO",
+    "COO",
+    "CTO",
+    "VP",
+    "HR",
+    "QA",
+    "QC",
+    "QMS",
+    "IT",
+    "ISO",
+    "AWS",
+    "API",
+    "AI",
+    "PhD",
+    "MBA",
+    "iOS",
+    "macOS",
+    "McDonald",
+    "MacKenzie",
+    "O'Connor",
+)
+
+_CASE_EXCEPTION_LOOKUP = {
+    exception.casefold(): exception for exception in CONTACT_CASE_EXCEPTIONS
+}
+_WORD_TOKEN = re.compile(r"[^\W\d_]+(?:['’][^\W\d_]+)*")
+_PHONE_EXTENSION = re.compile(
+    r"\s*(?:extension|ext\.?|x|#)\s*(\d+)\s*$",
+    re.IGNORECASE,
+)
+_NORTH_AMERICAN_PHONE = re.compile(
+    r"^(?:(?:\+1|1)[ .\-/]*)?"
+    r"(?:\(\s*(\d{3})\s*\)|(\d{3}))"
+    r"[ .\-/]*(\d{3})[ .\-/]*(\d{4})$"
+)
+
+
+def normalize_proper_case(value: Any) -> str:
+    """Trim and Proper Case a submitted name or title."""
+    text = _text(value)
+
+    def canonical_word(match: re.Match[str]) -> str:
+        word = match.group()
+        return _CASE_EXCEPTION_LOOKUP.get(word.casefold(), word.title())
+
+    return _WORD_TOKEN.sub(canonical_word, text)
+
+
+def normalize_email(value: Any) -> str:
+    """Trim and lowercase a submitted email, even when it is invalid."""
+    return _text(value).lower()
+
+
+def normalize_phone(value: Any) -> str:
+    """Format a recognizable North American phone and preserve other input."""
+    text = _text(value)
+    if not text:
+        return ""
+
+    extension = ""
+    phone_text = text
+    extension_match = _PHONE_EXTENSION.search(phone_text)
+    if extension_match is not None:
+        extension = extension_match.group(1)
+        phone_text = phone_text[: extension_match.start()].rstrip()
+
+    phone_match = _NORTH_AMERICAN_PHONE.fullmatch(phone_text)
+    if phone_match is None:
+        return text
+
+    area_code = phone_match.group(1) or phone_match.group(2)
+    formatted = (
+        f"{area_code}.{phone_match.group(3)}.{phone_match.group(4)}"
+    )
+    return f"{formatted} x{extension}" if extension else formatted
+
+
+def normalize_contact_value(field_name: str, value: Any) -> str:
+    """Normalize one submitted Contact field by its internal field name."""
+    if field_name in {"first_name", "last_name", "title", "name"}:
+        return normalize_proper_case(value)
+    if field_name == "email":
+        return normalize_email(value)
+    if field_name == "phone":
+        return normalize_phone(value)
+    return _text(value)
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value).strip()

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, TextIO
 from zoneinfo import ZoneInfo
 
+from .contact_normalization import normalize_contact_value
 from .contact_resolution import (
     ContactResolution,
     ContactResolutionClassification,
@@ -35,6 +36,7 @@ from .stage_profile_updates import (
     CSV_COLUMNS,
     ROLE_DEFINITIONS,
     ProfileUpdateStagingService,
+    RoleDefinition,
     StagingResult,
     write_staged_profile_updates,
 )
@@ -870,17 +872,21 @@ class InteractiveProfileUpdateProcessor:
         fallback: dict[str, str],
     ) -> dict[str, str]:
         """Overlay fresh submission values on staged Contact details."""
-        details = dict(fallback)
+        details = {
+            field_name: normalize_contact_value(field_name, value)
+            for field_name, value in fallback.items()
+        }
         record = fresh_by_id.get(source.submission_id)
         if record is None:
             return details
         if source.kind == "submitter":
-            first_name, last_name = _split_person_name(_display(record.get("Name__c")))
+            name = normalize_contact_value("name", record.get("Name__c"))
+            first_name, last_name = _split_person_name(name)
             fresh_values = {
                 "first_name": first_name,
                 "last_name": last_name,
-                "email": _display(record.get("Email__c")),
-                "phone": _display(record.get("Phone__c")),
+                "email": normalize_contact_value("email", record.get("Email__c")),
+                "phone": normalize_contact_value("phone", record.get("Phone__c")),
             }
         else:
             role = next(
@@ -894,7 +900,7 @@ class InteractiveProfileUpdateProcessor:
             if role is None:
                 return details
             fresh_values = {
-                suffix: _display(record.get(source_field))
+                suffix: normalize_contact_value(suffix, record.get(source_field))
                 for suffix, source_field in role.submitted_fields
             }
         details.update(
@@ -1198,13 +1204,7 @@ class InteractiveProfileUpdateProcessor:
                 for source_id in _json_string_list(row["source_submission_ids"])
             ]
             for role in ROLE_DEFINITIONS:
-                submitted = {
-                    suffix: (
-                        _latest_nonblank(submissions, source_field)
-                        or row.get(f"{role.prefix}_{suffix}", "").strip()
-                    )
-                    for suffix, source_field in role.submitted_fields
-                }
+                submitted = _submitted_role_values(submissions, row, role)
                 if not any(submitted.values()) or submitted.get("email"):
                     continue
                 contact_id, contact = self._fresh_role_contact(
@@ -1305,13 +1305,7 @@ class InteractiveProfileUpdateProcessor:
         results: list[ActionResult] = []
         responses: list[_RoleResponse] = []
         for role in ROLE_DEFINITIONS:
-            submitted = {
-                suffix: (
-                    _latest_nonblank(submissions, source_field)
-                    or row.get(f"{role.prefix}_{suffix}", "").strip()
-                )
-                for suffix, source_field in role.submitted_fields
-            }
+            submitted = _submitted_role_values(submissions, row, role)
             if not any(submitted.values()):
                 continue
             original_id, original_contact = self._fresh_role_contact(
@@ -1626,14 +1620,7 @@ class InteractiveProfileUpdateProcessor:
         results: list[ActionResult] = []
         responses: list[_RoleResponse] = []
         for role in ROLE_DEFINITIONS:
-            prefix = role.prefix
-            submitted = {
-                suffix: (
-                    _latest_nonblank(submissions, source_field)
-                    or row.get(f"{prefix}_{suffix}", "").strip()
-                )
-                for suffix, source_field in role.submitted_fields
-            }
+            submitted = _submitted_role_values(submissions, row, role)
             if not any(submitted.values()):
                 continue
             self.output_fn(
@@ -2679,6 +2666,23 @@ def _latest_nonblank(records: list[dict[str, Any]], field_name: str) -> str:
         if candidate:
             value = candidate
     return value
+
+
+def _submitted_role_values(
+    submissions: list[dict[str, Any]],
+    row: dict[str, str],
+    role: RoleDefinition,
+) -> dict[str, str]:
+    """Prefer and normalize fresh submitted values for one Contact role."""
+    values: dict[str, str] = {}
+    for suffix, source_field in role.submitted_fields:
+        fresh_value = _latest_nonblank(submissions, source_field)
+        values[suffix] = (
+            normalize_contact_value(suffix, fresh_value)
+            if fresh_value
+            else row.get(f"{role.prefix}_{suffix}", "").strip()
+        )
+    return values
 
 
 def _json_string_list(value: str) -> list[str]:

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -12,13 +12,16 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from .contact_normalization import normalize_contact_value
 from .contact_resolution import (
     ContactResolution,
     ContactSource,
     family_account_ids,
     merge_resolution,
-    normalize_email,
     resolve_contact,
+)
+from .contact_resolution import (
+    normalize_email as normalize_resolution_email,
 )
 from .profile_update_subjects import subject_has_profile_update
 from .profile_updates import escape_soql_string
@@ -374,9 +377,15 @@ class ProfileUpdateStagingService:
                     account.get("Certification_ID__c") if account else None,
                     merged.get("Certification_ID__c"),
                 ),
-                "submitter_name": _clean_text(merged.get("Name__c")),
-                "submitter_email": _clean_text(merged.get("Email__c")),
-                "submitter_phone": _clean_text(merged.get("Phone__c")),
+                "submitter_name": normalize_contact_value(
+                    "name", merged.get("Name__c")
+                ),
+                "submitter_email": normalize_contact_value(
+                    "email", merged.get("Email__c")
+                ),
+                "submitter_phone": normalize_contact_value(
+                    "phone", merged.get("Phone__c")
+                ),
                 "comments": _collect_submitted_values(records, "Comments__c"),
                 "personnel_notes": _collect_submitted_values(
                     records, "Other_Personnel_Notes__c"
@@ -631,7 +640,7 @@ def _build_contact_resolutions(
     resolutions: dict[str, ContactResolution] = {}
     invalid_index = 0
     for email, source, submitted in entries:
-        normalized, comparison_key, _ = normalize_email(email)
+        normalized, comparison_key, _ = normalize_resolution_email(email)
         resolution = resolve_contact(
             normalized,
             contacts,
@@ -672,7 +681,9 @@ def _group_submissions(
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for index, record in enumerate(submissions):
         account_id = _clean_text(record.get("Account__c"))
-        normalized_email, comparison_key, _ = normalize_email(record.get("Email__c"))
+        normalized_email, comparison_key, _ = normalize_resolution_email(
+            record.get("Email__c")
+        )
         email = comparison_key or normalized_email
         record_id = _clean_text(record.get("Id")) or str(index)
         account_key = account_id or f"blank-account:{record_id}"
@@ -727,7 +738,9 @@ def _merge_roles(records: list[dict[str, Any]]) -> list[MergedRole]:
             supplied_here = False
             for suffix, api_name in definition.submitted_fields:
                 if _has_value(record.get(api_name)):
-                    values[suffix] = _display_value(record.get(api_name))
+                    values[suffix] = normalize_contact_value(
+                        suffix, record.get(api_name)
+                    )
                     supplied_here = True
             if supplied_here:
                 source_submission_id = _clean_text(record.get("Id"))

--- a/tests/test_contact_normalization.py
+++ b/tests/test_contact_normalization.py
@@ -1,0 +1,81 @@
+import pytest
+
+from aisc_salesforce.contact_normalization import (
+    CONTACT_CASE_EXCEPTIONS,
+    normalize_email,
+    normalize_phone,
+    normalize_proper_case,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("  jane DOE  ", "Jane Doe"),
+        ("anne-marie smith/jones", "Anne-Marie Smith/Jones"),
+        ("o'brien & sons", "O'Brien & Sons"),
+        ("", ""),
+        ("   ", ""),
+        (None, ""),
+    ],
+)
+def test_proper_case_handles_general_text_punctuation_and_blanks(value, expected):
+    assert normalize_proper_case(value) == expected
+
+
+@pytest.mark.parametrize("canonical", CONTACT_CASE_EXCEPTIONS)
+def test_proper_case_applies_every_whole_token_exception(canonical):
+    value = f"chief {canonical.swapcase()} officer"
+
+    assert normalize_proper_case(value) == f"Chief {canonical} Officer"
+
+
+def test_proper_case_exceptions_do_not_change_part_of_a_larger_word():
+    assert normalize_proper_case("ceos and apis") == "Ceos And Apis"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (" ALEX.SMITH@Example.COM ", "alex.smith@example.com"),
+        (" NOT-AN-EMAIL ", "not-an-email"),
+        ("", ""),
+        ("   ", ""),
+        (None, ""),
+    ],
+)
+def test_email_is_trimmed_and_lowercased_even_when_invalid(value, expected):
+    assert normalize_email(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("3125550100", "312.555.0100"),
+        ("(312) 555-0100", "312.555.0100"),
+        ("312.555.0100", "312.555.0100"),
+        ("1-312-555-0100", "312.555.0100"),
+        ("+1 (312) 555-0100", "312.555.0100"),
+        ("312-555-0100 x123", "312.555.0100 x123"),
+        ("312-555-0100 ext 4567", "312.555.0100 x4567"),
+        ("312-555-0100 ext. 890", "312.555.0100 x890"),
+        ("312-555-0100 extension 00123", "312.555.0100 x00123"),
+        ("312-555-0100 #9876543210", "312.555.0100 x9876543210"),
+    ],
+)
+def test_recognizable_north_american_phones_are_canonical(value, expected):
+    assert normalize_phone(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "+44 20 7946 0958",
+        "555-0100",
+        "call 312-555-0100",
+        "+52 55 1234 5678",
+        "312-555-0100 ext.",
+    ],
+)
+def test_unrecognized_phones_are_only_trimmed(value):
+    assert normalize_phone(f"  {value}  ") == value

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -930,7 +930,7 @@ def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
                 "FirstName": "Sam",
                 "LastName": "Submitter",
                 "Email": "sam@example.com",
-                "Phone": "312-555-0101",
+                "Phone": "312.555.0101",
             },
         )
     ]
@@ -958,6 +958,133 @@ def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
     assert contact_create["comparison_key"] == "sam@example.com"
     assert case_assignment["target_record_id"] == "case-1"
     assert role_assignment["selected_contact"]["Id"] == "created-1"
+
+
+def test_fresh_contact_resolution_normalizes_values_before_comparison():
+    client = FakeClient(
+        source=source_record(
+            Name__c="  jane mcdonald ",
+            Email__c=" JANE@Example.COM ",
+            Phone__c="+1 (312) 555-0100 ext. 123",
+        )
+    )
+    processor = InteractiveProfileUpdateProcessor(client, now=NOW)
+    row = staged_row(
+        contact_resolutions=staged_resolution(
+            email="old@example.com",
+            sources=[ContactSource("submitter", submission_id="submission-1")],
+            submitted={
+                "first_name": "Old",
+                "last_name": "Value",
+                "email": "old@example.com",
+                "phone": "old",
+            },
+        )
+    )
+    batch = build_case_batches([row], now=NOW)[0]
+
+    resolutions = processor._fresh_batch_resolutions(
+        batch,
+        {"submission-1": client.records[("Company_Profile_Change__c", "submission-1")]},
+    )
+
+    resolution = resolutions["jane@example.com"]
+    assert resolution.submitted == {
+        "first_name": "Jane",
+        "last_name": "McDonald",
+        "email": "jane@example.com",
+        "phone": "312.555.0100 x123",
+    }
+    assert any(
+        query[2] == "Email = 'jane@example.com'" for query in client.queries
+    )
+
+
+def test_fresh_role_without_email_is_normalized_before_review(tmp_path):
+    current = {
+        "Id": "contact-quality",
+        "AccountId": "account-1",
+        "FirstName": "Taylor",
+        "LastName": "Lee",
+        "Title": "Old Title",
+        "Email": "taylor@example.com",
+        "Phone": "312.555.0199",
+    }
+    client = FakeClient(
+        source=source_record(
+            QC_Title__c=" chief qa officer ",
+            Quality_Phone__c="+1 (312) 555-0104 #0007",
+        ),
+        account=account_record(Cert_Marketing_Contact__c="contact-quality"),
+        contacts=[current],
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically", "apply automatically", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    assert (
+        "Contact",
+        "contact-quality",
+        {"Title": "Chief QA Officer"},
+    ) in client.updated
+    assert (
+        "Contact",
+        "contact-quality",
+        {"Phone": "312.555.0104 x0007"},
+    ) in client.updated
+
+
+def test_compatibility_review_normalizes_fresh_role_values(tmp_path):
+    client = FakeClient(
+        source=source_record(
+            Cert_First_Name__c=" aLEX ",
+            Cert_Last_Name__c=" mcdonald ",
+            Cert_Title__c=" chief qa officer ",
+            Cert_Email__c=" NEW.CONTACT@Example.COM ",
+            Cert_Phone__c="+1 (312) 555-0105 ext 42",
+        )
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(
+            ["apply automatically", "apply automatically", "yes"]
+        ),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                certification_first_name="stale",
+                certification_last_name="stale",
+                certification_email="stale@example.com",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "Alex",
+                "LastName": "McDonald",
+                "Title": "Chief QA Officer",
+                "Email": "new.contact@example.com",
+                "Phone": "312.555.0105 x42",
+            },
+        )
+    ]
+    assert any(
+        query[2] == "Email = 'new.contact@example.com'" for query in client.queries
+    )
 
 
 def test_duplicate_create_can_recover_with_an_alternate_email_contact(tmp_path):

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -174,6 +174,101 @@ def test_staging_publishes_deduplicated_contact_resolution_contract():
     assert resolution["submitted"]["last_name"] == "Smith"
 
 
+def test_staging_normalizes_submitter_and_every_submitted_role_consistently():
+    record = submission(
+        Name__c="  jane mcdonald  ",
+        Email__c=" JANE.Submitter@Example.COM ",
+        Phone__c="+1 (312) 555-0100 ext. 123",
+        Cert_First_Name__c="aLEX",
+        Cert_Last_Name__c="mcdonald",
+        Cert_Title__c="chief qa officer",
+        Cert_Email__c=" CERT@Example.COM ",
+        Cert_Phone__c="312-555-0101",
+        Principal_First_Name__c="pat",
+        Principal_Last_Name__c="o'connor",
+        Principal_Title__c="ceo",
+        Principal_Email__c=" PRINCIPAL@Example.COM ",
+        Principal_Phone__c="1 312 555 0102",
+        AP_First_Name__c="casey",
+        AP_Last_Name__c="mackenzie",
+        AP_Title__c="vp of it",
+        AP_Email__c=" AP@Example.COM ",
+        AP_Phone__c="3125550103 x004",
+        Quality_First_Name__c="taylor",
+        Quality_Last_Name__c="lee",
+        QC_Title__c="qms api manager",
+        Quality_Email__c=" QUALITY@Example.COM ",
+        Quality_Phone__c="(312) 555-0104 #55",
+        NY_First_Name__c="morgan",
+        NY_Last_Name__c="reed",
+        NY_Email__c=" NY@Example.COM ",
+        NY_Phone__c="+44 20 7946 0958",
+    )
+
+    result, _ = stage([record], accounts=[account(ParentId="")])
+
+    row = result.rows[0]
+    assert (
+        row["submitter_name"],
+        row["submitter_email"],
+        row["submitter_phone"],
+    ) == (
+        "Jane McDonald",
+        "jane.submitter@example.com",
+        "312.555.0100 x123",
+    )
+    expected_roles = {
+        "certification": {
+            "first_name": "Alex",
+            "last_name": "McDonald",
+            "title": "Chief QA Officer",
+            "email": "cert@example.com",
+            "phone": "312.555.0101",
+        },
+        "principal": {
+            "first_name": "Pat",
+            "last_name": "O'Connor",
+            "title": "CEO",
+            "email": "principal@example.com",
+            "phone": "312.555.0102",
+        },
+        "accounting": {
+            "first_name": "Casey",
+            "last_name": "MacKenzie",
+            "title": "VP Of IT",
+            "email": "ap@example.com",
+            "phone": "312.555.0103 x004",
+        },
+        "quality": {
+            "first_name": "Taylor",
+            "last_name": "Lee",
+            "title": "QMS API Manager",
+            "email": "quality@example.com",
+            "phone": "312.555.0104 x55",
+        },
+        "new_york": {
+            "first_name": "Morgan",
+            "last_name": "Reed",
+            "email": "ny@example.com",
+            "phone": "+44 20 7946 0958",
+        },
+    }
+    resolutions = {
+        item["normalized_email"]: item["submitted"]
+        for item in json.loads(row["contact_resolutions"])
+    }
+    assert resolutions["jane.submitter@example.com"] == {
+        "first_name": "Jane",
+        "last_name": "McDonald",
+        "email": "jane.submitter@example.com",
+        "phone": "312.555.0100 x123",
+    }
+    for prefix, expected in expected_roles.items():
+        for suffix, value in expected.items():
+            assert row[f"{prefix}_{suffix}"] == value
+        assert resolutions[expected["email"]] == expected
+
+
 def test_staging_queries_the_parent_account_as_part_of_the_family():
     _, client = stage([submission()], accounts=[account()])
 
@@ -404,7 +499,7 @@ def test_same_submitted_contact_in_multiple_roles_is_not_ambiguous():
     row = result.rows[0]
     assert row["certification_resolution_action"] == "use_submitted_contact"
     assert row["certification_title"] == "President"
-    assert row["certification_phone"] == "312-555-0142"
+    assert row["certification_phone"] == "312.555.0142"
     assert row["certification_warning"] == ""
     assert row["has_warnings"] == "false"
 
@@ -513,7 +608,7 @@ def test_another_submitted_role_filling_optional_contact_details_is_reported():
 
     row = result.rows[0]
     assert row["certification_title"] == "President"
-    assert row["certification_phone"] == "312-555-0142"
+    assert row["certification_phone"] == "312.555.0142"
     assert row["has_contact_derived_values"] == "true"
 
 


### PR DESCRIPTION
## Summary
- Normalize submitted contact names, titles, emails, and recognizable North American phone numbers.
- Apply the same normalization during interactive profile-update processing.
- Document the normalization rules and add focused coverage.

Closes #19