### PR TITLE
Process profile contacts before role links

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,15 +410,42 @@ Each real field change accepts a shortcut or its complete decision phrase:
 Shortcuts and phrases are case-insensitive. Audit entries always store the
 complete phrase.
 
-All staged-row checkpoints are completed before Salesforce changes begin.
-Every distinct submitter or role email is then resolved once for the whole Case
-batch. Ambiguous matches show candidates and allow the reviewer to select one,
-create a new Contact, or ignore only that email. Likely typos show the suggested
-Contact and comparison key and require confirmation. Approved Contact creates
-and field updates finish first, non-role Account changes follow, and Account
-role assignments happen last. Several rows or roles with the same comparison
-key reuse the same result. A role without an email keeps its current
-Account-role Contact and cannot create one automatically.
+All staged-row checkpoints are completed before Salesforce changes begin. The
+review then prints three explicit sections in order: `Contact Updates`,
+`Account Updates`, and `Role Links`.
+
+The Contact section reloads every source Profile Update from Salesforce and
+collects only nonblank Contact values that were explicitly submitted for the
+submitter or a role. Staging fallbacks and old Salesforce values can help
+identify a Contact, but they are never treated as proposed changes. Salesforce
+Contact IDs are the primary identity, including the current Account-role
+lookup for partial or changed-email submissions. When no ID identifies the
+person, the existing conservative email matching rules still decide whether an
+exact Contact can be used, a new Contact can be created, or an operator choice
+is required.
+
+All values for the same Contact are reconciled together. Repeated normalized
+values collapse into one proposal with all of their sources. Distinct nonblank
+values are a conflict—even when two submissions supplied them for the same
+role. The reviewer sees every candidate value and its submission/role sources
+side by side, then must choose a candidate or `current` for each conflicting
+field. Choosing `current` removes that field from the eventual Salesforce
+write. Every conflict is resolved before the first Contact write.
+
+After reconciliation, one Contact-level table shows each current value,
+reconciled value, and source. One `A`, `M`, or `N` decision applies to the
+complete Contact. An automatic decision makes at most one Contact
+`update_record` call, or creates a shared new Contact once. A manual decision
+verifies all proposed fields together. A rejected Contact is unchanged.
+Source-to-Contact mappings are preserved after creation and email changes, so
+the final role section can reuse the same resolved Contact safely.
+
+Non-role Account changes run after every Contact is complete. The `Role Links`
+section runs last and may update only Account lookup fields; it never creates
+or updates a Contact. Several rows or roles that describe the same Contact
+reuse its one result. A partial role without an email uses its current
+Account-role Contact when available and cannot create a new Contact
+automatically without safe identity evidence.
 
 When a submitter email is also used by a role, the richer role details are used
 for Contact work. Otherwise the submitter name is split at its final space.
@@ -427,11 +454,9 @@ Contact created by that decision is assigned to `Case.ContactId` and both
 writes are audited separately. Merely matching an existing submitter Contact
 does not change `Case.ContactId`.
 
-Before individual fields are reviewed, an existing Contact's name, title,
-email, and phone are shown together. The submitted values are shown together
-before a new-Contact decision. Account-role proposals show current and proposed
-Contact names and emails; Salesforce Contact IDs remain internal to writes and
-the audit trail instead of appearing in decision prompts.
+Account-role proposals show current and proposed Contact names and emails;
+Salesforce Contact IDs remain internal to writes and the audit trail instead of
+appearing in decision prompts.
 
 If a Contact create is blocked by Salesforce with `DUPLICATES_DETECTED`, the
 structured error is retained and the reviewer can create manually, update an
@@ -456,9 +481,12 @@ response_emails.txt
 
 The JSON Lines audit is flushed after every decision and Salesforce result.
 Contact events include classification, comparison key, candidates, selected
-Contact, reason, confidence, and warnings. Operator selections, duplicate
-recovery, ignored entries, Contact writes, Case Contact assignment, and role
-assignments are separate events.
+Contact, reason, confidence, and warnings. Each conflict choice is an explicit
+event containing its candidate values and sources. Each reconciled Contact has
+one aggregate create/update event containing the final field dictionary and
+all source submission IDs. Operator identity selections, duplicate recovery,
+ignored entries, Case Contact assignment, and role assignments remain separate
+events.
 The response file contains one generated paragraph per submitter email.
 Account-information changes keep the `ITEM: NEW INFORMATION` and
 `Replaces OLD INFORMATION` format. Each submitted Contact role is consolidated

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ order:
 
 The command prints progress before and after authentication, Case preparation,
 staging, CSV publication, CSV validation, and review startup. Section
-separators make workflow stages, Cases, staged rows, Contact roles, and response
-emails easier to distinguish.
+separators make workflow stages, Cases, staged rows, individual Contact
+reviews, and response emails easier to distinguish.
 
 Use `--output-dir` the same way as the staging command:
 
@@ -418,32 +418,52 @@ The Contact section reloads every source Profile Update from Salesforce and
 collects only nonblank Contact values that were explicitly submitted for the
 submitter or a role. Staging fallbacks and old Salesforce values can help
 identify a Contact, but they are never treated as proposed changes. Salesforce
-Contact IDs are the primary identity, including the current Account-role
-lookup for partial or changed-email submissions. When no ID identifies the
-person, the existing conservative email matching rules still decide whether an
-exact Contact can be used, a new Contact can be created, or an operator choice
-is required.
+Contacts with a valid submitted email are identified by that email before role
+assignment is considered. The processor queries fresh Contacts and applies the
+conservative family-aware matching rules to decide whether an exact Contact can
+be used, a new Contact can be created, or an operator choice is required. It
+does not assume that the Contact currently holding a role is the submitted
+person. For example, if Tim's email is submitted for the principal role while
+Ray currently holds that role, Tim's Contact is reviewed and updated; Ray's
+Contact is not used merely because of the role. A partial proposal with no
+email may still use its staged or current Account-role Contact ID as a safe
+fallback.
 
-All values for the same Contact are reconciled together. Repeated normalized
-values collapse into one proposal with all of their sources. Distinct nonblank
-values are a conflict—even when two submissions supplied them for the same
-role. The reviewer sees every candidate value and its submission/role sources
-side by side, then must choose a candidate or `current` for each conflicting
-field. Choosing `current` removes that field from the eventual Salesforce
-write. Every conflict is resolved before the first Contact write.
+All values for the same email identity are reconciled together. Repeated
+normalized values collapse into one proposal with all of their sources.
+Different email identities remain separate Contact reviews even when they
+appeared in the same role. If identity review later resolves two entries to the
+same Salesforce Contact ID, their proposals are combined at that point.
+Distinct nonblank values for one resolved Contact are a conflict. The reviewer
+sees every candidate value and its submission/role sources side by side, then
+must choose a candidate or `current` for each conflicting field. Choosing
+`current` removes that field from the eventual Salesforce write. Every conflict
+is resolved before the first Contact write.
 
-After reconciliation, one Contact-level table shows each current value,
-reconciled value, and source. One `A`, `M`, or `N` decision applies to the
-complete Contact. An automatic decision makes at most one Contact
-`update_record` call, or creates a shared new Contact once. A manual decision
-verifies all proposed fields together. A rejected Contact is unchanged.
-Source-to-Contact mappings are preserved after creation and email changes, so
-the final role section can reuse the same resolved Contact safely.
+After reconciliation, the heading identifies the person and email rather than
+leading with a role. One Contact-level table shows each current value,
+reconciled value, and source. The final comparison uses readable field lines
+instead of printing a Python dictionary. For example:
+
+```text
+Salesforce changes:
+Title: Old Title -> Owner
+Phone: 312.555.0101 -> 312.555.0199
+```
+
+One `A`, `M`, or `N` decision applies to the complete Contact. An automatic
+decision makes at most one Contact `update_record` call, or creates a shared
+new Contact once. A manual decision verifies all proposed fields together. A
+rejected Contact is unchanged. Source-to-Contact mappings are preserved after
+creation and email changes, so the final role section can reuse the same
+resolved Contact safely.
 
 Non-role Account changes run after every Contact is complete. The `Role Links`
 section runs last and may update only Account lookup fields; it never creates
 or updates a Contact. Several rows or roles that describe the same Contact
-reuse its one result. A partial role without an email uses its current
+reuse its one result. This separation means a Contact is first brought up to
+date based on its identity; only afterward does the reviewer decide which role
+should point to it. A partial role without an email uses its current
 Account-role Contact when available and cannot create a new Contact
 automatically without safe identity evidence.
 
@@ -484,9 +504,10 @@ Contact events include classification, comparison key, candidates, selected
 Contact, reason, confidence, and warnings. Each conflict choice is an explicit
 event containing its candidate values and sources. Each reconciled Contact has
 one aggregate create/update event containing the final field dictionary and
-all source submission IDs. Operator identity selections, duplicate recovery,
-ignored entries, Case Contact assignment, and role assignments remain separate
-events.
+all source submission IDs. This structured dictionary remains in the JSON audit
+for machine-readable traceability, but it is not printed as the reviewer-facing
+comparison. Operator identity selections, duplicate recovery, ignored entries,
+Case Contact assignment, and role assignments remain separate events.
 The response file contains one generated paragraph per submitter email.
 Account-information changes keep the `ITEM: NEW INFORMATION` and
 `Replaces OLD INFORMATION` format. Each submitted Contact role is consolidated

--- a/docs/api.md
+++ b/docs/api.md
@@ -192,7 +192,13 @@ decisions, Salesforce execution, response formatting, and audit writing
 separate.
 
 `InteractiveProfileUpdateProcessor` refetches a target immediately before each
-decision. It writes `review_audit.jsonl` after every result and
+decision. Submitted Contacts with valid emails are resolved and reconciled by
+email identity before Account role assignment; a current role Contact ID is
+only a fallback for a partial proposal without an email. Different emails stay
+separate even when submitted for the same role, unless identity review resolves
+them to the same Salesforce Contact. Reviewer-facing Contact comparisons use
+labeled field lines, while the JSON audit retains structured dictionaries. The
+processor writes `review_audit.jsonl` after every result and
 `response_emails.txt` for successful Account changes and completed submitted
 roles. Profile Update closure and the Case's final status happen only after the
 entire Case batch is resolved. `format_response_emails` keeps Account field

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -702,34 +702,69 @@ An already-current value is an audited no-op. It does not prompt and does not
 appear in response-email text.
 
 All row checkpoints are shown before the first Salesforce write. Processing
-then uses these ordered phases:
+then prints and completes these ordered phases:
 
-1. Resolve every distinct submitter and role comparison key for the Case.
-2. Show ambiguous candidates and collect all operator choices. A reviewer may
-   select one, create a Contact, or ignore only that email. A likely typo shows
-   its suggested Contact and corrected comparison and requires confirmation.
-3. Finish all approved Contact creates and field updates.
-4. Process non-role Account changes.
-5. Assign resolved Contacts to Account roles.
+1. `Contact Updates`
+2. `Account Updates`
+3. `Role Links`
 
-The same resolved Contact is reused when several roles or rows share a key.
-Roles without email keep their current Account-role Contact; they cannot create
-a new Contact automatically. Ignoring an email skips only its resolutions and
-roles.
+### Contact Updates
 
-When submitter and role email keys match, richer role details take precedence.
-Otherwise `Name__c` is split at the final space for possible Contact creation.
-Creation still requires an explicit decision. If that decision creates the
-submitter Contact, its ID is assigned to `Case.ContactId`; the Contact create
-and Case update are audited separately. Matching an existing submitter Contact
-alone never changes `Case.ContactId`.
+The processor reloads every source Profile Update and collects each nonblank
+Contact value explicitly submitted for the submitter and every role. The
+flattened staging `submitted` dictionary, staging fallbacks, and existing
+Salesforce field values are not proposals. Blank values neither erase a field
+nor participate in a conflict.
 
-For an exact match, the Contact's current name, title, email, and phone are
-displayed together before its individual fields. For a new Contact, all
-submitted details are displayed together before the creation decision.
-Account-role proposals use friendly Contact names and emails for the current
-and proposed values. Salesforce IDs remain available internally for record
-writes and audit entries, but are not exposed in decision prompts.
+Contact identity is based primarily on a Salesforce Contact ID. This includes
+fresh current Account-role lookups for partial updates and staged
+`change_email` or `update_contact` resolutions. When there is no identifying
+ID, exact, ambiguous, likely-typo, and new-Contact email matching continues to
+use the conservative family-aware rules described above. Ambiguous candidates
+are shown together; the reviewer may select one, create a Contact, or ignore
+that unresolved entry.
+
+Proposals for the same Contact are grouped across rows, roles, and
+submissions. Identical normalized values are stored once with all their
+sources. Distinct values conflict, including two values submitted for the same
+role. For each conflict, the command displays numbered candidate values beside
+their submission/role sources and prompts:
+
+```text
+Choose reconciled Title [1-2/current]:
+```
+
+The reviewer must choose one candidate or `current`. Choosing `current` keeps
+the current Salesforce value and removes that field from the final write. All
+identity and field-conflict choices finish before any Contact is written.
+
+A final table for each Contact shows `Field`, `Current Salesforce`,
+`Reconciled`, and `Sources`. The reviewer then makes one `A`, `M`, or `N`
+decision for the complete Contact:
+
+- `A` updates all changed fields in one `update_record` call, or creates a
+  shared new Contact once.
+- `M` pauses for a manual change and verifies all reconciled fields together.
+- `N` leaves the Contact unchanged.
+
+Thus each resolved Contact has at most one automated Contact create or update
+call in a run. A Contact already matching every reconciled value is an audited
+no-op without a decision prompt. If a new submitter Contact is created, its ID
+is assigned to `Case.ContactId`; matching an existing submitter alone does not
+change that Case lookup.
+
+### Account Updates and Role Links
+
+Ordinary company-name, owner, and billing-address changes run only after the
+Contact phase is complete. The final role-link phase uses the preserved mapping
+from each submission/role source to its resolved Contact ID, so it still works
+when phase one changed the Contact email or created a Contact shared by several
+roles. This phase may update Account role lookup fields only. It performs no
+Contact create or update.
+
+Account-role proposals use friendly Contact names and emails for current and
+proposed values. Salesforce IDs remain available internally for record writes
+and audit entries, but are not exposed in decision prompts.
 
 ### Duplicate-create recovery
 
@@ -784,9 +819,12 @@ so the Case is also set to `Closed`. If a response is not sent, the source
 records are closed and the Case stays `Pending`.
 
 Contact audit objects include classification, comparison key, candidates,
-selected Contact, reason, confidence, and warnings. Operator selections,
-duplicate recovery, ignored entries, Contact writes, Case Contact assignment,
-and later Account-role assignments are separate, immediately flushed events.
+selected Contact, reason, confidence, and warnings. Every field-conflict
+selection is an explicit event that records the candidate values and their
+sources. A single aggregate Contact create/update event records the final field
+dictionary and every source submission ID for that Contact. Operator identity
+selections, duplicate recovery, ignored entries, Case Contact assignment, and
+later Account-role assignments are separate, immediately flushed events.
 
 On interruption, an unrelated Salesforce failure, or a manual value that does not verify,
 the audit is flushed, unfinalized source Profile Updates stay open, the Case is

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -585,6 +585,12 @@ warning for human review. Resolution sources show whether the match came from
 another submitted role, submitted data for a new Contact, an Account Contact, a
 sibling Account Contact, or the Account's current role lookup.
 
