### PR TITLE
Resolve blank Profile Update accounts

### DIFF
--- a/.agents/skills/wf-publish/SKILL.md
+++ b/.agents/skills/wf-publish/SKILL.md
@@ -27,7 +27,29 @@ Perform the merge using a **merge commit** (not squash or rebase), substituting 
 gh pr merge <pr> --merge
 ```
 
-### 3. Clean Up
+### 3. Update Local `main`
+
+After a successful merge, make sure the local checkout uses the newly merged
+code. First switch to `main`, then fetch and fast-forward it:
+
+```bash
+git switch main
+git fetch origin main
+git merge --ff-only origin/main
+```
+
+Verify the result:
+
+```bash
+git status --short
+git log --oneline -3
+```
+
+If the working tree has uncommitted changes or local `main` has diverged,
+stop and ask the user before changing or discarding anything. Do not use a
+forced reset to update `main`.
+
+### 4. Clean Up
 
 After a successful merge:
 - **Close related issues** referenced in the PR

--- a/README.md
+++ b/README.md
@@ -373,16 +373,26 @@ succeeds, so a failed run cannot leave a partial snapshot.
 `process-profile-updates` performs the complete processing workflow in this
 order:
 
-1. Run the existing Case automation.
-2. Stop if any required Case operation fails.
-3. Publish a fresh `profile_updates.csv`.
-4. Read that published file back from disk.
-5. Review rows in Account-and-Case batches.
+1. Repair blank Submission Accounts through the review interface.
+2. Run the existing Case automation.
+3. Stop if any required Case operation fails.
+4. Publish a fresh `profile_updates.csv`.
+5. Read that published file back from disk.
+6. Review rows in Account-and-Case batches.
 
-The command prints progress before and after authentication, Case preparation,
-staging, CSV publication, CSV validation, and review startup. Section
-separators make workflow stages, Cases, staged rows, individual Contact
-reviews, and response emails easier to distinguish.
+For a New Profile Update with a blank Account, the command looks up Accounts
+using the submitted Profile ID. It presents every match as a structured choice;
+press Enter to use the first Account, enter its displayed number to choose a
+different match, or enter `P` to look up a different Profile ID. The Account is
+saved on the Profile Update before Case preparation begins.
+
+Batches containing a Key Update strictly older than seven days are reviewed
+first. The remaining batches are reviewed from oldest to newest.
+
+The command prints progress before and after authentication, Submission Account
+resolution, Case preparation, staging, CSV publication, CSV validation, and
+review startup. Section separators make workflow stages, Cases, staged rows,
+individual Contact reviews, and response emails easier to distinguish.
 
 The review processor is renderer-neutral: it exchanges frozen Python
 dataclasses with a `ReviewUI` implementation instead of calling `print()` or

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -653,18 +653,29 @@ uv run aisc_salesforce process-profile-updates \
 ```
 
 The command has no dry-run option. A staged recommendation alone never causes
-a Salesforce data change. The command first runs `ProfileUpdateService`; if
-Case creation or reuse fails, it stops before staging or review. It then
-publishes and validates a new CSV and groups all rows with the same Account and
-Case. Batches containing a Key Update strictly older than seven days are
-reviewed first, followed by the remaining batches from oldest to newest.
+a Salesforce data change. Before Case preparation, the command repairs each New
+Profile Update whose Submission Account is blank. It looks up Accounts using
+the submitted Profile ID and presents the matches as a typed choice. Press
+Enter to select the first Account, enter another displayed number to choose
+that Account, or enter `P` to supply a different Profile ID. The selected
+Account is saved on the Profile Update, after which `ProfileUpdateService`
+creates or reuses its Case. If that Case operation fails, the command stops
+before staging or review.
 