+These prefixed actions explain the read-only staging recommendation; they do
+not override fresh identity resolution during processing. In particular,
+`change_email` does not cause a valid submitted email to be written onto the
+current role Contact automatically. The processing command resolves that email
+as its own Contact identity first.
+
 The target Account's **family accounts** are the target itself, its parent, and
 its **sibling accounts** with the same parent. A root Account without a parent
 has a family containing only itself. Contacts from this family are preferred.
@@ -656,7 +662,7 @@ reviewed first, followed by the remaining batches from oldest to newest.
 Progress messages appear around authentication, Case preparation, staging, CSV
 publication, CSV validation, and review startup. The same output channel is
 used for progress and interactive review. Visual separators mark stages, Cases,
-staged rows, Contact roles, and response-email sections.
+staged rows, individual Contact reviews, and response-email sections.
 
 ### What the reviewer sees
 
@@ -716,19 +722,24 @@ flattened staging `submitted` dictionary, staging fallbacks, and existing
 Salesforce field values are not proposals. Blank values neither erase a field
 nor participate in a conflict.
 
-Contact identity is based primarily on a Salesforce Contact ID. This includes
-fresh current Account-role lookups for partial updates and staged
-`change_email` or `update_contact` resolutions. When there is no identifying
-ID, exact, ambiguous, likely-typo, and new-Contact email matching continues to
-use the conservative family-aware rules described above. Ambiguous candidates
-are shown together; the reviewer may select one, create a Contact, or ignore
-that unresolved entry.
+When a proposal contains a valid submitted email, that email is the starting
+identity and the Contact's role does not choose the record. The processor
+queries fresh Salesforce Contacts, then applies the exact, ambiguous,
+likely-typo, and new-Contact family-aware rules described above. It does not
+automatically attach the proposal to the Contact currently holding the role.
+For example, submitted details for `tim@wsfabrication.com` are compared with
+Tim's Contact even if Ray is the current principal. A partial proposal with no
+email can still use a staged Contact ID or the fresh current Account-role
+lookup. Ambiguous candidates are shown together; the reviewer may select one,
+create a Contact, or ignore that unresolved entry.
 