-Progress messages appear around authentication, Case preparation, staging, CSV
-publication, CSV validation, and review startup. Progress output belongs to the
-CLI workflow, while reviewer interactions cross a separate typed `ReviewUI`
-boundary. The CLI adapter sends both to the configured terminal output
-function, preserving the existing display. Visual separators mark stages,
-Cases, staged rows, individual Contact reviews, and response-email sections.
+The command then publishes and validates a new CSV and groups all rows with the
+same Account and Case. Batches containing a Key Update strictly older than
+seven days are reviewed first, followed by the remaining batches from oldest
+to newest. A Key Update exactly seven days old remains in the normal
+oldest-to-newest group.
+
+Progress messages appear around authentication, Submission Account resolution,
+Case preparation, staging, CSV publication, CSV validation, and review startup.
+Progress output belongs to the CLI workflow, while reviewer interactions cross
+a separate typed `ReviewUI` boundary. The Account selection, including its
+first-choice default, is represented by the same `ChoiceQuestion` used by other
+review actions. The CLI adapter sends both kinds of output to the configured
+terminal output function. Visual separators mark stages, Cases, staged rows,
+individual Contact reviews, and response-email sections.
 
 For another front end, implement `ReviewUI.display(event)` and
 `ReviewUI.ask(question)`, then pass that object to

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -328,6 +328,16 @@ class ProfileUpdateProcessingWorkflow:
 
     def run(self, output_dir: Path) -> ProcessingResult | Any:
         """Execute setup in the required order and review the published CSV."""
+        resolve_accounts = getattr(
+            self.processor, "resolve_missing_submission_accounts", None
+        )
+        if resolve_accounts is not None:
+            self.output_fn(_section_heading("Resolving Submission Accounts"))
+            repaired = resolve_accounts()
+            self.output_fn(
+                f"Submission Account resolution complete: {repaired} repaired."
+            )
+
         self.output_fn(_section_heading("Preparing Profile Update Cases"))
         counts: AutomationCounts = self.case_service.run()
         if counts.failed:
@@ -597,6 +607,118 @@ class InteractiveProfileUpdateProcessor:
                 "AcknowledgementQuestion requires AcknowledgementAnswer, got "
                 f"{type(answer).__name__}."
             )
+
+    def resolve_missing_submission_accounts(self) -> int:
+        """Let the reviewer repair blank Account lookups before Case creation."""
+        submissions = self.client.query_records(
+            "Company_Profile_Change__c",
+            ["Id", "Name", "CreatedDate", "Account__c", "Certification_ID__c"],
+            where=(f"Status__c = '{ProfileChangeStatus.NEW}' AND Account__c = NULL"),
+            order_by="CreatedDate ASC, Id ASC",
+        )
+        repaired = 0
+        for submission in submissions:
+            submission_id = _required_record_text(submission, "Id", "Profile Update ID")
+            submission_name = _display(submission.get("Name") or submission_id)
+            profile_id = _display(submission.get("Certification_ID__c")).strip()
+            account = self._choose_submission_account(submission_name, profile_id)
+            account_id = _required_record_text(account, "Id", "Account ID")
+            self.client.update_record(
+                "Company_Profile_Change__c",
+                submission_id,
+                {"Account__c": account_id},
+            )
+            repaired += 1
+            self._display_event(
+                Notice(
+                    styled(
+                        "Assigned Profile Update ",
+                        ValueFragment(submission_name),
+                        " to ",
+                        ValueFragment(_display(account.get("Name")) or account_id),
+                        ".",
+                    )
+                )
+            )
+        return repaired
+
+    def _choose_submission_account(
+        self, submission_name: str, profile_id: str
+    ) -> dict[str, Any]:
+        """Choose an Account, defaulting to the first Profile ID match."""
+        while True:
+            if not profile_id:
+                profile_id = self._ask_free_text(
+                    FreeTextQuestion(
+                        styled(
+                            "Profile Update ",
+                            ValueFragment(submission_name),
+                            " has no Submission Account. Enter its Profile ID: ",
+                        )
+                    )
+                ).strip()
+                if not profile_id:
+                    self._display_event(
+                        ValidationFeedback(styled("Profile ID cannot be blank."))
+                    )
+                    continue
+
+            accounts = self.client.query_records(
+                "Account",
+                ["Id", "Name", "Certification_ID__c"],
+                where=(f"Certification_ID__c = '{escape_soql_string(profile_id)}'"),
+                order_by="Name ASC, Id ASC",
+            )
+            accounts = [account for account in accounts if _display(account.get("Id"))]
+            if not accounts:
+                self._display_event(
+                    ValidationFeedback(
+                        styled(
+                            "No Account was found for Profile ID ",
+                            ValueFragment(profile_id),
+                            ".",
+                        )
+                    )
+                )
+                profile_id = ""
+                continue
+
+            choices = tuple(
+                ReviewChoice(
+                    str(index),
+                    _account_choice_label(account),
+                )
+                for index, account in enumerate(accounts, start=1)
+            ) + (
+                ReviewChoice(
+                    "different_profile_id",
+                    "Use a different Profile ID",
+                    ("p",),
+                ),
+            )
+            prompt_fragments: list[str | ValueFragment] = [
+                "Choose the Submission Account for Profile Update ",
+                ValueFragment(submission_name),
+                ":\n",
+            ]
+            for choice in choices:
+                marker = "P" if choice.key == "different_profile_id" else choice.key
+                prompt_fragments.extend(
+                    (f"{marker}. ", ValueFragment(choice.label), "\n")
+                )
+            prompt_fragments.append("Selection (default 1): ")
+            selected = self._ask_choice(
+                ChoiceQuestion(
+                    styled(*prompt_fragments),
+                    choices,
+                    styled("Enter an Account number or P for a different Profile ID."),
+                    default_key="1",
+                )
+            )
+            if selected == "different_profile_id":
+                profile_id = ""
+                continue
+            return accounts[int(selected) - 1]
 
     def review(
         self, rows: list[dict[str, str]], artifact_dir: Path
@@ -3049,6 +3171,14 @@ def _display(value: Any) -> str:
     return str(value).strip()
 
 
+def _required_record_text(record: dict[str, Any], field_name: str, label: str) -> str:
+    """Read one required text value from a Salesforce record."""
+    value = _display(record.get(field_name))
+    if not value:
+        raise ProcessingError(f"{label} is missing.")
+    return value
+
+
 def _split_person_name(value: Any) -> tuple[str, str]:
     """Split a submitter name at the final space."""
     parts = _display(value).rsplit(maxsplit=1)
@@ -3083,6 +3213,13 @@ def _is_duplicate_contact_error(error: SalesforceError) -> bool:
 
 def _section_heading(title: str, separator: str = STAGE_SEPARATOR) -> str:
     return f"\n{separator}\n{title}\n{separator}"
+
+
+def _account_choice_label(account: dict[str, Any]) -> str:
+    """Return the identifying Account text shown in a selection control."""
+    name = _display(account.get("Name")) or "(name unavailable)"
+    profile_id = _display(account.get("Certification_ID__c")) or "(blank)"
+    return f"{name} (Profile ID {profile_id})"
 
 
 def _contact_name_email(contact: dict[str, Any] | None) -> str:

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -23,6 +23,12 @@ from aisc_salesforce.process_profile_updates import (
     read_staged_profile_updates,
 )
 from aisc_salesforce.profile_updates import AutomationCounts
+from aisc_salesforce.review_ui import (
+    ChoiceAnswer,
+    ChoiceQuestion,
+    FreeTextAnswer,
+    FreeTextQuestion,
+)
 from aisc_salesforce.salesforce import SalesforceError
 from aisc_salesforce.stage_profile_updates import CSV_COLUMNS, StagingResult
 
@@ -240,6 +246,40 @@ class CapturingProcessor:
         return artifact_dir
 
 
+class ResolvingProcessor(CapturingProcessor):
+    def resolve_missing_submission_accounts(self):
+        self.events.append("resolve_accounts")
+        return 1
+
+
+def test_workflow_repairs_submission_accounts_before_creating_cases(tmp_path):
+    events = []
+    processor = ResolvingProcessor(events)
+
+    def writer(rows, output_dir):
+        events.append("write")
+        folder = output_dir / "published"
+        folder.mkdir()
+        with (folder / "profile_updates.csv").open(
+            "w", newline="", encoding="utf-8"
+        ) as output:
+            csv.DictWriter(output, fieldnames=CSV_COLUMNS).writeheader()
+            csv.DictWriter(output, fieldnames=CSV_COLUMNS).writerow(rows[0])
+        return folder
+
+    workflow = ProfileUpdateProcessingWorkflow(
+        CaseService(events),
+        StagingService(events),
+        processor,
+        staging_writer=writer,
+        output_fn=lambda message: None,
+    )
+
+    workflow.run(tmp_path)
+
+    assert events == ["resolve_accounts", "cases", "stage", "write", "review"]
+
+
 def test_workflow_creates_cases_then_stages_and_reads_the_published_csv(tmp_path):
     events = []
     output = []
@@ -368,6 +408,124 @@ def test_batches_group_account_and_case_and_prioritize_old_key_updates():
         "case-newer",
     ]
     assert len(batches[-1].rows) == 2