-Proposals for the same Contact are grouped across rows, roles, and
-submissions. Identical normalized values are stored once with all their
-sources. Distinct values conflict, including two values submitted for the same
-role. For each conflict, the command displays numbered candidate values beside
-their submission/role sources and prompts:
+Proposals sharing one email comparison key are grouped across rows, roles, and
+submissions. Different emails remain separate Contact work items even when they
+were submitted for the same role. If identity review later selects the same
+Salesforce Contact ID for two items, they are merged then. Identical normalized
+values are stored once with all their sources. Distinct values for one resolved
+Contact conflict. For each conflict, the command displays numbered candidate
+values beside their submission/role sources and prompts:
 
 ```text
 Choose reconciled Title [1-2/current]:
@@ -738,9 +749,20 @@ The reviewer must choose one candidate or `current`. Choosing `current` keeps
 the current Salesforce value and removes that field from the final write. All
 identity and field-conflict choices finish before any Contact is written.
 
-A final table for each Contact shows `Field`, `Current Salesforce`,
-`Reconciled`, and `Sources`. The reviewer then makes one `A`, `M`, or `N`
-decision for the complete Contact:
+A final heading identifies each Contact by person and email, independent of
+role. Its table shows `Field`, `Current Salesforce`, `Reconciled`, and
+`Sources`. The decision summary displays readable lines instead of a Python
+dictionary:
+
+```text
+Salesforce changes:
+Title: Old Title -> Owner
+Phone: 312.555.0101 -> 312.555.0199
+```
+
+A new Contact similarly appears under `New Salesforce values`, with one
+labeled field per line. The reviewer then makes one `A`, `M`, or `N` decision
+for the complete Contact:
 
 - `A` updates all changed fields in one `update_record` call, or creates a
   shared new Contact once.
@@ -760,7 +782,8 @@ Contact phase is complete. The final role-link phase uses the preserved mapping
 from each submission/role source to its resolved Contact ID, so it still works
 when phase one changed the Contact email or created a Contact shared by several
 roles. This phase may update Account role lookup fields only. It performs no
-Contact create or update.
+Contact create or update. Contact identity and field updates therefore finish
+before role assignment can influence an Account lookup.
 
 Account-role proposals use friendly Contact names and emails for current and
 proposed values. Salesforce IDs remain available internally for record writes
@@ -822,9 +845,11 @@ Contact audit objects include classification, comparison key, candidates,
 selected Contact, reason, confidence, and warnings. Every field-conflict
 selection is an explicit event that records the candidate values and their
 sources. A single aggregate Contact create/update event records the final field
-dictionary and every source submission ID for that Contact. Operator identity
-selections, duplicate recovery, ignored entries, Case Contact assignment, and
-later Account-role assignments are separate, immediately flushed events.
+dictionary and every source submission ID for that Contact. The dictionary is
+kept in JSON for machine-readable auditing; the interactive comparison uses the
+readable field lines shown above. Operator identity selections, duplicate
+recovery, ignored entries, Case Contact assignment, and later Account-role
+assignments are separate, immediately flushed events.
 
 On interruption, an unrelated Salesforce failure, or a manual value that does not verify,
 the audit is flushed, unfinalized source Profile Updates stay open, the Case is

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -20,7 +20,6 @@ from .contact_resolution import (
     ContactSource,
     contact_snapshot,
     family_account_ids,
-    merge_resolution,
     normalize_email,
     resolve_contact,
 )
@@ -227,6 +226,46 @@ class _ResolvedContact:
     contact_id: str = ""
     ignored: bool = False
     contact_results: list[ActionResult] | None = None
+
+
+@dataclass
+class _ContactWorkItem:
+    """Fresh proposals that resolve to one Salesforce Contact."""
+
+    key: str
+    resolution: ContactResolution
+    row: dict[str, str]
+    proposals: dict[str, dict[str, list[ContactSource]]]
+    source_keys: set[tuple[str, str, str]]
+    contact_id: str = ""
+    ignored: bool = False
+    original_contact: dict[str, Any] | None = None
+    current_contact: dict[str, Any] | None = None
+    reconciled: dict[str, str] | None = None
+    write_values: dict[str, str] | None = None
+    decision: ReviewDecision | None = None
+    result: ActionResult | None = None
+
+    @property
+    def sources(self) -> list[ContactSource]:
+        """Return every source once, preserving collection order."""
+        unique: dict[tuple[str, str, str], ContactSource] = {}
+        for values in self.proposals.values():
+            for proposal_sources in values.values():
+                for source in proposal_sources:
+                    unique.setdefault(
+                        (source.kind, source.role, source.submission_id), source
+                    )
+        return list(unique.values())
+
+    @property
+    def source_submission_ids(self) -> tuple[str, ...]:
+        """Return submission IDs represented by this Contact."""
+        return tuple(
+            dict.fromkeys(
+                source.submission_id for source in self.sources if source.submission_id
+            )
+        )
 
 
 class ProfileUpdateProcessingWorkflow:
@@ -543,103 +582,12 @@ class InteractiveProfileUpdateProcessor:
         )
 
     def _review_batch(self, batch: CaseBatch, response_writer: _ResponseWriter) -> bool:
-        if any(row.get("contact_resolutions", "").strip() for row in batch.rows):
-            return self._review_resilient_batch(batch, response_writer)
-        return self._review_legacy_batch(batch, response_writer)
-
-    def _review_legacy_batch(
-        self, batch: CaseBatch, response_writer: _ResponseWriter
-    ) -> bool:
-        """Process staging files from before the Contact-resolution contract."""
-        account_name = next(
-            (
-                row.get("account_name", "").strip()
-                for row in batch.rows
-                if row.get("account_name", "").strip()
-            ),
-            batch.account_id,
-        )
-        self.output_fn(
-            _section_heading(
-                f"Case {batch.case_number or batch.case_id}: {account_name}"
-            )
-        )
-        self._update_status_with_audit(
-            batch,
-            batch.case_id,
-            "Case",
-            "Status",
-            CaseStatus.PENDING,
-            action="prepare batch",
-        )
-        fresh_by_id = self._fresh_case_submissions(batch)
-        self._show_case_context(batch, fresh_by_id)
-        self._show_account_history(batch, list(fresh_by_id.values()))
-
-        results: list[ActionResult] = []
-        account_results: list[ActionResult] = []
-        role_responses: list[_RoleResponse] = []
-        for row in batch.rows:
-            self._checkpoint_row(row)
-            fresh_submissions = [
-                fresh_by_id[source_id]
-                for source_id in _json_string_list(row["source_submission_ids"])
-            ]
-            reviewed_account = self._review_account_proposals(
-                batch, row, fresh_submissions
-            )
-            account_results.extend(reviewed_account)
-            results.extend(reviewed_account)
-            reviewed_roles, responses = self._review_roles(
-                batch, row, fresh_submissions
-            )
-            results.extend(reviewed_roles)
-            role_responses.extend(responses)
-
-        emails = format_response_emails(account_results, role_responses)
-        all_sent = True
-        for email, text in emails.items():
-            response_writer.append(batch.case_id, email, text)
-            self.output_fn(
-                f"{_section_heading(f'Response email for {email}', ITEM_SEPARATOR)}"
-                f"\n{text}"
-            )
-            sent = self._prompt_yes_no(
-                f"Was the response email to {email} sent? [yes/no]: "
-            )
-            all_sent = all_sent and sent
-
-        successful_without_email = any(
-            result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
-            and not result.proposal.submitter_email.strip()
-            for result in results
-        )
-        missing_role_email = any(
-            not response.submitter_email.strip() for response in role_responses
-        )
-        all_sent = all_sent and not successful_without_email and not missing_role_email
-        for source_id in batch.source_submission_ids:
-            self._update_status_with_audit(
-                batch,
-                source_id,
-                "Company_Profile_Change__c",
-                "Status__c",
-                ProfileChangeStatus.CLOSED,
-            )
-        case_status = CaseStatus.CLOSED if all_sent else CaseStatus.PENDING
-        self._update_status_with_audit(
-            batch,
-            batch.case_id,
-            "Case",
-            "Status",
-            case_status,
-        )
-        return not all_sent
+        return self._review_resilient_batch(batch, response_writer)
 
     def _review_resilient_batch(
         self, batch: CaseBatch, response_writer: _ResponseWriter
     ) -> bool:
-        """Resolve all Contacts first, then apply Account and role changes."""
+        """Reconcile Contacts once, then process Accounts and role links."""
         account_name = next(
             (
                 row.get("account_name", "").strip()
@@ -661,12 +609,6 @@ class InteractiveProfileUpdateProcessor:
         for row in batch.rows:
             self._checkpoint_row(row)
 
-        resolutions = self._fresh_batch_resolutions(batch, fresh_by_id)
-        resolved: dict[str, _ResolvedContact] = {}
-        for key, resolution in resolutions.items():
-            row = self._row_for_resolution(batch, resolution)
-            resolved[key] = self._review_resolution_choice(batch, row, resolution)
-
         self._update_status_with_audit(
             batch,
             batch.case_id,
@@ -676,16 +618,27 @@ class InteractiveProfileUpdateProcessor:
             action="prepare batch",
         )
 
+        self.output_fn(_section_heading("Contact Updates"))
+        contact_items, source_mapping = self._collect_contact_work(batch, fresh_by_id)
+        contact_items = self._resolve_contact_identities(batch, contact_items)
+        source_mapping = {
+            source_key: next(
+                (item.key for item in contact_items if source_key in item.source_keys),
+                item_key,
+            )
+            for source_key, item_key in source_mapping.items()
+        }
+        for item in contact_items:
+            self._reconcile_contact_fields(batch, item)
+        for item in contact_items:
+            self._prepare_contact_decision(batch, item)
+
         results: list[ActionResult] = []
-        for state in resolved.values():
-            row = self._row_for_resolution(batch, state.resolution)
-            contact_results = self._complete_contact_work(batch, row, state)
-            state.contact_results = contact_results
+        for item in contact_items:
+            contact_results = self._execute_contact_work(batch, item)
             results.extend(contact_results)
 
-        no_email_results = self._review_no_email_role_contacts(batch, fresh_by_id)
-        results.extend(no_email_results)
-
+        self.output_fn(_section_heading("Account Updates"))
         account_results: list[ActionResult] = []
         for row in batch.rows:
             fresh_submissions = [
@@ -696,17 +649,19 @@ class InteractiveProfileUpdateProcessor:
             account_results.extend(reviewed)
             results.extend(reviewed)
 
+        self.output_fn(_section_heading("Role Links"))
         role_responses: list[_RoleResponse] = []
         for row in batch.rows:
             fresh_submissions = [
                 fresh_by_id[source_id]
                 for source_id in _json_string_list(row["source_submission_ids"])
             ]
-            reviewed, responses = self._assign_resolved_roles(
+            reviewed, responses = self._assign_reconciled_roles(
                 batch,
                 row,
                 fresh_submissions,
-                resolved,
+                contact_items,
+                source_mapping,
             )
             results.extend(reviewed)
             role_responses.extend(responses)
@@ -719,14 +674,17 @@ class InteractiveProfileUpdateProcessor:
             role_responses,
         )
 
-    def _fresh_batch_resolutions(
+    def _collect_contact_work(
         self,
         batch: CaseBatch,
         fresh_by_id: dict[str, dict[str, Any]],
-    ) -> dict[str, ContactResolution]:
-        """Reload staged decisions against fresh family and exact-email Contacts."""
-        staged: dict[str, ContactResolution] = {}
-        invalid_index = 0
+    ) -> tuple[
+        list[_ContactWorkItem],
+        dict[tuple[str, str, str], str],
+    ]:
+        """Collect only fresh, explicitly submitted Contact values."""
+        staged_by_source: dict[tuple[str, str, str], ContactResolution] = {}
+        staged_submitter_ids: set[str] = set()
         for row in batch.rows:
             try:
                 raw_items = json.loads(row.get("contact_resolutions", "") or "[]")
@@ -745,87 +703,209 @@ class InteractiveProfileUpdateProcessor:
                     )
                 try:
                     resolution = ContactResolution.from_dict(raw_item)
-                except (
-                    AttributeError,
-                    KeyError,
-                    TypeError,
-                    ValueError,
-                ) as error:
+                except (AttributeError, KeyError, TypeError, ValueError) as error:
                     raise ProcessingError(
                         "A staged Contact resolution has invalid fields."
                     ) from error
-                key = resolution.comparison_key
-                if not key:
-                    invalid_index += 1
-                    key = f"invalid:{invalid_index}:{resolution.normalized_email}"
-                if key in staged:
-                    merge_resolution(staged[key], resolution)
-                    if any(source.kind == "role" for source in resolution.sources):
-                        staged[key].submitted.update(
-                            {
-                                field_name: value
-                                for field_name, value in resolution.submitted.items()
-                                if value
-                            }
+                has_submitter = False
+                for source in resolution.sources:
+                    source_key = (source.kind, source.role, source.submission_id)
+                    staged_by_source[source_key] = resolution
+                    has_submitter = has_submitter or source.kind == "submitter"
+                if has_submitter:
+                    row_source_ids = _json_string_list(row["source_submission_ids"])
+                    staged_submitter_ids.update(row_source_ids)
+                    for submission_id in row_source_ids:
+                        staged_by_source.setdefault(
+                            ("submitter", "", submission_id),
+                            resolution,
                         )
-                else:
-                    staged[key] = resolution
 
-        refreshed: dict[str, ContactResolution] = {}
+        account_fields = [
+            "Id",
+            "ParentId",
+            *(role.account_lookup for role in ROLE_DEFINITIONS),
+        ]
+        account = self.client.get_record("Account", batch.account_id, account_fields)
+        family_ids = self._fresh_family_account_ids(batch)
+
+        occurrences: list[
+            tuple[
+                ContactSource,
+                dict[str, str],
+                dict[str, str],
+                str,
+            ]
+        ] = []
+        for row in batch.rows:
+            for submission_id in _json_string_list(row["source_submission_ids"]):
+                record = fresh_by_id[submission_id]
+                if submission_id in staged_submitter_ids:
+                    name = normalize_contact_value("name", record.get("Name__c"))
+                    first_name, last_name = _split_person_name(name)
+                    details = {
+                        "first_name": first_name,
+                        "last_name": last_name,
+                        "email": normalize_contact_value(
+                            "email", record.get("Email__c")
+                        ),
+                        "phone": normalize_contact_value(
+                            "phone", record.get("Phone__c")
+                        ),
+                    }
+                    details = {
+                        field_name: value
+                        for field_name, value in details.items()
+                        if value
+                    }
+                    if details:
+                        source = ContactSource("submitter", submission_id=submission_id)
+                        staged_resolution = staged_by_source.get(
+                            ("submitter", "", submission_id)
+                        )
+                        selected = (
+                            staged_resolution.selected_contact
+                            if staged_resolution is not None
+                            else None
+                        )
+                        identity_id = (
+                            _display(selected.get("Id")) if selected is not None else ""
+                        )
+                        occurrences.append((source, details, row, identity_id))
+
+                for role in ROLE_DEFINITIONS:
+                    details = {
+                        suffix: normalize_contact_value(
+                            suffix, record.get(source_field)
+                        )
+                        for suffix, source_field in role.submitted_fields
+                    }
+                    details = {
+                        field_name: value
+                        for field_name, value in details.items()
+                        if value
+                    }
+                    if not details:
+                        continue
+                    source = ContactSource(
+                        "role",
+                        role=role.prefix,
+                        submission_id=submission_id,
+                    )
+                    action = row.get(f"{role.prefix}_resolution_action", "").strip()
+                    staged_id = row.get(
+                        f"{role.prefix}_salesforce_contact_id", ""
+                    ).strip()
+                    current_id = _display(account.get(role.account_lookup))
+                    identity_id = ""
+                    if action in {"update_contact", "change_email"}:
+                        identity_id = current_id or staged_id
+                    elif not details.get("email") and action != "create_contact":
+                        identity_id = current_id or staged_id
+                    staged_resolution = staged_by_source.get(
+                        ("role", role.prefix, submission_id)
+                    )
+                    selected = (
+                        staged_resolution.selected_contact
+                        if staged_resolution is not None
+                        else None
+                    )
+                    if not identity_id and selected is not None:
+                        identity_id = _display(selected.get("Id"))
+                    occurrences.append((source, details, row, identity_id))
+
+        email_identity_ids: dict[str, set[str]] = {}
+        for _, details, _, identity_id in occurrences:
+            _, comparison_key, _ = normalize_email(details.get("email"))
+            if comparison_key and identity_id:
+                email_identity_ids.setdefault(comparison_key, set()).add(identity_id)
+
+        grouped: dict[str, _ContactWorkItem] = {}
+        source_mapping: dict[tuple[str, str, str], str] = {}
         invalid_index = 0
-        for staged_resolution in staged.values():
-            sources = staged_resolution.sources or [ContactSource("unknown")]
-            for source in sources:
-                details = self._fresh_source_contact_details(
-                    source,
-                    fresh_by_id,
-                    staged_resolution.submitted,
+        for source, details, row, identity_id in occurrences:
+            normalized_email, comparison_key, warnings = normalize_email(
+                details.get("email")
+            )
+            linked_ids = email_identity_ids.get(comparison_key, set())
+            if not identity_id and len(linked_ids) == 1:
+                identity_id = next(iter(linked_ids))
+            if identity_id:
+                key = f"id:{identity_id}"
+            elif comparison_key:
+                key = f"email:{comparison_key}"
+            else:
+                invalid_index += 1
+                key = (
+                    f"unresolved:{invalid_index}:{source.kind}:"
+                    f"{source.role}:{source.submission_id}"
                 )
-                email = details.get("email") or staged_resolution.normalized_email
-                normalized, comparison_key, _ = normalize_email(email)
-                key = comparison_key
-                if not comparison_key:
-                    invalid_index += 1
-                    key = f"invalid:{invalid_index}:{normalized}"
-                if key not in refreshed:
-                    refreshed[key] = ContactResolution(
-                        staged_resolution.classification,
-                        normalized,
+            source_key = (source.kind, source.role, source.submission_id)
+            source_mapping[source_key] = key
+            item = grouped.get(key)
+            if item is None:
+                if identity_id:
+                    contact = self.client.get_record(
+                        "Contact", identity_id, CONTACT_REVIEW_FIELDS
+                    )
+                    resolution = ContactResolution(
+                        ContactResolutionClassification.USE_EXISTING,
+                        normalized_email,
                         comparison_key,
                         sources=[source],
-                        reason=staged_resolution.reason,
-                        confidence=staged_resolution.confidence,
-                        warnings=list(staged_resolution.warnings),
-                        submitted=details,
+                        selected_contact=contact,
+                        reason=(
+                            "The fresh Salesforce Contact ID identified the "
+                            "existing Contact."
+                        ),
+                        confidence="exact Contact ID",
+                        warnings=warnings,
                     )
                 else:
-                    refreshed[key].sources.append(source)
-                    refreshed[key].warnings.extend(
-                        warning
-                        for warning in staged_resolution.warnings
-                        if warning not in refreshed[key].warnings
+                    classification = (
+                        ContactResolutionClassification.CREATE_NEW
+                        if source.kind == "role"
+                        and row.get(f"{source.role}_resolution_action", "").strip()
+                        == "create_contact"
+                        else ContactResolutionClassification.AMBIGUOUS
                     )
-                    if source.kind == "role":
-                        refreshed[key].submitted.update(
-                            {
-                                field_name: value
-                                for field_name, value in details.items()
-                                if value
-                            }
-                        )
-        staged = refreshed
+                    resolution = ContactResolution(
+                        classification,
+                        normalized_email,
+                        comparison_key,
+                        sources=[source],
+                        reason="Fresh Contact proposals require matching.",
+                        confidence="unresolved",
+                        warnings=warnings,
+                    )
+                item = _ContactWorkItem(
+                    key,
+                    resolution,
+                    row,
+                    proposals={},
+                    source_keys=set(),
+                    contact_id=identity_id,
+                )
+                grouped[key] = item
+            elif source not in item.resolution.sources:
+                item.resolution.sources.append(source)
+            item.source_keys.add(source_key)
+            for field_name, value in details.items():
+                item.proposals.setdefault(field_name, {}).setdefault(value, []).append(
+                    source
+                )
 
-        family_ids = self._fresh_family_account_ids(batch)
         contacts: list[dict[str, Any]] = []
-        for resolution in staged.values():
-            if not resolution.normalized_email:
+        for item in grouped.values():
+            if item.contact_id or not item.resolution.normalized_email:
                 continue
             contacts.extend(
                 self.client.query_records(
                     "Contact",
                     CONTACT_REVIEW_FIELDS,
                     where=(
-                        f"Email = '{escape_soql_string(resolution.normalized_email)}'"
+                        "Email = "
+                        f"'{escape_soql_string(item.resolution.normalized_email)}'"
                     ),
                     order_by="Id ASC",
                 )
@@ -850,63 +930,646 @@ class InteractiveProfileUpdateProcessor:
             }.values()
         )
 
-        fresh: dict[str, ContactResolution] = {}
-        for key, staged_resolution in staged.items():
-            resolution = resolve_contact(
-                staged_resolution.normalized_email,
+        for item in grouped.values():
+            if item.contact_id:
+                continue
+            if (
+                not item.resolution.comparison_key
+                and item.resolution.classification
+                is not ContactResolutionClassification.CREATE_NEW
+            ):
+                item.ignored = True
+                item.resolution.reason = (
+                    "A partial Contact proposal has no current role Contact ID "
+                    "and no valid email."
+                )
+                item.resolution.warnings.append(
+                    "The Contact proposal was ignored because it cannot be "
+                    "identified safely."
+                )
+                continue
+            if not item.resolution.comparison_key:
+                continue
+            submitted = {
+                field_name: next(iter(values))
+                for field_name, values in item.proposals.items()
+                if values
+            }
+            fresh_resolution = resolve_contact(
+                item.resolution.normalized_email,
                 contacts,
                 family_ids,
-                sources=staged_resolution.sources,
-                submitted=staged_resolution.submitted,
+                sources=item.resolution.sources,
+                submitted=submitted,
             )
-            resolution.warnings = list(
-                dict.fromkeys([*staged_resolution.warnings, *resolution.warnings])
+            fresh_resolution.warnings = list(
+                dict.fromkeys([*item.resolution.warnings, *fresh_resolution.warnings])
             )
-            fresh[key] = resolution
-        return fresh
+            item.resolution = fresh_resolution
+        items = list(grouped.values())
+        for row in batch.rows:
+            row_source_ids = set(_json_string_list(row["source_submission_ids"]))
+            for role in ROLE_DEFINITIONS:
+                same_role = [
+                    item
+                    for item in items
+                    if any(
+                        kind == "role"
+                        and source_role == role.prefix
+                        and submission_id in row_source_ids
+                        for kind, source_role, submission_id in item.source_keys
+                    )
+                ]
+                if len(same_role) < 2:
+                    continue
+                target = same_role[0]
+                preferred_resolution = same_role[-1].resolution
+                selected_contacts = {
+                    _display(
+                        (item.resolution.selected_contact or {}).get("Id")
+                    ): item.resolution.selected_contact
+                    for item in same_role
+                    if _display((item.resolution.selected_contact or {}).get("Id"))
+                }
+                for item in same_role[1:]:
+                    target.source_keys.update(item.source_keys)
+                    for source in item.resolution.sources:
+                        if source not in target.resolution.sources:
+                            target.resolution.sources.append(source)
+                    for field_name, values in item.proposals.items():
+                        for value, sources in values.items():
+                            destination = target.proposals.setdefault(
+                                field_name, {}
+                            ).setdefault(value, [])
+                            destination.extend(
+                                source
+                                for source in sources
+                                if source not in destination
+                            )
+                    items.remove(item)
+                if len(selected_contacts) == 1:
+                    contact = next(iter(selected_contacts.values()))
+                    target.resolution.classification = (
+                        ContactResolutionClassification.USE_EXISTING
+                    )
+                    target.resolution.selected_contact = contact
+                    target.contact_id = _display(contact.get("Id"))
+                elif len(selected_contacts) > 1:
+                    target.resolution.classification = (
+                        ContactResolutionClassification.AMBIGUOUS
+                    )
+                    target.resolution.selected_contact = None
+                    target.resolution.candidates = [
+                        dict(contact)
+                        for contact in selected_contacts.values()
+                        if contact is not None
+                    ]
+                    target.contact_id = ""
+                    target.resolution.reason = (
+                        "Submissions for the same role identify different "
+                        "Salesforce Contacts."
+                    )
+                else:
+                    combined_sources = target.resolution.sources
+                    combined_warnings = target.resolution.warnings
+                    target.resolution = preferred_resolution
+                    target.resolution.sources = combined_sources
+                    target.resolution.warnings = list(
+                        dict.fromkeys(
+                            [
+                                *combined_warnings,
+                                *preferred_resolution.warnings,
+                            ]
+                        )
+                    )
+        return items, source_mapping
+
+    def _resolve_contact_identities(
+        self,
+        batch: CaseBatch,
+        items: list[_ContactWorkItem],
+    ) -> list[_ContactWorkItem]:
+        """Finish identity choices and merge items that select the same ID."""
+        for item in items:
+            if item.ignored:
+                self._audit_resolution(
+                    batch,
+                    item.row,
+                    item.resolution,
+                    ActionStatus.REJECTED,
+                    "ignore Contact without safe identity",
+                )
+                continue
+            state = self._review_resolution_choice(batch, item.row, item.resolution)
+            item.contact_id = state.contact_id
+            item.ignored = state.ignored
+
+        merged: dict[str, _ContactWorkItem] = {}
+        for item in items:
+            key = f"id:{item.contact_id}" if item.contact_id else item.key
+            existing = merged.get(key)
+            if existing is None:
+                item.key = key
+                merged[key] = item
+                continue
+            existing.source_keys.update(item.source_keys)
+            existing.ignored = existing.ignored and item.ignored
+            for source in item.resolution.sources:
+                if source not in existing.resolution.sources:
+                    existing.resolution.sources.append(source)
+            for field_name, values in item.proposals.items():
+                for value, sources in values.items():
+                    target = existing.proposals.setdefault(field_name, {}).setdefault(
+                        value, []
+                    )
+                    target.extend(source for source in sources if source not in target)
+        return list(merged.values())
+
+    def _reconcile_contact_fields(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+    ) -> None:
+        """Resolve every field conflict without writing to Salesforce."""
+        if item.ignored:
+            item.reconciled = {}
+            item.write_values = {}
+            return
+        if item.contact_id:
+            item.current_contact = self.client.get_record(
+                "Contact", item.contact_id, CONTACT_REVIEW_FIELDS
+            )
+            item.original_contact = dict(item.current_contact)
+        else:
+            item.current_contact = {}
+            item.original_contact = {}
+
+        reconciled: dict[str, str] = {}
+        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+            values = item.proposals.get(suffix, {})
+            if (
+                suffix == "email"
+                and item.resolution.classification
+                is ContactResolutionClassification.LIKELY_TYPO
+            ):
+                values = {}
+            if not values:
+                continue
+            if len(values) == 1:
+                reconciled[suffix] = next(iter(values))
+                continue
+            current = _display((item.current_contact or {}).get(contact_field))
+            self.output_fn(
+                _section_heading(
+                    f"Contact field conflict: {field_label}",
+                    ITEM_SEPARATOR,
+                )
+            )
+            for index, (value, sources) in enumerate(values.items(), start=1):
+                self.output_fn(
+                    f"{index}. {value}\n"
+                    f"   Sources: {self._format_contact_sources(sources)}"
+                )
+            self.output_fn(f"current. {current or '(blank)'}")
+            conflict_sources = "\n".join(
+                f"{value}: {self._format_contact_sources(sources)}"
+                for value, sources in values.items()
+            )
+            while True:
+                try:
+                    answer = (
+                        self.input_fn(
+                            f"Choose reconciled {field_label} "
+                            f"[1-{len(values)}/current]: "
+                        )
+                        .strip()
+                        .casefold()
+                    )
+                except StopIteration as error:
+                    proposal = self._contact_proposal(
+                        batch,
+                        item,
+                        field_name=contact_field,
+                        label=f"{field_label} conflict",
+                        original_value=current,
+                        proposed_value="",
+                        warnings=conflict_sources,
+                    )
+                    self._append_audit(
+                        ActionResult(
+                            proposal,
+                            None,
+                            ActionStatus.FAILED,
+                            action="resolve Contact field conflict",
+                            error=(
+                                f"Conflicting {field_label} values require an "
+                                "explicit choice."
+                            ),
+                        )
+                    )
+                    raise ProcessingError(
+                        f"Conflicting {field_label} values require an explicit choice."
+                    ) from error
+                except (KeyboardInterrupt, EOFError) as error:
+                    proposal = self._contact_proposal(
+                        batch,
+                        item,
+                        field_name=contact_field,
+                        label=f"{field_label} conflict",
+                        original_value=current,
+                        proposed_value="",
+                        warnings=conflict_sources,
+                    )
+                    self._append_audit(
+                        ActionResult(
+                            proposal,
+                            None,
+                            ActionStatus.INTERRUPTED,
+                            action="resolve Contact field conflict",
+                            error="Reviewer interrupted conflict resolution.",
+                        )
+                    )
+                    raise ProcessingInterrupted(
+                        "Profile Update review was interrupted."
+                    ) from error
+                if answer == "current":
+                    chosen = current
+                    break
+                if answer.isdigit() and 1 <= int(answer) <= len(values):
+                    chosen = list(values)[int(answer) - 1]
+                    break
+                self.output_fn("Choose a candidate number or current.")
+            reconciled[suffix] = chosen
+            proposal = self._contact_proposal(
+                batch,
+                item,
+                field_name=contact_field,
+                label=f"{field_label} conflict",
+                original_value=current,
+                proposed_value=chosen,
+                warnings=conflict_sources,
+            )
+            self._append_audit(
+                ActionResult(
+                    proposal,
+                    None,
+                    ActionStatus.VERIFIED_MANUAL,
+                    action="resolve Contact field conflict",
+                )
+            )
+
+        item.reconciled = reconciled
+        current = item.current_contact or {}
+        item.write_values = {
+            contact_field: reconciled[suffix]
+            for suffix, contact_field, _ in CONTACT_SUFFIX_FIELDS
+            if suffix in reconciled
+            and reconciled[suffix]
+            and not _values_equal(current.get(contact_field), reconciled[suffix])
+        }
 
     @staticmethod
-    def _fresh_source_contact_details(
-        source: ContactSource,
-        fresh_by_id: dict[str, dict[str, Any]],
-        fallback: dict[str, str],
-    ) -> dict[str, str]:
-        """Overlay fresh submission values on staged Contact details."""
-        details = {
-            field_name: normalize_contact_value(field_name, value)
-            for field_name, value in fallback.items()
-        }
-        record = fresh_by_id.get(source.submission_id)
-        if record is None:
-            return details
-        if source.kind == "submitter":
-            name = normalize_contact_value("name", record.get("Name__c"))
-            first_name, last_name = _split_person_name(name)
-            fresh_values = {
-                "first_name": first_name,
-                "last_name": last_name,
-                "email": normalize_contact_value("email", record.get("Email__c")),
-                "phone": normalize_contact_value("phone", record.get("Phone__c")),
-            }
-        else:
-            role = next(
-                (
-                    definition
-                    for definition in ROLE_DEFINITIONS
-                    if definition.prefix == source.role
-                ),
-                None,
+    def _format_contact_sources(sources: list[ContactSource]) -> str:
+        return ", ".join(
+            (
+                f"{source.submission_id or '(unknown submission)'} / "
+                f"{source.role.replace('_', ' ').title()}"
+                if source.kind == "role"
+                else f"{source.submission_id or '(unknown submission)'} / Submitter"
             )
-            if role is None:
-                return details
-            fresh_values = {
-                suffix: normalize_contact_value(suffix, record.get(source_field))
-                for suffix, source_field in role.submitted_fields
-            }
-        details.update(
-            {field_name: value for field_name, value in fresh_values.items() if value}
+            for source in sources
         )
-        return details
+
+    def _show_reconciled_contact(self, item: _ContactWorkItem) -> None:
+        self.output_fn(
+            _section_heading(
+                f"Reconciled {self._resolution_label(item.resolution)}",
+                ITEM_SEPARATOR,
+            )
+        )
+        self.output_fn("Field | Current Salesforce | Reconciled | Sources")
+        current = item.current_contact or {}
+        reconciled = item.reconciled or {}
+        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+            values = item.proposals.get(suffix, {})
+            if not values:
+                continue
+            sources = [
+                source
+                for proposal_sources in values.values()
+                for source in proposal_sources
+            ]
+            self.output_fn(
+                f"{field_label} | "
+                f"{_display(current.get(contact_field)) or '(blank)'} | "
+                f"{reconciled.get(suffix, '') or '(blank)'} | "
+                f"{self._format_contact_sources(sources)}"
+            )
+
+    def _prepare_contact_decision(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+    ) -> None:
+        """Show one final Contact proposal and collect one A/M/N decision."""
+        if item.ignored:
+            return
+        self._show_reconciled_contact(item)
+        payload = dict(item.write_values or {})
+        if not item.contact_id:
+            payload = {"AccountId": batch.account_id, **payload}
+        proposal = self._contact_proposal(
+            batch,
+            item,
+            field_name="Contact",
+            label=f"{self._resolution_label(item.resolution)} Contact",
+            original_value=item.current_contact or {},
+            proposed_value=payload,
+        )
+        if item.contact_id and not item.write_values:
+            item.result = ActionResult(
+                proposal,
+                None,
+                ActionStatus.NOOP,
+                action="reconciled Contact already current",
+            )
+            self._append_audit(item.result)
+            self.output_fn("Contact is already current; no change needed.")
+            return
+        has_last_name = bool((item.reconciled or {}).get("last_name"))
+        if not item.contact_id and not has_last_name:
+            self.output_fn(
+                "This Contact cannot be created automatically because the "
+                "required Last Name field is missing."
+            )
+        self._show_proposal(proposal)
+        item.decision = self._review_decision(
+            proposal,
+            automatic_allowed=bool(item.contact_id)
+            or (has_last_name and bool(item.resolution.comparison_key)),
+            action="review reconciled Contact",
+        )
+
+    def _execute_contact_work(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+    ) -> list[ActionResult]:
+        """Apply or verify one aggregate Contact decision."""
+        if item.ignored:
+            return []
+        if item.result is not None:
+            return [item.result]
+        proposal = self._contact_proposal(
+            batch,
+            item,
+            field_name="Contact",
+            label=f"{self._resolution_label(item.resolution)} Contact",
+            original_value=item.current_contact or {},
+            proposed_value=(
+                dict(item.write_values or {})
+                if item.contact_id
+                else {"AccountId": batch.account_id, **dict(item.write_values or {})}
+            ),
+        )
+        decision = item.decision
+        if decision is ReviewDecision.WILL_NOT_BE_MADE:
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.REJECTED,
+                action="no Contact write",
+            )
+            self._append_audit(result)
+            item.result = result
+            return [result]
+        if decision is ReviewDecision.MAKE_MANUALLY:
+            result = self._verify_manual_contact(batch, item, proposal)
+        elif item.contact_id:
+            try:
+                self.client.update_record(
+                    "Contact", item.contact_id, dict(item.write_values or {})
+                )
+            except SalesforceError as error:
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.FAILED,
+                    action="update Contact from reconciled proposals",
+                    error=str(error),
+                    error_code=error.error_code or "",
+                    salesforce_message=error.salesforce_message or "",
+                )
+                self._append_audit(result)
+                raise ProcessingError(str(error)) from error
+            result = ActionResult(
+                proposal,
+                decision,
+                ActionStatus.APPLIED,
+                action="update Contact from reconciled proposals",
+            )
+            self._append_audit(result)
+        else:
+            try:
+                contact_id = self.client.create_record(
+                    "Contact", dict(proposal.proposed_value)
+                )
+            except SalesforceError as error:
+                if _is_duplicate_contact_error(error):
+                    result = self._recover_duplicate_contact(
+                        batch,
+                        item.row,
+                        proposal,
+                        item.resolution,
+                        error,
+                    )
+                    contact_id = result.proposal.target_record_id
+                else:
+                    result = ActionResult(
+                        proposal,
+                        decision,
+                        ActionStatus.FAILED,
+                        action="create Contact",
+                        error=str(error),
+                        error_code=error.error_code or "",
+                        salesforce_message=error.salesforce_message or "",
+                    )
+                    self._append_audit(result)
+                    raise ProcessingError(str(error)) from error
+            else:
+                created_proposal = ChangeProposal(
+                    **{
+                        **proposal.__dict__,
+                        "target_record_id": contact_id,
+                        "selected_contact": contact_snapshot(
+                            {"Id": contact_id, **dict(proposal.proposed_value)}
+                        ),
+                    }
+                )
+                result = ActionResult(
+                    created_proposal,
+                    decision,
+                    ActionStatus.APPLIED,
+                    action="create Contact",
+                )
+                self._append_audit(result)
+            if result.status in {
+                ActionStatus.APPLIED,
+                ActionStatus.VERIFIED_MANUAL,
+            }:
+                item.contact_id = contact_id
+
+        item.result = result
+        results = [result]
+        if result.status in {
+            ActionStatus.APPLIED,
+            ActionStatus.VERIFIED_MANUAL,
+        }:
+            item.current_contact = self.client.get_record(
+                "Contact", item.contact_id, CONTACT_REVIEW_FIELDS
+            )
+            item.resolution.selected_contact = item.current_contact
+            if (
+                not proposal.target_record_id or proposal.target_record_id == "(new)"
+            ) and any(source.kind == "submitter" for source in item.sources):
+                results.append(
+                    self._assign_created_submitter_to_case(
+                        batch,
+                        item.row,
+                        item.resolution,
+                        item.contact_id,
+                    )
+                )
+        return results
+
+    def _verify_manual_contact(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+        proposal: ChangeProposal,
+    ) -> ActionResult:
+        """Verify all reconciled Contact fields together."""
+        try:
+            if item.contact_id:
+                self.input_fn(
+                    "Make the complete Contact change in Salesforce, then "
+                    "press Enter to verify it: "
+                )
+                contact_id = item.contact_id
+            else:
+                contact_id = self.input_fn(
+                    "Create the Contact in Salesforce, then enter its Contact ID: "
+                ).strip()
+                if not contact_id:
+                    raise ProcessingError(
+                        "A Contact ID is required for manual verification."
+                    )
+            fresh = self.client.get_record("Contact", contact_id, CONTACT_REVIEW_FIELDS)
+        except (KeyboardInterrupt, EOFError) as error:
+            result = ActionResult(
+                proposal,
+                ReviewDecision.MAKE_MANUALLY,
+                ActionStatus.INTERRUPTED,
+                action="verify reconciled Contact manually",
+                error="Reviewer interrupted processing.",
+            )
+            self._append_audit(result)
+            raise ProcessingInterrupted(
+                "Profile Update review was interrupted."
+            ) from error
+        except ProcessingError as error:
+            result = ActionResult(
+                proposal,
+                ReviewDecision.MAKE_MANUALLY,
+                ActionStatus.FAILED,
+                action="verify reconciled Contact manually",
+                error=str(error),
+            )
+            self._append_audit(result)
+            raise
+        except SalesforceError as error:
+            result = ActionResult(
+                proposal,
+                ReviewDecision.MAKE_MANUALLY,
+                ActionStatus.FAILED,
+                action="verify reconciled Contact manually",
+                error=str(error),
+            )
+            self._append_audit(result)
+            raise ProcessingError(str(error)) from error
+        expected = item.write_values or {}
+        if not item.contact_id:
+            expected = {
+                field_name: value
+                for field_name, value in proposal.proposed_value.items()
+                if field_name != "AccountId"
+            }
+        if (
+            not item.contact_id
+            and not _values_equal(fresh.get("AccountId"), batch.account_id)
+        ) or any(
+            not _values_equal(fresh.get(field_name), value)
+            for field_name, value in expected.items()
+        ):
+            error = "Salesforce Contact does not match all reconciled proposed fields."
+            result = ActionResult(
+                proposal,
+                ReviewDecision.MAKE_MANUALLY,
+                ActionStatus.FAILED,
+                action="verify reconciled Contact manually",
+                error=error,
+            )
+            self._append_audit(result)
+            raise ProcessingError(error)
+        item.contact_id = contact_id
+        verified_proposal = ChangeProposal(
+            **{
+                **proposal.__dict__,
+                "target_record_id": contact_id,
+                "selected_contact": contact_snapshot(fresh),
+            }
+        )
+        result = ActionResult(
+            verified_proposal,
+            ReviewDecision.MAKE_MANUALLY,
+            ActionStatus.VERIFIED_MANUAL,
+            action="verify reconciled Contact manually",
+        )
+        self._append_audit(result)
+        return result
+
+    def _contact_proposal(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+        *,
+        field_name: str,
+        label: str,
+        original_value: Any,
+        proposed_value: Any,
+        warnings: str = "",
+    ) -> ChangeProposal:
+        """Build an aggregate Contact proposal with every source ID."""
+        base = self._proposal(
+            batch,
+            item.row,
+            target_object="Contact",
+            target_record_id=item.contact_id or "(new)",
+            field_name=field_name,
+            label=label,
+            original_value=original_value,
+            proposed_value=proposed_value,
+            resolution=item.resolution,
+        )
+        return ChangeProposal(
+            **{
+                **base.__dict__,
+                "source_submission_ids": item.source_submission_ids,
+                "warnings": "\n".join(
+                    value for value in (base.warnings, warnings) if value
+                ),
+            }
+        )
 
     def _fresh_family_account_ids(self, batch: CaseBatch) -> set[str]:
         target = self.client.get_record("Account", batch.account_id, ["Id", "ParentId"])
@@ -925,25 +1588,6 @@ class InteractiveProfileUpdateProcessor:
                 )
             )
         return family_account_ids(target, family_accounts)
-
-    def _row_for_resolution(
-        self, batch: CaseBatch, resolution: ContactResolution
-    ) -> dict[str, str]:
-        source_ids = {
-            source.submission_id
-            for source in resolution.sources
-            if source.submission_id
-        }
-        return next(
-            (
-                row
-                for row in batch.rows
-                if source_ids.intersection(
-                    _json_string_list(row["source_submission_ids"])
-                )
-            ),
-            batch.rows[0],
-        )
 
     def _review_resolution_choice(
         self,
@@ -1036,6 +1680,13 @@ class InteractiveProfileUpdateProcessor:
                     .casefold()
                 )
             except StopIteration as error:
+                self._audit_resolution(
+                    batch,
+                    row,
+                    resolution,
+                    ActionStatus.FAILED,
+                    "resolve ambiguous Contact",
+                )
                 raise ProcessingError(
                     "Multiple Salesforce Contacts require an explicit "
                     "operator selection."
@@ -1100,162 +1751,6 @@ class InteractiveProfileUpdateProcessor:
         )
         self._append_audit(ActionResult(proposal, None, status, action=action))
 
-    def _complete_contact_work(
-        self,
-        batch: CaseBatch,
-        row: dict[str, str],
-        state: _ResolvedContact,
-    ) -> list[ActionResult]:
-        resolution = state.resolution
-        if state.ignored:
-            return []
-        if state.contact_id:
-            results = self._review_existing_contact_fields(
-                batch,
-                row,
-                resolution,
-                state.contact_id,
-            )
-        else:
-            label = self._resolution_label(resolution)
-            created = self._review_new_contact(
-                batch,
-                row,
-                label,
-                resolution.submitted,
-                resolution=resolution,
-            )
-            results = [created]
-            if created.status in {
-                ActionStatus.APPLIED,
-                ActionStatus.VERIFIED_MANUAL,
-            }:
-                state.contact_id = created.proposal.target_record_id
-                resolution.selected_contact = self.client.get_record(
-                    "Contact", state.contact_id, CONTACT_REVIEW_FIELDS
-                )
-
-        created_contact = any(
-            result.proposal.target_record_id == state.contact_id
-            and result.proposal.field_name == "Contact"
-            and (
-                result.action == "create Contact"
-                or "manual Contact creation" in result.action
-            )
-            and result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
-            for result in results
-        )
-        is_submitter = any(source.kind == "submitter" for source in resolution.sources)
-        if created_contact and is_submitter and state.contact_id:
-            results.append(
-                self._assign_created_submitter_to_case(
-                    batch, row, resolution, state.contact_id
-                )
-            )
-        return results
-
-    def _review_existing_contact_fields(
-        self,
-        batch: CaseBatch,
-        row: dict[str, str],
-        resolution: ContactResolution,
-        contact_id: str,
-    ) -> list[ActionResult]:
-        contact = self.client.get_record("Contact", contact_id, CONTACT_REVIEW_FIELDS)
-        self._show_contact_details(
-            f"Resolved {self._resolution_label(resolution)}",
-            contact,
-        )
-        results: list[ActionResult] = []
-        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
-            proposed = resolution.submitted.get(suffix, "")
-            if not proposed:
-                continue
-            if (
-                suffix == "email"
-                and resolution.classification
-                is ContactResolutionClassification.LIKELY_TYPO
-            ):
-                continue
-            proposal = self._proposal(
-                batch,
-                row,
-                target_object="Contact",
-                target_record_id=contact_id,
-                field_name=contact_field,
-                label=f"{self._resolution_label(resolution)} {field_label}",
-                proposed_value=proposed,
-                resolution=resolution,
-            )
-            results.append(self._review_proposal(proposal))
-        return results
-
-    def _review_no_email_role_contacts(
-        self,
-        batch: CaseBatch,
-        fresh_by_id: dict[str, dict[str, Any]],
-    ) -> list[ActionResult]:
-        """Apply partial role updates to the current role Contact only."""
-        results: list[ActionResult] = []
-        reviewed: set[tuple[str, str, str]] = set()
-        for row in batch.rows:
-            submissions = [
-                fresh_by_id[source_id]
-                for source_id in _json_string_list(row["source_submission_ids"])
-            ]
-            for role in ROLE_DEFINITIONS:
-                submitted = _submitted_role_values(submissions, row, role)
-                if not any(submitted.values()) or submitted.get("email"):
-                    continue
-                contact_id, contact = self._fresh_role_contact(
-                    batch, role.account_lookup
-                )
-                if not contact_id or contact is None:
-                    resolution = ContactResolution(
-                        ContactResolutionClassification.AMBIGUOUS,
-                        "",
-                        "",
-                        sources=[ContactSource("role", role=role.prefix)],
-                        reason=(
-                            "A role without email has no current Account-role "
-                            "Contact and cannot create one automatically."
-                        ),
-                        confidence="none",
-                        warnings=[
-                            "Role without email was ignored because its current "
-                            "Account-role Contact is blank."
-                        ],
-                        submitted=submitted,
-                    )
-                    self._audit_resolution(
-                        batch,
-                        row,
-                        resolution,
-                        ActionStatus.REJECTED,
-                        "ignore role without email and current Contact",
-                    )
-                    continue
-                for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
-                    proposed = submitted.get(suffix, "")
-                    identity = (contact_id, contact_field, proposed)
-                    if not proposed or identity in reviewed:
-                        continue
-                    reviewed.add(identity)
-                    results.append(
-                        self._review_proposal(
-                            self._proposal(
-                                batch,
-                                row,
-                                target_object="Contact",
-                                target_record_id=contact_id,
-                                field_name=contact_field,
-                                label=f"{role.label} Contact {field_label}",
-                                proposed_value=proposed,
-                            )
-                        )
-                    )
-        return results
-
     def _assign_created_submitter_to_case(
         self,
         batch: CaseBatch,
@@ -1295,15 +1790,18 @@ class InteractiveProfileUpdateProcessor:
         self._append_audit(result)
         return result
 
-    def _assign_resolved_roles(
+    def _assign_reconciled_roles(
         self,
         batch: CaseBatch,
         row: dict[str, str],
         submissions: list[dict[str, Any]],
-        resolved: dict[str, _ResolvedContact],
+        items: list[_ContactWorkItem],
+        source_mapping: dict[tuple[str, str, str], str],
     ) -> tuple[list[ActionResult], list[_RoleResponse]]:
+        """Link roles using the preserved source mapping; never mutate Contacts."""
         results: list[ActionResult] = []
         responses: list[_RoleResponse] = []
+        items_by_key = {item.key: item for item in items}
         for role in ROLE_DEFINITIONS:
             submitted = _submitted_role_values(submissions, row, role)
             if not any(submitted.values()):
@@ -1311,37 +1809,23 @@ class InteractiveProfileUpdateProcessor:
             original_id, original_contact = self._fresh_role_contact(
                 batch, role.account_lookup
             )
-            email = submitted.get("email", "")
-            if not email:
-                final_contact = (
-                    self.client.get_record(
-                        "Contact", original_id, CONTACT_REVIEW_FIELDS
-                    )
-                    if original_id
-                    else None
+            item: _ContactWorkItem | None = None
+            for submission in reversed(submissions):
+                if not any(
+                    normalize_contact_value(suffix, submission.get(source_field))
+                    for suffix, source_field in role.submitted_fields
+                ):
+                    continue
+                source_key = (
+                    "role",
+                    role.prefix,
+                    _display(submission.get("Id")),
                 )
-                responses.append(
-                    self._build_role_response(
-                        row,
-                        role.label,
-                        final_contact,
-                        original_contact,
-                        changed=final_contact != original_contact,
-                    )
-                )
-                continue
-            normalized, key, _ = normalize_email(email)
-            state = resolved.get(key)
-            if state is None and normalized:
-                state = next(
-                    (
-                        candidate
-                        for candidate in resolved.values()
-                        if candidate.resolution.normalized_email == normalized
-                    ),
-                    None,
-                )
-            if state is None or state.ignored or not state.contact_id:
+                mapped_key = source_mapping.get(source_key)
+                if mapped_key:
+                    item = items_by_key.get(mapped_key)
+                    break
+            if item is None or item.ignored or not item.contact_id:
                 responses.append(
                     self._build_role_response(
                         row,
@@ -1352,9 +1836,12 @@ class InteractiveProfileUpdateProcessor:
                     )
                 )
                 continue
-            final_contact = self.client.get_record(
-                "Contact", state.contact_id, CONTACT_REVIEW_FIELDS
-            )
+
+            final_contact = item.current_contact
+            if final_contact is None:
+                final_contact = self.client.get_record(
+                    "Contact", item.contact_id, CONTACT_REVIEW_FIELDS
+                )
             result = self._review_proposal(
                 self._proposal(
                     batch,
@@ -1363,14 +1850,23 @@ class InteractiveProfileUpdateProcessor:
                     target_record_id=batch.account_id,
                     field_name=role.account_lookup,
                     label=f"{role.label} Account Role",
-                    proposed_value=state.contact_id,
-                    resolution=state.resolution,
+                    proposed_value=item.contact_id,
+                    resolution=item.resolution,
                 ),
                 original_display=_contact_name_email(original_contact),
                 proposed_display=_contact_name_email(final_contact),
             )
             results.append(result)
-            changed = result.status in {
+            previous_contact = (
+                item.original_contact
+                if original_id == item.contact_id and item.original_contact
+                else original_contact
+            )
+            contact_changed = item.result is not None and item.result.status in {
+                ActionStatus.APPLIED,
+                ActionStatus.VERIFIED_MANUAL,
+            }
+            changed = contact_changed or result.status in {
                 ActionStatus.APPLIED,
                 ActionStatus.VERIFIED_MANUAL,
             }
@@ -1378,10 +1874,12 @@ class InteractiveProfileUpdateProcessor:
                 self._build_role_response(
                     row,
                     role.label,
-                    final_contact
-                    if result.status is not ActionStatus.REJECTED
-                    else original_contact,
-                    original_contact,
+                    (
+                        final_contact
+                        if result.status is not ActionStatus.REJECTED
+                        else previous_contact
+                    ),
+                    previous_contact,
                     changed=changed,
                 )
             )
@@ -1611,131 +2109,6 @@ class InteractiveProfileUpdateProcessor:
             results.append(self._review_proposal(proposal))
         return results
 
-    def _review_roles(
-        self,
-        batch: CaseBatch,
-        row: dict[str, str],
-        submissions: list[dict[str, Any]],
-    ) -> tuple[list[ActionResult], list[_RoleResponse]]:
-        results: list[ActionResult] = []
-        responses: list[_RoleResponse] = []
-        for role in ROLE_DEFINITIONS:
-            submitted = _submitted_role_values(submissions, row, role)
-            if not any(submitted.values()):
-                continue
-            self.output_fn(
-                _section_heading(f"{role.label} Contact role", ITEM_SEPARATOR)
-            )
-
-            original_role_id, original_role_contact = self._fresh_role_contact(
-                batch, role.account_lookup
-            )
-            matched = self._fresh_contact_by_email(
-                batch,
-                row,
-                role.label,
-                submitted.get("email", ""),
-            )
-            contact_results: list[ActionResult] = []
-            if matched is None:
-                created = self._review_new_contact(batch, row, role.label, submitted)
-                results.append(created)
-                contact_results.append(created)
-                if created.status in {
-                    ActionStatus.APPLIED,
-                    ActionStatus.VERIFIED_MANUAL,
-                }:
-                    contact_id = created.proposal.target_record_id
-                else:
-                    contact_id = ""
-            else:
-                self._show_contact_details(
-                    f"Current {role.label} Contact",
-                    matched,
-                )
-                contact_id = _display(matched.get("Id"))
-                for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
-                    if suffix == "title" and role.title_field is None:
-                        continue
-                    proposed = submitted.get(suffix, "")
-                    if not proposed:
-                        continue
-                    proposal = self._proposal(
-                        batch,
-                        row,
-                        target_object="Contact",
-                        target_record_id=contact_id,
-                        field_name=contact_field,
-                        label=f"{role.label} Contact {field_label}",
-                        proposed_value=proposed,
-                    )
-                    reviewed = self._review_proposal(proposal)
-                    results.append(reviewed)
-                    contact_results.append(reviewed)
-
-            if not contact_id:
-                responses.append(
-                    self._build_role_response(
-                        row,
-                        role.label,
-                        original_role_contact,
-                        original_role_contact,
-                        changed=False,
-                    )
-                )
-                continue
-
-            proposed_role_contact = self.client.get_record(
-                "Contact",
-                contact_id,
-                CONTACT_REVIEW_FIELDS,
-            )
-            role_result = self._review_proposal(
-                self._proposal(
-                    batch,
-                    row,
-                    target_object="Account",
-                    target_record_id=batch.account_id,
-                    field_name=role.account_lookup,
-                    label=f"{role.label} Account Role",
-                    proposed_value=contact_id,
-                ),
-                original_display=_contact_name_email(original_role_contact),
-                proposed_display=_contact_name_email(proposed_role_contact),
-            )
-            results.append(role_result)
-
-            resolved_role = role_result.status in {
-                ActionStatus.APPLIED,
-                ActionStatus.VERIFIED_MANUAL,
-                ActionStatus.NOOP,
-            }
-            final_role_id = contact_id if resolved_role else original_role_id
-            final_role_contact = (
-                self.client.get_record("Contact", final_role_id, CONTACT_REVIEW_FIELDS)
-                if final_role_id
-                else None
-            )
-            contact_changed = any(
-                result.status in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
-                for result in contact_results
-            )
-            role_changed = role_result.status in {
-                ActionStatus.APPLIED,
-                ActionStatus.VERIFIED_MANUAL,
-            }
-            responses.append(
-                self._build_role_response(
-                    row,
-                    role.label,
-                    final_role_contact,
-                    original_role_contact,
-                    changed=role_changed
-                    or (contact_changed and final_role_id == contact_id),
-                )
-            )
-        return results, responses
-
     def _fresh_role_contact(
         self,
         batch: CaseBatch,
@@ -1756,56 +2129,6 @@ class InteractiveProfileUpdateProcessor:
         )
         return contact_id, contact
 
-    def _fresh_contact_by_email(
-        self,
-        batch: CaseBatch,
-        row: dict[str, str],
-        role_label: str,
-        email: str,
-    ) -> dict[str, Any] | None:
-        contacts: list[dict[str, Any]] = []
-        if email:
-            contacts = self.client.query_records(
-                "Contact",
-                CONTACT_REVIEW_FIELDS,
-                where=f"Email = '{escape_soql_string(email)}'",
-                order_by="Id ASC",
-            )
-        if len(contacts) > 1:
-            error = (
-                f"Multiple Salesforce Contacts have the exact email {email!r}; "
-                f"the {role_label} role cannot be resolved safely."
-            )
-            proposal = self._proposal(
-                batch,
-                row,
-                target_object="Contact",
-                target_record_id="",
-                field_name="Email",
-                label=f"{role_label} Contact exact email match",
-                original_value=tuple(
-                    _display(contact.get("Id")) for contact in contacts
-                ),
-                proposed_value=email,
-            )
-            self._append_audit(
-                ActionResult(
-                    proposal,
-                    None,
-                    ActionStatus.FAILED,
-                    action="match Contact by exact email",
-                    error=error,
-                )
-            )
-            raise ProcessingError(error)
-        if contacts:
-            return dict(contacts[0])
-        self.output_fn(
-            f"No Salesforce Contact has the exact submitted {role_label} "
-            f"email {_display(email) or '(blank)'}."
-        )
-        return None
-
     def _build_role_response(
         self,
         row: dict[str, str],
@@ -1825,181 +2148,6 @@ class InteractiveProfileUpdateProcessor:
             previous_details=(previous if changed and previous != current else ""),
             changed=changed,
         )
-
-    def _review_new_contact(
-        self,
-        batch: CaseBatch,
-        row: dict[str, str],
-        role_label: str,
-        submitted: dict[str, str],
-        *,
-        resolution: ContactResolution | None = None,
-    ) -> ActionResult:
-        last_name = submitted.get("last_name", "")
-        payload: dict[str, str] = {"AccountId": batch.account_id}
-        for suffix, contact_field, _ in CONTACT_SUFFIX_FIELDS:
-            value = submitted.get(suffix, "")
-            if value:
-                payload[contact_field] = value
-        proposal = self._proposal(
-            batch,
-            row,
-            target_object="Contact",
-            target_record_id="(new)",
-            field_name="Contact",
-            label=f"{role_label} Contact",
-            proposed_value=payload,
-            original_value="",
-            resolution=resolution,
-        )
-        submitted_contact = {
-            contact_field: submitted.get(suffix, "")
-            for suffix, contact_field, _ in CONTACT_SUFFIX_FIELDS
-        }
-        self._show_contact_details(
-            f"Submitted {role_label} Contact",
-            submitted_contact,
-        )
-        if not last_name:
-            self.output_fn(
-                f"{role_label} Contact cannot be created automatically because "
-                "the required Last Name field is missing."
-            )
-        self._show_proposal(
-            proposal,
-            proposed_display=_contact_name_email(submitted_contact),
-        )
-        decision = self._review_decision(
-            proposal,
-            automatic_allowed=bool(last_name)
-            and (resolution is None or bool(resolution.comparison_key)),
-            action="create Contact",
-        )
-
-        if decision is ReviewDecision.WILL_NOT_BE_MADE:
-            result = ActionResult(
-                proposal,
-                decision,
-                ActionStatus.REJECTED,
-                action="create Contact",
-            )
-            self._append_audit(result)
-            return result
-        if decision is ReviewDecision.MAKE_MANUALLY:
-            try:
-                contact_id = self.input_fn(
-                    "Create the Contact in Salesforce, then enter its Contact ID: "
-                ).strip()
-                if not contact_id:
-                    raise ProcessingError(
-                        "A Contact ID is required for manual verification."
-                    )
-                fresh = self.client.get_record(
-                    "Contact", contact_id, CONTACT_REVIEW_FIELDS
-                )
-            except (KeyboardInterrupt, EOFError) as error:
-                result = ActionResult(
-                    proposal,
-                    decision,
-                    ActionStatus.INTERRUPTED,
-                    action="verify manual Contact creation",
-                    error="Reviewer interrupted processing.",
-                )
-                self._append_audit(result)
-                raise ProcessingInterrupted(
-                    "Profile Update review was interrupted."
-                ) from error
-            except ProcessingError as error:
-                result = ActionResult(
-                    proposal,
-                    decision,
-                    ActionStatus.FAILED,
-                    action="verify manual Contact creation",
-                    error=str(error),
-                )
-                self._append_audit(result)
-                raise
-            except SalesforceError as error:
-                result = ActionResult(
-                    proposal,
-                    decision,
-                    ActionStatus.FAILED,
-                    action="verify manual Contact creation",
-                    error=str(error),
-                )
-                self._append_audit(result)
-                raise ProcessingError(str(error)) from error
-            matches_account = _values_equal(fresh.get("AccountId"), batch.account_id)
-            matches_fields = all(
-                _values_equal(fresh.get(field_name), value)
-                for field_name, value in payload.items()
-                if field_name != "AccountId"
-            )
-            if not matches_account or not matches_fields:
-                error = (
-                    "Manually selected Contact does not match the submitted "
-                    "Contact information."
-                )
-                result = ActionResult(
-                    proposal,
-                    decision,
-                    ActionStatus.FAILED,
-                    action="verify manual Contact creation",
-                    error=error,
-                )
-                self._append_audit(result)
-                raise ProcessingError(error)
-            verified_proposal = ChangeProposal(
-                **{
-                    **proposal.__dict__,
-                    "target_record_id": contact_id,
-                    "selected_contact": contact_snapshot(fresh),
-                }
-            )
-            result = ActionResult(
-                verified_proposal,
-                decision,
-                ActionStatus.VERIFIED_MANUAL,
-                action="verify manual Contact creation",
-            )
-            self._append_audit(result)
-            return result
-
-        try:
-            contact_id = self.client.create_record("Contact", payload)
-        except SalesforceError as error:
-            if resolution is not None and _is_duplicate_contact_error(error):
-                return self._recover_duplicate_contact(
-                    batch,
-                    row,
-                    proposal,
-                    resolution,
-                    error,
-                )
-            result = ActionResult(
-                proposal,
-                decision,
-                ActionStatus.FAILED,
-                action="create Contact",
-                error=str(error),
-            )
-            self._append_audit(result)
-            raise ProcessingError(str(error)) from error
-        created_proposal = ChangeProposal(
-            **{
-                **proposal.__dict__,
-                "target_record_id": contact_id,
-                "selected_contact": contact_snapshot({"Id": contact_id, **payload}),
-            }
-        )
-        result = ActionResult(
-            created_proposal,
-            decision,
-            ActionStatus.APPLIED,
-            action="create Contact",
-        )
-        self._append_audit(result)
-        return result
 
     def _recover_duplicate_contact(
         self,

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -92,6 +92,14 @@ CONTACT_SUFFIX_FIELDS = [
     ("phone", "Phone", "Phone"),
 ]
 
+CONTACT_FIELD_LABELS = {
+    "AccountId": "Account ID",
+    **{
+        contact_field: field_label
+        for _, contact_field, field_label in CONTACT_SUFFIX_FIELDS
+    },
+}
+
 ACCOUNT_EMAIL_OPENING = (
     "Thank you for updating your information with AISC. The changes are "
     "summarized below. An updated Participant Portal login will be sent by a "
@@ -760,18 +768,7 @@ class InteractiveProfileUpdateProcessor:
                     }
                     if details:
                         source = ContactSource("submitter", submission_id=submission_id)
-                        staged_resolution = staged_by_source.get(
-                            ("submitter", "", submission_id)
-                        )
-                        selected = (
-                            staged_resolution.selected_contact
-                            if staged_resolution is not None
-                            else None
-                        )
-                        identity_id = (
-                            _display(selected.get("Id")) if selected is not None else ""
-                        )
-                        occurrences.append((source, details, row, identity_id))
+                        occurrences.append((source, details, row, ""))
 
                 for role in ROLE_DEFINITIONS:
                     details = {
@@ -798,10 +795,11 @@ class InteractiveProfileUpdateProcessor:
                     ).strip()
                     current_id = _display(account.get(role.account_lookup))
                     identity_id = ""
-                    if action in {"update_contact", "change_email"}:
-                        identity_id = current_id or staged_id
-                    elif not details.get("email") and action != "create_contact":
-                        identity_id = current_id or staged_id
+                    # A submitted email identifies the Contact independently of
+                    # the role. Only a partial proposal with no email falls back
+                    # to the Contact currently linked to that role.
+                    if not details.get("email") and action != "create_contact":
+                        identity_id = staged_id or current_id
                     staged_resolution = staged_by_source.get(
                         ("role", role.prefix, submission_id)
                     )
@@ -810,7 +808,11 @@ class InteractiveProfileUpdateProcessor:
                         if staged_resolution is not None
                         else None
                     )
-                    if not identity_id and selected is not None:
+                    if (
+                        not details.get("email")
+                        and not identity_id
+                        and selected is not None
+                    ):
                         identity_id = _display(selected.get("Id"))
                     occurrences.append((source, details, row, identity_id))
 
@@ -966,83 +968,10 @@ class InteractiveProfileUpdateProcessor:
                 dict.fromkeys([*item.resolution.warnings, *fresh_resolution.warnings])
             )
             item.resolution = fresh_resolution
-        items = list(grouped.values())
-        for row in batch.rows:
-            row_source_ids = set(_json_string_list(row["source_submission_ids"]))
-            for role in ROLE_DEFINITIONS:
-                same_role = [
-                    item
-                    for item in items
-                    if any(
-                        kind == "role"
-                        and source_role == role.prefix
-                        and submission_id in row_source_ids
-                        for kind, source_role, submission_id in item.source_keys
-                    )
-                ]
-                if len(same_role) < 2:
-                    continue
-                target = same_role[0]
-                preferred_resolution = same_role[-1].resolution
-                selected_contacts = {
-                    _display(
-                        (item.resolution.selected_contact or {}).get("Id")
-                    ): item.resolution.selected_contact
-                    for item in same_role
-                    if _display((item.resolution.selected_contact or {}).get("Id"))
-                }
-                for item in same_role[1:]:
-                    target.source_keys.update(item.source_keys)
-                    for source in item.resolution.sources:
-                        if source not in target.resolution.sources:
-                            target.resolution.sources.append(source)
-                    for field_name, values in item.proposals.items():
-                        for value, sources in values.items():
-                            destination = target.proposals.setdefault(
-                                field_name, {}
-                            ).setdefault(value, [])
-                            destination.extend(
-                                source
-                                for source in sources
-                                if source not in destination
-                            )
-                    items.remove(item)
-                if len(selected_contacts) == 1:
-                    contact = next(iter(selected_contacts.values()))
-                    target.resolution.classification = (
-                        ContactResolutionClassification.USE_EXISTING
-                    )
-                    target.resolution.selected_contact = contact
-                    target.contact_id = _display(contact.get("Id"))
-                elif len(selected_contacts) > 1:
-                    target.resolution.classification = (
-                        ContactResolutionClassification.AMBIGUOUS
-                    )
-                    target.resolution.selected_contact = None
-                    target.resolution.candidates = [
-                        dict(contact)
-                        for contact in selected_contacts.values()
-                        if contact is not None
-                    ]
-                    target.contact_id = ""
-                    target.resolution.reason = (
-                        "Submissions for the same role identify different "
-                        "Salesforce Contacts."
-                    )
-                else:
-                    combined_sources = target.resolution.sources
-                    combined_warnings = target.resolution.warnings
-                    target.resolution = preferred_resolution
-                    target.resolution.sources = combined_sources
-                    target.resolution.warnings = list(
-                        dict.fromkeys(
-                            [
-                                *combined_warnings,
-                                *preferred_resolution.warnings,
-                            ]
-                        )
-                    )
-        return items, source_mapping
+        # Keep different email identities separate even when they appeared in
+        # the same role. Role assignment happens later, after every submitted
+        # Contact has been reviewed and brought up to date.
+        return list(grouped.values()), source_mapping
 
     def _resolve_contact_identities(
         self,
@@ -1241,9 +1170,10 @@ class InteractiveProfileUpdateProcessor:
         )
 
     def _show_reconciled_contact(self, item: _ContactWorkItem) -> None:
+        identity = self._contact_review_identity(item)
         self.output_fn(
             _section_heading(
-                f"Reconciled {self._resolution_label(item.resolution)}",
+                f"Reconciled Contact: {identity}",
                 ITEM_SEPARATOR,
             )
         )
@@ -1282,7 +1212,7 @@ class InteractiveProfileUpdateProcessor:
             batch,
             item,
             field_name="Contact",
-            label=f"{self._resolution_label(item.resolution)} Contact",
+            label=f"Contact: {self._contact_review_identity(item)}",
             original_value=item.current_contact or {},
             proposed_value=payload,
         )
@@ -1324,7 +1254,7 @@ class InteractiveProfileUpdateProcessor:
             batch,
             item,
             field_name="Contact",
-            label=f"{self._resolution_label(item.resolution)} Contact",
+            label=f"Contact: {self._contact_review_identity(item)}",
             original_value=item.current_contact or {},
             proposed_value=(
                 dict(item.write_values or {})
@@ -1886,15 +1816,26 @@ class InteractiveProfileUpdateProcessor:
         return results, responses
 
     @staticmethod
-    def _resolution_label(resolution: ContactResolution) -> str:
-        role_names = [
-            source.role.replace("_", " ").title()
-            for source in resolution.sources
-            if source.kind == "role" and source.role
-        ]
-        if role_names:
-            return "/".join(dict.fromkeys(role_names)) + " Contact"
-        return "Submitter Contact"
+    def _contact_review_identity(item: _ContactWorkItem) -> str:
+        """Return a person/email label that does not depend on a role."""
+        contact = item.current_contact or item.resolution.selected_contact or {}
+        reconciled = item.reconciled or {}
+        name = " ".join(
+            value
+            for value in (
+                reconciled.get("first_name") or _display(contact.get("FirstName")),
+                reconciled.get("last_name") or _display(contact.get("LastName")),
+            )
+            if value
+        )
+        email = (
+            reconciled.get("email")
+            or item.resolution.normalized_email
+            or _display(contact.get("Email"))
+        )
+        if name and email:
+            return f"{name} <{email}>"
+        return name or email or "(unidentified)"
 
     def _finish_batch(
         self,
@@ -2527,11 +2468,40 @@ class InteractiveProfileUpdateProcessor:
             if proposed_display is not None
             else _display(proposal.proposed_value)
         )
+        if (
+            original_display is None
+            and proposed_display is None
+            and isinstance(proposal.original_value, dict)
+            and isinstance(proposal.proposed_value, dict)
+        ):
+            self._show_mapping_proposal(proposal)
+            return
         self.output_fn(
             f"\n{proposal.label}\n"
             f"Current Salesforce value: {current or '(blank)'}\n"
             f"Proposed value: {proposed or '(blank)'}"
         )
+
+    def _show_mapping_proposal(self, proposal: ChangeProposal) -> None:
+        """Show dictionary-backed changes as readable field comparisons."""
+        current = proposal.original_value
+        proposed = proposal.proposed_value
+        heading = (
+            "New Salesforce values:"
+            if not proposal.target_record_id
+            or proposal.target_record_id == "(new)"
+            else "Salesforce changes:"
+        )
+        lines = [f"\n{proposal.label}", heading]
+        for field_name, proposed_value in proposed.items():
+            label = CONTACT_FIELD_LABELS.get(field_name, field_name)
+            current_value = _display(current.get(field_name)) or "(blank)"
+            new_value = _display(proposed_value) or "(blank)"
+            if heading == "New Salesforce values:":
+                lines.append(f"{label}: {new_value}")
+            else:
+                lines.append(f"{label}: {current_value} -> {new_value}")
+        self.output_fn("\n".join(lines))
 
     def _show_contact_details(
         self,

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -805,11 +805,15 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         for item in entries
     )
     displayed = "\n".join(output)
-    assert "Reconciled Certification Contact" in displayed
+    assert "Reconciled Contact: Alexa Jones <old@example.com>" in displayed
     assert ("First Name | Alex | Alexa | submission-1 / Certification") in displayed
     assert (
         "Phone | 312-555-0100 | 312.555.0199 | submission-1 / Certification"
     ) in displayed
+    assert "First Name: Alex -> Alexa" in displayed
+    assert "Phone: 312-555-0100 -> 312.555.0199" in displayed
+    assert "Current Salesforce value: {" not in displayed
+    assert "Proposed value: {" not in displayed
     assert (
         "Certification Account Role\n"
         "Current Salesforce value: Old Contact <old.contact@example.com>\n"
@@ -903,11 +907,18 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
         {"Cert_Certification_Contact__c": "created-1"},
     ) in client.updated
     displayed = "\n".join(output)
-    assert "Reconciled Certification Contact" in displayed
+    assert (
+        "Reconciled Contact: New Person <new.person@example.com>" in displayed
+    )
     assert "First Name | (blank) | New | submission-1 / Certification" in displayed
     assert (
         "Email | (blank) | new.person@example.com | submission-1 / Certification"
     ) in displayed
+    assert "New Salesforce values:" in displayed
+    assert "First Name: New" in displayed
+    assert "Last Name: Person" in displayed
+    assert "Email: new.person@example.com" in displayed
+    assert "Proposed value: {" not in displayed
 
 
 def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
@@ -1328,30 +1339,48 @@ def test_interruption_during_contact_conflict_is_audited_before_any_write(tmp_pa
     assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
 
 
-def test_changed_email_uses_current_role_contact_id_and_updates_once(tmp_path):
-    contact = {
+def test_submitted_email_selects_its_contact_instead_of_current_role_contact(
+    tmp_path,
+):
+    current_role_contact = {
         "Id": "contact-1",
         "AccountId": "account-1",
-        "FirstName": "Alex",
-        "LastName": "Smith",
+        "FirstName": "Ray",
+        "LastName": "Ryan",
         "Title": "",
-        "Email": "old@example.com",
+        "Email": "ray@example.com",
+        "Phone": "",
+    }
+    submitted_contact = {
+        "Id": "contact-2",
+        "AccountId": "account-1",
+        "FirstName": "Tim",
+        "LastName": "Ryan",
+        "Title": "Old Title",
+        "Email": "tim@example.com",
         "Phone": "",
     }
     client = FakeClient(
         account=account_record(Cert_Certification_Contact__c="contact-1"),
-        contacts=[contact],
+        contacts=[current_role_contact, submitted_contact],
     )
     client.records[("Company_Profile_Change__c", "submission-1")].update(
         {
-            "Cert_First_Name__c": "Alex",
-            "Cert_Last_Name__c": "Smith",
-            "Cert_Email__c": "new@example.com",
+            "Cert_First_Name__c": "Tim",
+            "Cert_Last_Name__c": "Ryan",
+            "Cert_Title__c": "President",
+            "Cert_Email__c": "tim@example.com",
         }
     )
     processor = InteractiveProfileUpdateProcessor(
         client,
-        input_fn=Feeder(["apply automatically", "yes"]),
+        input_fn=Feeder(
+            [
+                "apply automatically",
+                "apply automatically",
+                "yes",
+            ]
+        ),
         output_fn=lambda message: None,
         now=NOW,
     )
@@ -1359,7 +1388,7 @@ def test_changed_email_uses_current_role_contact_id_and_updates_once(tmp_path):
         certification_resolution_action="change_email",
         certification_salesforce_contact_id="contact-1",
         contact_resolutions=staged_resolution(
-            email="new@example.com",
+            email="tim@example.com",
             sources=[
                 ContactSource(
                     "role",
@@ -1375,8 +1404,135 @@ def test_changed_email_uses_current_role_contact_id_and_updates_once(tmp_path):
 
     assert client.created == []
     assert [item for item in client.updated if item[0] == "Contact"] == [
-        ("Contact", "contact-1", {"Email": "new@example.com"})
+        ("Contact", "contact-2", {"Title": "President"})
     ]
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "contact-2"},
+    ) in client.updated
+
+
+def test_contact_updates_use_tim_and_stacy_emails_before_assigning_roles(tmp_path):
+    ray = {
+        "Id": "contact-ray",
+        "AccountId": "account-1",
+        "FirstName": "Ray",
+        "LastName": "Ryan",
+        "Title": "President",
+        "Email": "ray@wsfabrication.com",
+        "Phone": "312.555.0100",
+    }
+    tim = {
+        "Id": "contact-tim",
+        "AccountId": "account-1",
+        "FirstName": "Tim",
+        "LastName": "Ryan",
+        "Title": "Old Title",
+        "Email": "tim@wsfabrication.com",
+        "Phone": "312.555.0101",
+    }
+    stacy = {
+        "Id": "contact-stacy",
+        "AccountId": "account-1",
+        "FirstName": "Stacy",
+        "LastName": "Morgan",
+        "Title": "",
+        "Email": "stacy@wsfabrication.com",
+        "Phone": "312.555.0102",
+    }
+    client = FakeClient(
+        source=source_record(
+            Name__c="Stacy Morgan",
+            Email__c="stacy@wsfabrication.com",
+            Phone__c="312-555-0198",
+            Principal_First_Name__c="Tim",
+            Principal_Last_Name__c="Ryan",
+            Principal_Title__c="Owner",
+            Principal_Email__c="tim@wsfabrication.com",
+            Principal_Phone__c="312-555-0199",
+        ),
+        account=account_record(Cert_Principal_Contact__c="contact-ray"),
+        contacts=[ray, tim, stacy],
+    )
+    submitter_resolution = json.loads(
+        staged_resolution(
+            email="stacy@wsfabrication.com",
+            sources=[ContactSource("submitter", submission_id="submission-1")],
+            classification=ContactResolutionClassification.USE_EXISTING,
+            selected=stacy,
+        )
+    )[0]
+    # This deliberately reproduces the stale/wrong role-based selection. Fresh
+    # email resolution must still choose Tim rather than Ray.
+    principal_resolution = json.loads(
+        staged_resolution(
+            email="tim@wsfabrication.com",
+            sources=[
+                ContactSource(
+                    "role",
+                    role="principal",
+                    submission_id="submission-1",
+                )
+            ],
+            classification=ContactResolutionClassification.USE_EXISTING,
+            selected=ray,
+        )
+    )[0]
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(
+            [
+                "apply automatically",
+                "apply automatically",
+                "apply automatically",
+                "yes",
+            ]
+        ),
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                submitter_name="Stacy Morgan",
+                submitter_email="stacy@wsfabrication.com",
+                principal_resolution_action="update_contact",
+                principal_salesforce_contact_id="contact-ray",
+                contact_resolutions=json.dumps(
+                    [submitter_resolution, principal_resolution]
+                ),
+            )
+        ],
+        tmp_path,
+    )
+
+    assert [item for item in client.updated if item[0] == "Contact"] == [
+        ("Contact", "contact-stacy", {"Phone": "312.555.0198"}),
+        (
+            "Contact",
+            "contact-tim",
+            {"Title": "Owner", "Phone": "312.555.0199"},
+        ),
+    ]
+    assert not any(
+        object_name == "Contact" and record_id == "contact-ray"
+        for object_name, record_id, _ in client.updated
+    )
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Principal_Contact__c": "contact-tim"},
+    ) in client.updated
+    displayed = "\n".join(output)
+    assert (
+        "Reconciled Contact: Stacy Morgan <stacy@wsfabrication.com>" in displayed
+    )
+    assert "Reconciled Contact: Tim Ryan <tim@wsfabrication.com>" in displayed
+    assert "Current Salesforce value: {" not in displayed
+    assert "Proposed value: {" not in displayed
 
 
 def test_shared_new_contact_is_created_once_and_reused_for_both_roles(tmp_path):
@@ -1445,7 +1601,7 @@ def test_shared_new_contact_is_created_once_and_reused_for_both_roles(tmp_path):
     ) in client.updated
 
 
-def test_distinct_emails_from_two_submissions_for_one_role_are_one_conflict(
+def test_distinct_emails_in_one_role_stay_separate_until_role_assignment(
     tmp_path,
 ):
     client = FakeClient()
@@ -1471,7 +1627,7 @@ def test_distinct_emails_from_two_submissions_for_one_role_are_one_conflict(
     ]
     feeder = Feeder(
         [
-            "2",
+            "apply automatically",
             "apply automatically",
             "apply automatically",
             "yes",
@@ -1507,24 +1663,42 @@ def test_distinct_emails_from_two_submissions_for_one_role_are_one_conflict(
                 "AccountId": "account-1",
                 "FirstName": "New",
                 "LastName": "Person",
+                "Email": "first@example.com",
+            },
+        ),
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "New",
+                "LastName": "Person",
                 "Email": "second@example.com",
             },
         )
     ]
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "created-2"},
+    ) in client.updated
     entries = [
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    email_conflict = next(
-        entry
-        for entry in entries
-        if entry["action"] == "resolve Contact field conflict"
-        and entry["field"] == "Email"
-    )
-    assert email_conflict["source_submission_ids"] == [
-        "submission-1",
-        "submission-2",
+    creates = [entry for entry in entries if entry["action"] == "create Contact"]
+    assert [entry["proposed_value"]["Email"] for entry in creates] == [
+        "first@example.com",
+        "second@example.com",
     ]
+    assert [entry["source_submission_ids"] for entry in creates] == [
+        ["submission-1"],
+        ["submission-2"],
+    ]
+    assert not any(
+        entry["action"] == "resolve Contact field conflict"
+        and entry["field"] == "Email"
+        for entry in entries
+    )
 
 
 def test_every_fresh_submitter_submission_contributes_to_reconciliation(tmp_path):

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -560,6 +560,8 @@ def test_decision_shortcuts_are_case_insensitive_but_audit_full_phrases(
     if shortcut.casefold() == "m":
         client.get_sequences[("Account", "account-1")] = [
             account_record(),
+            account_record(),
+            account_record(),
             account_record(Name="Acme Steel LLC"),
         ]
         answers.extend(["", "yes"])
@@ -680,6 +682,8 @@ def test_manual_change_is_refetched_and_must_match(tmp_path):
     client = FakeClient()
     client.get_sequences[("Account", "account-1")] = [
         account_record(),
+        account_record(),
+        account_record(),
         account_record(Name="Acme Steel LLC"),
     ]
     feeder = Feeder(["make manually", "", "yes"])
@@ -732,11 +736,18 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         "Phone": "312-555-0100",
     }
     client = FakeClient(contacts=[contact])
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alexa",
+            "Cert_Last_Name__c": "Jones",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "old@example.com",
+            "Cert_Phone__c": "312-555-0199",
+        }
+    )
     feeder = Feeder(
         [
-            "apply automatically",
-            "apply automatically",
-            "apply automatically",
+            "1",
             "apply automatically",
             "will not be made",
             "yes",
@@ -755,8 +766,6 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         certification_title="Director",
         certification_email="old@example.com",
         certification_phone="312-555-0199",
-        certification_salesforce_contact_id="contact-1",
-        certification_resolution_action="update_contact",
     )
 
     result = processor.review([row], tmp_path)
@@ -764,17 +773,18 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
     contact_query = next(query for query in client.queries if query[0] == "Contact")
     assert contact_query[2] == "Email = 'old@example.com'"
     assert "AccountId" not in contact_query[2]
-    assert "candidates" not in "\n".join(output).casefold()
-    assert not any("Contact choice" in prompt for prompt in feeder.prompts)
-    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 5
+    assert any("Contact choice" in prompt for prompt in feeder.prompts)
+    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 2
     assert (
         "Contact",
         "contact-1",
-        {"FirstName": "Alexa"},
+        {
+            "FirstName": "Alexa",
+            "LastName": "Jones",
+            "Title": "Director",
+            "Phone": "312.555.0199",
+        },
     ) in client.updated
-    assert ("Contact", "contact-1", {"LastName": "Jones"}) in client.updated
-    assert ("Contact", "contact-1", {"Title": "Director"}) in client.updated
-    assert ("Contact", "contact-1", {"Phone": "312-555-0199"}) in client.updated
     assert not any(
         item[0] == "Account" and "Cert_Certification_Contact__c" in item[2]
         for item in client.updated
@@ -784,7 +794,10 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
     assert any(
-        item["field"] == "FirstName" and item["result"] == "applied" for item in entries
+        item["field"] == "Contact"
+        and item["action"] == "update Contact from reconciled proposals"
+        and item["result"] == "applied"
+        for item in entries
     )
     assert any(
         item["field"] == "Cert_Certification_Contact__c"
@@ -792,12 +805,10 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         for item in entries
     )
     displayed = "\n".join(output)
+    assert "Reconciled Certification Contact" in displayed
+    assert ("First Name | Alex | Alexa | submission-1 / Certification") in displayed
     assert (
-        "Current Certification Contact:\n"
-        "Name: Alex Smith\n"
-        "Title: Manager\n"
-        "Email: old@example.com\n"
-        "Phone: 312-555-0100"
+        "Phone | 312-555-0100 | 312.555.0199 | submission-1 / Certification"
     ) in displayed
     assert (
         "Certification Account Role\n"
@@ -810,6 +821,9 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
 
 def test_incomplete_contact_is_not_automatically_created(tmp_path):
     client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_First_Name__c"
+    ] = "Only"
     feeder = Feeder(["will not be made", "yes"])
     output = []
     processor = InteractiveProfileUpdateProcessor(
@@ -835,6 +849,13 @@ def test_incomplete_contact_is_not_automatically_created(tmp_path):
 
 def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
     client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Email__c": "new.person@example.com",
+        }
+    )
     feeder = Feeder(
         [
             "apply automatically",
@@ -881,17 +902,24 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
         "account-1",
         {"Cert_Certification_Contact__c": "created-1"},
     ) in client.updated
+    displayed = "\n".join(output)
+    assert "Reconciled Certification Contact" in displayed
+    assert "First Name | (blank) | New | submission-1 / Certification" in displayed
     assert (
-        "Submitted Certification Contact:\n"
-        "Name: New Person\n"
-        "Title: (blank)\n"
-        "Email: new.person@example.com\n"
-        "Phone: (blank)"
-    ) in "\n".join(output)
+        "Email | (blank) | new.person@example.com | submission-1 / Certification"
+    ) in displayed
 
 
 def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
     client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Sam",
+            "Cert_Last_Name__c": "Submitter",
+            "Cert_Email__c": "sam@example.com",
+            "Cert_Phone__c": "312-555-0101",
+        }
+    )
     feeder = Feeder(["apply automatically", "apply automatically", "yes"])
     processor = InteractiveProfileUpdateProcessor(
         client,
@@ -960,7 +988,7 @@ def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
     assert role_assignment["selected_contact"]["Id"] == "created-1"
 
 
-def test_fresh_contact_resolution_normalizes_values_before_comparison():
+def test_fresh_contact_collection_normalizes_values_before_comparison():
     client = FakeClient(
         source=source_record(
             Name__c="  jane mcdonald ",
@@ -983,21 +1011,22 @@ def test_fresh_contact_resolution_normalizes_values_before_comparison():
     )
     batch = build_case_batches([row], now=NOW)[0]
 
-    resolutions = processor._fresh_batch_resolutions(
+    items, _ = processor._collect_contact_work(
         batch,
         {"submission-1": client.records[("Company_Profile_Change__c", "submission-1")]},
     )
 
-    resolution = resolutions["jane@example.com"]
-    assert resolution.submitted == {
-        "first_name": "Jane",
-        "last_name": "McDonald",
-        "email": "jane@example.com",
-        "phone": "312.555.0100 x123",
+    assert len(items) == 1
+    item = items[0]
+    assert {
+        field_name: set(values) for field_name, values in item.proposals.items()
+    } == {
+        "first_name": {"Jane"},
+        "last_name": {"McDonald"},
+        "email": {"jane@example.com"},
+        "phone": {"312.555.0100 x123"},
     }
-    assert any(
-        query[2] == "Email = 'jane@example.com'" for query in client.queries
-    )
+    assert any(query[2] == "Email = 'jane@example.com'" for query in client.queries)
 
 
 def test_fresh_role_without_email_is_normalized_before_review(tmp_path):
@@ -1030,13 +1059,720 @@ def test_fresh_role_without_email_is_normalized_before_review(tmp_path):
     assert (
         "Contact",
         "contact-quality",
-        {"Title": "Chief QA Officer"},
+        {
+            "Title": "Chief QA Officer",
+            "Phone": "312.555.0104 x0007",
+        },
+    ) in client.updated
+
+
+def test_contact_phase_combines_roles_into_one_write_before_account_and_role_links(
+    tmp_path,
+):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Old Title",
+        "Email": "alex@example.com",
+        "Phone": "312.555.0100",
+    }
+    client = FakeClient(contacts=[contact])
+    source = client.records[("Company_Profile_Change__c", "submission-1")]
+    source.update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Email__c": "alex@example.com",
+            "Cert_Phone__c": "312-555-0199",
+            "Principal_First_Name__c": "Alex",
+            "Principal_Last_Name__c": "Smith",
+            "Principal_Title__c": "Director",
+            "Principal_Email__c": "alex@example.com",
+            "Revised_Company_Name__c": "Acme Steel LLC",
+        }
+    )
+    sources = [
+        ContactSource("role", role="certification", submission_id="submission-1"),
+        ContactSource("role", role="principal", submission_id="submission-1"),
+    ]
+    feeder = Feeder(
+        [
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "yes",
+        ]
+    )
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=output.append,
+        now=NOW,
+    )
+    row = staged_row(
+        revised_company_name="stale staging value",
+        certification_first_name="fallback",
+        certification_email="alex@example.com",
+        principal_first_name="fallback",
+        principal_email="alex@example.com",
+        contact_resolutions=staged_resolution(
+            email="alex@example.com",
+            sources=sources,
+            submitted={"title": "stale fallback"},
+        ),
+    )
+
+    result = processor.review([row], tmp_path)
+
+    contact_writes = [
+        item
+        for item in client.updated
+        if item[0] == "Contact" and item[1] == "contact-1"
+    ]
+    assert contact_writes == [
+        (
+            "Contact",
+            "contact-1",
+            {"Title": "Director", "Phone": "312.555.0199"},
+        )
+    ]
+    contact_index = client.updated.index(contact_writes[0])
+    account_index = next(
+        index
+        for index, item in enumerate(client.updated)
+        if item[:2] == ("Account", "account-1") and "Name" in item[2]
+    )
+    role_index = next(
+        index
+        for index, item in enumerate(client.updated)
+        if item[:2] == ("Account", "account-1")
+        and "Cert_Certification_Contact__c" in item[2]
+    )
+    assert contact_index < account_index < role_index
+    displayed = "\n".join(output)
+    assert displayed.index("Contact Updates") < displayed.index("Account Updates")
+    assert displayed.index("Account Updates") < displayed.index("Role Links")
+
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    aggregate = next(
+        entry
+        for entry in entries
+        if entry["action"] == "update Contact from reconciled proposals"
+    )
+    assert aggregate["proposed_value"] == {
+        "Phone": "312.555.0199",
+        "Title": "Director",
+    }
+    assert aggregate["source_submission_ids"] == ["submission-1"]
+
+
+def test_conflicting_contact_values_are_resolved_before_any_contact_write(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Current Title",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    first = client.records[("Company_Profile_Change__c", "submission-1")]
+    first.update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Manager",
+            "Cert_Email__c": "alex@example.com",
+        }
+    )
+    second = source_record(
+        Id="submission-2",
+        Name="PU-101",
+        Cert_First_Name__c="Alex",
+        Cert_Last_Name__c="Smith",
+        Cert_Title__c="Director",
+        Cert_Email__c="alex@example.com",
+    )
+    client.records[("Company_Profile_Change__c", "submission-2")] = second
+    sources = [
+        ContactSource("role", role="certification", submission_id="submission-1"),
+        ContactSource("role", role="certification", submission_id="submission-2"),
+    ]
+    writes_seen_at_conflict = []
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Choose reconciled Title"):
+            writes_seen_at_conflict.append(
+                [item for item in client.updated if item[0] == "Contact"]
+            )
+            return "current"
+        if prompt.startswith("Was the response email"):
+            return "yes"
+        raise AssertionError(prompt)
+
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=answer,
+        output_fn=output.append,
+        now=NOW,
+    )
+    row = staged_row(
+        source_submission_ids=json.dumps(["submission-1", "submission-2"]),
+        source_submission_names=json.dumps(["PU-100", "PU-101"]),
+        contact_resolutions=staged_resolution(
+            email="alex@example.com",
+            sources=sources,
+            submitted={"title": "stale fallback"},
+        ),
+    )
+
+    result = processor.review([row], tmp_path)
+
+    assert writes_seen_at_conflict == [[]]
+    assert not any(item[0] == "Contact" for item in client.updated)
+    displayed = "\n".join(output)
+    assert "Manager" in displayed
+    assert "Director" in displayed
+    assert "submission-1 / Certification" in displayed
+    assert "submission-2 / Certification" in displayed
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    conflict = next(
+        entry
+        for entry in entries
+        if entry["action"] == "resolve Contact field conflict"
+    )
+    assert conflict["field"] == "Title"
+    assert conflict["proposed_value"] == "Current Title"
+    assert conflict["result"] == "verified manually"
+
+
+def test_interruption_during_contact_conflict_is_audited_before_any_write(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Current Title",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    first = client.records[("Company_Profile_Change__c", "submission-1")]
+    first.update(
+        {
+            "Cert_Title__c": "Manager",
+            "Cert_Email__c": "alex@example.com",
+        }
+    )
+    client.records[("Company_Profile_Change__c", "submission-2")] = source_record(
+        Id="submission-2",
+        Name="PU-101",
+        Cert_Title__c="Director",
+        Cert_Email__c="alex@example.com",
+    )
+
+    def interrupt(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Choose reconciled Title"):
+            raise KeyboardInterrupt
+        raise AssertionError(prompt)
+
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=interrupt,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    row = staged_row(
+        source_submission_ids=json.dumps(["submission-1", "submission-2"]),
+        source_submission_names=json.dumps(["PU-100", "PU-101"]),
+        contact_resolutions="[]",
+    )
+
+    with pytest.raises(ProcessingInterrupted):
+        processor.review([row], tmp_path)
+
+    assert not any(item[0] == "Contact" for item in client.updated)
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "review_audit.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert any(
+        entry["action"] == "resolve Contact field conflict"
+        and entry["result"] == "interrupted"
+        for entry in entries
+    )
+    assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
+
+
+def test_changed_email_uses_current_role_contact_id_and_updates_once(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "",
+        "Email": "old@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Email__c": "new@example.com",
+        }
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    row = staged_row(
+        certification_resolution_action="change_email",
+        certification_salesforce_contact_id="contact-1",
+        contact_resolutions=staged_resolution(
+            email="new@example.com",
+            sources=[
+                ContactSource(
+                    "role",
+                    role="certification",
+                    submission_id="submission-1",
+                )
+            ],
+            submitted={"email": "stale@example.com"},
+        ),
+    )
+
+    processor.review([row], tmp_path)
+
+    assert client.created == []
+    assert [item for item in client.updated if item[0] == "Contact"] == [
+        ("Contact", "contact-1", {"Email": "new@example.com"})
+    ]
+
+
+def test_shared_new_contact_is_created_once_and_reused_for_both_roles(tmp_path):
+    client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Email__c": "new@example.com",
+            "Principal_First_Name__c": "New",
+            "Principal_Last_Name__c": "Person",
+            "Principal_Email__c": "new@example.com",
+        }
+    )
+    sources = [
+        ContactSource("role", role="certification", submission_id="submission-1"),
+        ContactSource("role", role="principal", submission_id="submission-1"),
+    ]
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(
+            [
+                "apply automatically",
+                "apply automatically",
+                "apply automatically",
+                "yes",
+            ]
+        ),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                contact_resolutions=staged_resolution(
+                    email="new@example.com",
+                    sources=sources,
+                    submitted={"email": "stale@example.com"},
+                )
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "New",
+                "LastName": "Person",
+                "Email": "new@example.com",
+            },
+        )
+    ]
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "created-1"},
     ) in client.updated
     assert (
-        "Contact",
-        "contact-quality",
-        {"Phone": "312.555.0104 x0007"},
+        "Account",
+        "account-1",
+        {"Cert_Principal_Contact__c": "created-1"},
     ) in client.updated
+
+
+def test_distinct_emails_from_two_submissions_for_one_role_are_one_conflict(
+    tmp_path,
+):
+    client = FakeClient()
+    first = client.records[("Company_Profile_Change__c", "submission-1")]
+    first.update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Email__c": "first@example.com",
+        }
+    )
+    second = source_record(
+        Id="submission-2",
+        Name="PU-101",
+        Cert_First_Name__c="New",
+        Cert_Last_Name__c="Person",
+        Cert_Email__c="second@example.com",
+    )
+    client.records[("Company_Profile_Change__c", "submission-2")] = second
+    sources = [
+        ContactSource("role", role="certification", submission_id="submission-1"),
+        ContactSource("role", role="certification", submission_id="submission-2"),
+    ]
+    feeder = Feeder(
+        [
+            "2",
+            "apply automatically",
+            "apply automatically",
+            "yes",
+        ]
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                source_submission_ids=json.dumps(["submission-1", "submission-2"]),
+                source_submission_names=json.dumps(["PU-100", "PU-101"]),
+                certification_resolution_action="create_contact",
+                contact_resolutions=staged_resolution(
+                    email="second@example.com",
+                    sources=sources,
+                    submitted={"email": "flattened@example.com"},
+                ),
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "New",
+                "LastName": "Person",
+                "Email": "second@example.com",
+            },
+        )
+    ]
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    email_conflict = next(
+        entry
+        for entry in entries
+        if entry["action"] == "resolve Contact field conflict"
+        and entry["field"] == "Email"
+    )
+    assert email_conflict["source_submission_ids"] == [
+        "submission-1",
+        "submission-2",
+    ]
+
+
+def test_every_fresh_submitter_submission_contributes_to_reconciliation(tmp_path):
+    client = FakeClient(
+        source=source_record(
+            Name__c="Sam First",
+            Email__c="sam@example.com",
+        )
+    )
+    second = source_record(
+        Id="submission-2",
+        Name="PU-101",
+        Name__c="Sam Second",
+        Email__c="sam@example.com",
+    )
+    client.records[("Company_Profile_Change__c", "submission-2")] = second
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["2", "apply automatically"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    row = staged_row(
+        source_submission_ids=json.dumps(["submission-1", "submission-2"]),
+        source_submission_names=json.dumps(["PU-100", "PU-101"]),
+        contact_resolutions=staged_resolution(
+            sources=[ContactSource("submitter", submission_id="submission-2")],
+            submitted={
+                "first_name": "flattened",
+                "last_name": "fallback",
+                "email": "sam@example.com",
+            },
+        ),
+    )
+
+    result = processor.review([row], tmp_path)
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "Sam",
+                "LastName": "Second",
+                "Email": "sam@example.com",
+            },
+        )
+    ]
+    conflicts = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+        if '"action": "resolve Contact field conflict"' in line
+    ]
+    assert len(conflicts) == 1
+    assert conflicts[0]["field"] == "LastName"
+    assert conflicts[0]["source_submission_ids"] == [
+        "submission-1",
+        "submission-2",
+    ]
+
+
+def test_rejected_reconciled_contact_has_no_contact_write(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Old Title",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "alex@example.com",
+        }
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["will not be made", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    assert not any(item[0] == "Contact" for item in client.updated)
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    rejected = next(entry for entry in entries if entry["action"] == "no Contact write")
+    assert rejected["decision"] == "will not be made"
+    assert rejected["proposed_value"] == {"Title": "Director"}
+
+
+def test_manual_contact_decision_verifies_all_fields_together(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Old Title",
+        "Email": "alex@example.com",
+        "Phone": "312.555.0100",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "alex@example.com",
+            "Cert_Phone__c": "312-555-0199",
+        }
+    )
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Decision ["):
+            return "make manually"
+        if prompt.startswith("Make the complete Contact change"):
+            client.records[("Contact", "contact-1")].update(
+                {"Title": "Director", "Phone": "312.555.0199"}
+            )
+            return ""
+        if prompt.startswith("Was the response email"):
+            return "yes"
+        raise AssertionError(prompt)
+
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=answer,
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    assert not any(item[0] == "Contact" for item in client.updated)
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    verified = next(
+        entry
+        for entry in entries
+        if entry["action"] == "verify reconciled Contact manually"
+    )
+    assert verified["result"] == "verified manually"
+    assert verified["proposed_value"] == {
+        "Phone": "312.555.0199",
+        "Title": "Director",
+    }
+
+
+def test_contact_failure_is_audited_and_same_input_retries_then_becomes_noop(
+    tmp_path,
+):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Old Title",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "alex@example.com",
+        }
+    )
+    row = staged_row(contact_resolutions="[]")
+    client.fail_update = ("Contact", "contact-1")
+    failed_processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingError, match="write failed"):
+        failed_processor.review([row], tmp_path / "failed")
+
+    failed_entries = [
+        json.loads(line)
+        for line in (tmp_path / "failed" / "review_audit.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert any(
+        entry["action"] == "update Contact from reconciled proposals"
+        and entry["result"] == "failed"
+        for entry in failed_entries
+    )
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+
+    client.fail_update = None
+    retry_processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    retry_processor.review([row], tmp_path / "retry")
+    successful_contact_writes = [
+        item for item in client.updated if item[0] == "Contact"
+    ]
+    assert successful_contact_writes == [
+        ("Contact", "contact-1", {"Title": "Director"})
+    ]
+
+    noop_processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    noop_result = noop_processor.review([row], tmp_path / "noop")
+    assert [
+        item for item in client.updated if item[0] == "Contact"
+    ] == successful_contact_writes
+    noop_entries = [
+        json.loads(line)
+        for line in noop_result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        entry["action"] == "reconciled Contact already current"
+        for entry in noop_entries
+    )
 
 
 def test_compatibility_review_normalizes_fresh_role_values(tmp_path):
@@ -1051,9 +1787,7 @@ def test_compatibility_review_normalizes_fresh_role_values(tmp_path):
     )
     processor = InteractiveProfileUpdateProcessor(
         client,
-        input_fn=Feeder(
-            ["apply automatically", "apply automatically", "yes"]
-        ),
+        input_fn=Feeder(["apply automatically", "apply automatically", "yes"]),
         output_fn=lambda message: None,
         now=NOW,
     )
@@ -1098,6 +1832,13 @@ def test_duplicate_create_can_recover_with_an_alternate_email_contact(tmp_path):
         "Phone": "",
     }
     client = FakeClient(contacts=[alternate])
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Email__c": "new.person@example.com",
+        }
+    )
     client.fail_create = SalesforceError(
         "Salesforce failed to create Contact: Use one of these records?",
         error_code="DUPLICATES_DETECTED",
@@ -1184,6 +1925,13 @@ def test_duplicate_exact_email_matches_are_audited_and_keep_case_retryable(tmp_p
         },
     ]
     client = FakeClient(contacts=contacts)
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Email__c": "shared@example.com",
+        }
+    )
     feeder = Feeder([])
     output = []
     processor = InteractiveProfileUpdateProcessor(
@@ -1211,17 +1959,14 @@ def test_duplicate_exact_email_matches_are_audited_and_keep_case_retryable(tmp_p
         .read_text(encoding="utf-8")
         .splitlines()
     ]
-    failure = next(
-        item for item in entries if item["action"] == "match Contact by exact email"
-    )
-    assert failure["field"] == "Email"
+    failure = next(item for item in entries if item["result"] == "failed")
+    assert failure["field"] == "resolution"
     assert failure["proposed_value"] == "shared@example.com"
     assert failure["result"] == "failed"
-    assert "contact-1" in failure["original_value"]
-    assert "contact-2" in failure["original_value"]
     assert not any(prompt.startswith("Decision [") for prompt in feeder.prompts)
-    assert not any("Contact choice" in prompt for prompt in feeder.prompts)
-    assert "candidates" not in "\n".join(output).casefold()
+    assert any("Contact choice" in prompt for prompt in feeder.prompts)
+    assert "Candidate 1" in "\n".join(output)
+    assert "Candidate 2" in "\n".join(output)
     assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
     assert ("Case", "case-1", {"Status": "Pending"}) in client.updated
 
@@ -1296,7 +2041,7 @@ def test_role_response_is_consolidated_and_marks_unchanged_roles(tmp_path):
             "LastName": "Jones",
             "Title": "President",
             "Email": "pat@example.com",
-            "Phone": "312-555-0200",
+            "Phone": "312.555.0200",
         },
     ]
     client = FakeClient(
@@ -1305,6 +2050,20 @@ def test_role_response_is_consolidated_and_marks_unchanged_roles(tmp_path):
             Cert_Principal_Contact__c="contact-2",
         ),
         contacts=contacts,
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alex",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Safety Director",
+            "Cert_Email__c": "alex@example.com",
+            "Cert_Phone__c": "312-555-0199",
+            "Principal_First_Name__c": "Pat",
+            "Principal_Last_Name__c": "Jones",
+            "Principal_Title__c": "President",
+            "Principal_Email__c": "pat@example.com",
+            "Principal_Phone__c": "312-555-0200",
+        }
     )
     feeder = Feeder(["apply automatically", "yes"])
     processor = InteractiveProfileUpdateProcessor(
@@ -1336,14 +2095,14 @@ def test_role_response_is_consolidated_and_marks_unchanged_roles(tmp_path):
     assert response.count("Certification Contact:") == 1
     assert (
         "Certification Contact: Alex Smith, Safety Director, "
-        "alex@example.com, 312-555-0199"
+        "alex@example.com, 312.555.0199"
     ) in response
     assert (
         "Replaces Alex Smith, Safety Director, alex@example.com, 312-555-0100"
     ) in response
     assert (
         "Principal Contact: Pat Jones, President, "
-        "pat@example.com, 312-555-0200 - no change"
+        "pat@example.com, 312.555.0200 - no change"
     ) in response
     assert response.count("Replaces ") == 1
     assert "Certification Contact Phone:" not in response


### PR DESCRIPTION
## Summary
- Process profile contacts before role links so contact updates are handled first.
- Add email-first contact review behavior and related documentation.
- Expand test coverage for the updated processing flow.

Closes #21