+
+
+def test_key_update_exactly_seven_days_old_is_not_in_the_priority_group():
+    rows = [
+        staged_row(
+            earliest_submission_date="2026-07-01T12:00:00+00:00",
+            case_id="case-old-ordinary",
+        ),
+        staged_row(
+            earliest_submission_date="2026-07-16T12:00:00+00:00",
+            earliest_key_update_date="2026-07-10T18:00:00+00:00",
+            has_key_updates="true",
+            case_id="case-exactly-seven-days",
+        ),
+    ]
+
+    batches = build_case_batches(rows, now=NOW)
+
+    assert [batch.case_id for batch in batches] == [
+        "case-old-ordinary",
+        "case-exactly-seven-days",
+    ]
+
+
+class AccountResolutionUI:
+    def __init__(self, *, entered_profile_id=""):
+        self.entered_profile_id = entered_profile_id
+        self.events = []
+        self.questions = []
+
+    def display(self, event):
+        self.events.append(event)
+
+    def ask(self, question):
+        self.questions.append(question)
+        if isinstance(question, FreeTextQuestion):
+            return FreeTextAnswer(self.entered_profile_id)
+        if isinstance(question, ChoiceQuestion):
+            return ChoiceAnswer(question.choices[0])
+        raise AssertionError(type(question))
+
+
+class AccountResolutionClient:
+    def __init__(self, *, profile_id="C-100"):
+        self.profile_id = profile_id
+        self.queries = []
+        self.updated = []
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where, order_by))
+        if object_name == "Company_Profile_Change__c":
+            return [
+                {
+                    "Id": "submission-1",
+                    "Name": "PU-100",
+                    "CreatedDate": "2026-07-15T14:30:00.000+0000",
+                    "Account__c": None,
+                    "Certification_ID__c": self.profile_id,
+                }
+            ]
+        if object_name == "Account":
+            return [
+                {
+                    "Id": "account-1",
+                    "Name": "Acme Steel",
+                    "Certification_ID__c": self.profile_id or "C-200",
+                },
+                {
+                    "Id": "account-2",
+                    "Name": "Beta Steel",
+                    "Certification_ID__c": self.profile_id or "C-200",
+                },
+            ]
+        raise AssertionError(object_name)
+
+    def update_record(self, object_name, record_id, values):
+        self.updated.append((object_name, record_id, values))
+
+
+def test_missing_submission_account_defaults_to_first_profile_id_match():
+    client = AccountResolutionClient()
+    ui = AccountResolutionUI()
+    processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
+
+    repaired = processor.resolve_missing_submission_accounts()
+
+    assert repaired == 1
+    assert client.updated == [
+        (
+            "Company_Profile_Change__c",
+            "submission-1",
+            {"Account__c": "account-1"},
+        )
+    ]
+    account_query = next(query for query in client.queries if query[0] == "Account")
+    assert account_query[2] == "Certification_ID__c = 'C-100'"
+    assert account_query[3] == "Name ASC, Id ASC"
+    question = next(
+        question for question in ui.questions if isinstance(question, ChoiceQuestion)
+    )
+    assert question.default_key == "1"
+    assert [choice.key for choice in question.choices] == [
+        "1",
+        "2",
+        "different_profile_id",
+    ]
+
+
+def test_missing_submission_account_accepts_profile_id_when_form_value_is_blank():
+    client = AccountResolutionClient(profile_id="")
+    ui = AccountResolutionUI(entered_profile_id="C-200")
+    processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
+
+    processor.resolve_missing_submission_accounts()
+
+    account_query = next(query for query in client.queries if query[0] == "Account")
+    assert account_query[2] == "Certification_ID__c = 'C-200'"
+    assert isinstance(ui.questions[0], FreeTextQuestion)
 
 
 def test_blocking_case_match_is_never_guessed():


### PR DESCRIPTION
## Summary
- repair New Profile Updates with blank Submission Account lookups before Case preparation
- resolve Accounts by submitted Certification/Profile ID and let the reviewer choose among matches
- document the workflow and add coverage for the repair flow

Follow-up to #25; related to #24