### PR TITLE
Support parent account profile updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,32 @@ values; warnings and blockers; statuses; prior Case activity; and
 identity keys. The CLI prints a short summary from each complete queue snapshot,
 while another `ReviewUI` implementation can use the full model for navigation.
 
+Parent Accounts are detected from fresh, direct-child Account records at the
+start of each Case batch. Traversal stops after that one level; grandchildren
+are never targets. Only direct children whose certification status is exactly
+`Certified` or `Initials` receive Account field changes or Account-role links.
+The staging CSV records this affected-Account context, and the queue expands
+child-specific Account and role-link entries to those child IDs while keeping
+Contact work shared.
+
+Before any Salesforce write in the batch, the processor compares the active
+children only for Account fields and role lookups actually submitted. Displayed
+values are compared after outer whitespace is trimmed, and null equals blank;
+remaining text is case-sensitive. When all relevant child values agree,
+Contacts are reconciled once, newly created Contacts remain owned by the Parent
+Account, and each active child follows the normal Account and role review path.
+Inactive children are not updated.
+
+If active child values conflict, the CLI shows every conflicting field, its
+requested value, and every active child's current name, ID, and value. If the
+Parent has direct children but none are active, it shows their statuses instead.
+Either condition requires acknowledgement, records a `deferred manual
+follow-up` audit outcome, marks the whole Case batch `blocked` in the queue,
+leaves every source Profile Update and the Case open, and continues to the next
+Case. No Contact, Account, role, Case, or submission write occurs for that
+blocked batch. A later retry restages and refetches Salesforce, so processing
+can continue normally after manual reconciliation.
+
 Use `--output-dir` the same way as the staging command:
 
 ```bash
@@ -538,7 +564,9 @@ The queue is deterministic for unchanged staged input and contains no run
 timestamp. Its ordered work phases are setup, Contact, Account, and role link.
 Statuses are `pending`, `in_progress`, `blocked`, `completed`, `failed`, and
 `stopped_early`; a completed change also keeps its audit outcome, such as
-`applied`, `verified manually`, `rejected`, or `no-op`. The default-next pointer
+`applied`, `verified manually`, `rejected`, or `no-op`. Parent work deferred to
+manual processing keeps the `deferred manual follow-up` outcome on blocked queue
+work. The default-next pointer
 is the first unblocked pending change and becomes `null` when none remains.
 
 The JSON Lines audit is flushed after every decision and Salesforce result.

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,10 @@ refreshes Account or Case references.
         - ContactComparison
         - ConflictCandidate
         - ContactFieldConflict
+        - ParentAccountChildValue
+        - ParentAccountFieldConflict
+        - ParentAccountConflict
+        - ParentAccountNoActiveChildren
         - StagedRowSummary
         - AccountHistory
         - ResponseEmail
@@ -282,7 +286,13 @@ Contact ID is only a fallback for a partial proposal without an email. Different
 emails stay separate even when submitted for the same role, unless identity
 review resolves them to the same Salesforce Contact. Reviewer-facing Contact
 comparisons use labeled field lines, while the JSON audit retains structured
-dictionaries. The
+dictionaries. Parent Account preflight refetches only direct children, filters
+them to exact `Certified` and `Initials` statuses, and emits renderer-neutral
+conflict or no-active-child events before any batch write. Safe Account and
+role-link proposals target each active child; Contact work remains shared and a
+new Contact stays owned by the submitted Parent Account. Acknowledged unsafe
+batches use the `DEFERRED_MANUAL` action status, a blocked queue state, and leave
+the source records and Case open for manual follow-up and retry. The
 processor writes `review_audit.jsonl` after every result and
 `response_emails.txt` for successful Account changes and completed submitted
 roles. Profile Update closure and the Case's final status happen only after the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -709,7 +709,8 @@ Every batch, row, and change includes an `id`, readable `label`, `status`,
 `warnings`, and `blockers`. Changes also include their phase, source submission
 and row IDs, Salesforce object/record/field reference, current value, proposed
 value, and optional completed `outcome`. Batch and row references retain the
-source Profile Updates, target Account and Case, and related prior Case activity.
+source Profile Updates, target Account and Case, affected direct child Accounts,
+and related prior Case activity.
 Only submissions queried with `Status__c = 'New'` become work; older records are
 context references, not queue items.
 
@@ -863,6 +864,33 @@ when phase one changed the Contact email or created a Contact shared by several
 roles. This phase may update Account role lookup fields only. It performs no
 Contact create or update. Contact identity and field updates therefore finish
 before role assignment can influence an Account lookup.
+
+At the start of every Case batch, the submitted Account and its direct children
+are fetched again. An Account with at least one direct child is treated as a
+Parent Account. Only that first child level is inspected, so grandchildren are
+never selected. Direct children are active only when
+`Cert_Certification_Status__c` is exactly `Certified` or `Initials`; `Dropped`,
+`Suspended`, blank, and all other statuses are excluded.
+
+Before the Case, Contacts, Accounts, role links, or source submissions can be
+changed, active children are compared for the ordinary Account fields and
+Account-role lookups actually submitted in this Case batch. Outer whitespace is
+ignored, null and blank are equal, and other text remains case-sensitive.
+Differences in unsubmitted fields and values on inactive children do not block
+processing. If relevant values agree, Contact reconciliation runs once. A newly
+created Contact keeps the Parent Account as `AccountId`, while the ordinary
+Account proposal and role-link review runs once for each active child.
+
+A relevant conflict produces a typed summary with the field label, requested
+value, and every active child's current name, ID, and value. A Parent with no
+active direct children produces a typed notice listing the direct children's
+statuses. The reviewer acknowledges either message; the processor then writes a
+`deferred manual follow-up` audit event, marks the complete Case batch blocked,
+leaves every included Profile Update and the Case open, performs no Salesforce
+write for that batch, and advances to the next Case. An interruption during the
+acknowledgement also occurs before any Salesforce write. On a later run, staging
+and preflight refetch the hierarchy and values, so manually reconciled work can
+be retried without carrying stale child routing.
 
 Account-role proposals use friendly Contact names and emails for current and
 proposed values. Salesforce IDs remain available internally for record writes

--- a/src/aisc_salesforce/cli_review_ui.py
+++ b/src/aisc_salesforce/cli_review_ui.py
@@ -20,6 +20,8 @@ from .review_ui import (
     Heading,
     MappingComparison,
     Notice,
+    ParentAccountConflict,
+    ParentAccountNoActiveChildren,
     ResponseEmail,
     ReviewAnswer,
     ReviewEvent,
@@ -61,7 +63,9 @@ class CLIReviewUI:
                 f"Proposed value: {_value(event.proposed)}"
             )
         elif isinstance(event, MappingComparison):
-            heading = "New Salesforce values:" if event.is_new else "Salesforce changes:"
+            heading = (
+                "New Salesforce values:" if event.is_new else "Salesforce changes:"
+            )
             lines = [f"\n{event.label}", heading]
             for row in event.rows:
                 if event.is_new:
@@ -101,6 +105,42 @@ class CLIReviewUI:
                     f"   Sources: {candidate.sources.value}"
                 )
             self.output_fn(f"current. {_value(event.current)}")
+        elif isinstance(event, ParentAccountConflict):
+            lines = [
+                _section_heading(
+                    f"Parent Account needs manual follow-up: {event.parent.value}",
+                    "-" * 72,
+                ),
+                "Active direct child values conflict, so this entire Case batch "
+                "will remain open:",
+            ]
+            for field in event.fields:
+                lines.extend(
+                    (f"\n{field.label}", f"Requested value: {_value(field.requested)}")
+                )
+                lines.extend(
+                    f"{child.account_name.value or '(unnamed)'} "
+                    f"({child.account_id.value}): {_value(child.current)}"
+                    for child in field.children
+                )
+            self.output_fn("\n".join(lines))
+        elif isinstance(event, ParentAccountNoActiveChildren):
+            lines = [
+                _section_heading(
+                    f"Parent Account needs manual follow-up: {event.parent.value}",
+                    "-" * 72,
+                ),
+                "This Parent Account has no direct child with status Certified or "
+                "Initials, so this entire Case batch will remain open.",
+            ]
+            if event.children:
+                lines.append("Direct children:")
+                lines.extend(
+                    f"{child.account_name.value or '(unnamed)'} "
+                    f"({child.account_id.value}): {_value(child.current)}"
+                    for child in event.children
+                )
+            self.output_fn("\n".join(lines))
         elif isinstance(event, StagedRowSummary):
             heading = (
                 "Staged row\n"
@@ -115,9 +155,7 @@ class CLIReviewUI:
                     "contact information."
                 )
             if event.has_no_update_content:
-                heading += (
-                    "\nNote: this combined profile update has no submitted update content."
-                )
+                heading += "\nNote: this combined profile update has no submitted update content."
             self.output_fn(_section_heading(heading, "-" * 72))
         elif isinstance(event, AccountHistory):
             self.output_fn(

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -26,10 +26,12 @@ from .contact_resolution import (
 from .profile_updates import AutomationCounts, escape_soql_string
 from .queried_fields import (
     ACCOUNT_HISTORY_FIELDS,
+    ACCOUNT_REVIEW_FIELDS,
     CONTACT_REVIEW_FIELDS,
     SUBMISSION_FIELDS,
 )
 from .review_queue import (
+    QueueBlocker,
     QueuePhase,
     QueueStatus,
     ReviewQueueManifest,
@@ -56,6 +58,10 @@ from .review_ui import (
     MappingComparison,
     MappingComparisonRow,
     Notice,
+    ParentAccountChildValue,
+    ParentAccountConflict,
+    ParentAccountFieldConflict,
+    ParentAccountNoActiveChildren,
     ResponseEmail,
     ReviewChoice,
     ReviewEvent,
@@ -72,6 +78,7 @@ from .review_ui import (
 from .salesforce import SalesforceClient, SalesforceError
 from .salesforce_enums import CaseStatus, ProfileChangeStatus
 from .stage_profile_updates import (
+    ACTIVE_CERTIFICATION_STATUSES,
     CSV_COLUMNS,
     ROLE_DEFINITIONS,
     ProfileUpdateStagingService,
@@ -156,6 +163,10 @@ class ProcessingInterrupted(ProcessingError):
     """The reviewer interrupted processing before the batch was finalized."""
 
 
+class _ParentPreflightInterrupted(ProcessingInterrupted):
+    """The reviewer interrupted before a blocked Parent batch made any write."""
+
+
 class ProcessingStoppedEarly(Exception):
     """The reviewer deliberately stopped before the current row was reviewed."""
 
@@ -178,6 +189,7 @@ class ActionStatus(StrEnum):
     FAILED = "failed"
     INTERRUPTED = "interrupted"
     STOPPED_EARLY = "stopped early"
+    DEFERRED_MANUAL = "deferred manual follow-up"
 
 
 @dataclass(frozen=True)
@@ -240,6 +252,24 @@ class CaseBatch:
                 for source_id in _json_string_list(row["source_submission_ids"])
             )
         )
+
+
+@dataclass(frozen=True)
+class _ParentRouting:
+    """Fresh one-level Account routing selected before a Case batch writes."""
+
+    submitted_account: dict[str, Any]
+    direct_children: tuple[dict[str, Any], ...]
+    target_accounts: tuple[dict[str, Any], ...]
+    conflicts: tuple[ParentAccountFieldConflict, ...] = ()
+
+    @property
+    def is_parent(self) -> bool:
+        return bool(self.direct_children)
+
+    @property
+    def blocked(self) -> bool:
+        return self.is_parent and (not self.target_accounts or bool(self.conflicts))
 
 
 @dataclass(frozen=True)
@@ -745,6 +775,7 @@ class InteractiveProfileUpdateProcessor:
         self._audit: _AuditWriter | None = None
         self._queue_store: ReviewQueueStore | None = None
         self._active_change_id: str | None = None
+        self._review_rows: list[dict[str, str]] | None = None
 
     def prepare_review_queue(
         self, rows: list[dict[str, str]], artifact_dir: Path
@@ -986,6 +1017,7 @@ class InteractiveProfileUpdateProcessor:
                     outcome=ActionStatus.NOOP.value,
                 )
         response_writer = _ResponseWriter(response_path)
+        self._review_rows = rows
         batches = build_case_batches(rows, now=self.now)
         completed = 0
         pending = 0
@@ -1007,6 +1039,10 @@ class InteractiveProfileUpdateProcessor:
                         pending += len(batches) - completed
                         stopped_early = True
                         break
+                    except _ParentPreflightInterrupted:
+                        # The Case and submissions were already open, and parent
+                        # preflight deliberately runs before any Salesforce write.
+                        raise
                     except ProcessingInterrupted:
                         self._keep_case_pending(batch)
                         raise
@@ -1037,6 +1073,7 @@ class InteractiveProfileUpdateProcessor:
                     pending += int(is_pending)
         finally:
             self._audit = None
+            self._review_rows = None
         return ProcessingResult(
             staging_path=artifact_dir,
             audit_path=audit_path,
@@ -1075,6 +1112,9 @@ class InteractiveProfileUpdateProcessor:
         )
         fresh_by_id = self._fresh_case_submissions(batch)
         self._show_case_context(batch, fresh_by_id)
+        routing = self._preflight_parent_routing(batch, fresh_by_id)
+        if routing.blocked:
+            return self._defer_parent_batch(batch, routing)
         self._show_account_history(batch, list(fresh_by_id.values()))
 
         # Every row checkpoint happens before the first Salesforce write.
@@ -1124,31 +1164,53 @@ class InteractiveProfileUpdateProcessor:
 
         self._display_event(Heading(styled("Account Updates"), STAGE_SEPARATOR))
         account_results: list[ActionResult] = []
-        for row in batch.rows:
-            fresh_submissions = [
-                fresh_by_id[source_id]
-                for source_id in _json_string_list(row["source_submission_ids"])
-            ]
-            reviewed = self._review_account_proposals(batch, row, fresh_submissions)
-            account_results.extend(reviewed)
-            results.extend(reviewed)
+        for target_index, target_account in enumerate(routing.target_accounts):
+            target_account_id = _required_record_text(
+                target_account, "Id", "Affected Account ID"
+            )
+            target_account_name = _display(target_account.get("Name"))
+            for row in batch.rows:
+                fresh_submissions = [
+                    fresh_by_id[source_id]
+                    for source_id in _json_string_list(row["source_submission_ids"])
+                ]
+                reviewed = self._review_account_proposals(
+                    batch,
+                    row,
+                    fresh_submissions,
+                    target_account_id=target_account_id,
+                    target_account_name=target_account_name,
+                    parent_routed=routing.is_parent,
+                )
+                if target_index == 0:
+                    account_results.extend(reviewed)
+                results.extend(reviewed)
 
         self._display_event(Heading(styled("Role Links"), STAGE_SEPARATOR))
         role_responses: list[_RoleResponse] = []
-        for row in batch.rows:
-            fresh_submissions = [
-                fresh_by_id[source_id]
-                for source_id in _json_string_list(row["source_submission_ids"])
-            ]
-            reviewed, responses = self._assign_reconciled_roles(
-                batch,
-                row,
-                fresh_submissions,
-                contact_items,
-                source_mapping,
+        for target_index, target_account in enumerate(routing.target_accounts):
+            target_account_id = _required_record_text(
+                target_account, "Id", "Affected Account ID"
             )
-            results.extend(reviewed)
-            role_responses.extend(responses)
+            target_account_name = _display(target_account.get("Name"))
+            for row in batch.rows:
+                fresh_submissions = [
+                    fresh_by_id[source_id]
+                    for source_id in _json_string_list(row["source_submission_ids"])
+                ]
+                reviewed, responses = self._assign_reconciled_roles(
+                    batch,
+                    row,
+                    fresh_submissions,
+                    contact_items,
+                    source_mapping,
+                    target_account_id=target_account_id,
+                    target_account_name=target_account_name,
+                    parent_routed=routing.is_parent,
+                )
+                results.extend(reviewed)
+                if target_index == 0:
+                    role_responses.extend(responses)
 
         return self._finish_batch(
             batch,
@@ -1707,7 +1769,9 @@ class InteractiveProfileUpdateProcessor:
                 action="reconciled Contact already current",
             )
             self._append_audit(item.result)
-            self._display_event(Notice(styled("Contact is already current; no change needed.")))
+            self._display_event(
+                Notice(styled("Contact is already current; no change needed."))
+            )
             return
         has_last_name = bool((item.reconciled or {}).get("last_name"))
         if not item.contact_id and not has_last_name:
@@ -2103,9 +2167,7 @@ class InteractiveProfileUpdateProcessor:
             Heading(
                 styled(
                     "Contact resolution for ",
-                    ValueFragment(
-                        resolution.normalized_email or "(invalid email)"
-                    ),
+                    ValueFragment(resolution.normalized_email or "(invalid email)"),
                 ),
                 ITEM_SEPARATOR,
             )
@@ -2113,13 +2175,13 @@ class InteractiveProfileUpdateProcessor:
         for index, candidate in enumerate(resolution.candidates, start=1):
             self._show_contact_details(f"Candidate {index}", candidate)
         while True:
-            candidate_range = f"1-{len(resolution.candidates)}, " if resolution.candidates else ""
+            candidate_range = (
+                f"1-{len(resolution.candidates)}, " if resolution.candidates else ""
+            )
             try:
                 answer = self._ask_choice(
                     ChoiceQuestion(
-                        styled(
-                            f"Contact choice [{candidate_range}create/ignore]: "
-                        ),
+                        styled(f"Contact choice [{candidate_range}create/ignore]: "),
                         tuple(
                             ReviewChoice(str(index), f"Candidate {index}")
                             for index in range(1, len(resolution.candidates) + 1)
@@ -2248,6 +2310,10 @@ class InteractiveProfileUpdateProcessor:
         submissions: list[dict[str, Any]],
         items: list[_ContactWorkItem],
         source_mapping: dict[tuple[str, str, str], str],
+        *,
+        target_account_id: str,
+        target_account_name: str,
+        parent_routed: bool,
     ) -> tuple[list[ActionResult], list[_RoleResponse]]:
         """Link roles using the preserved source mapping; never mutate Contacts."""
         results: list[ActionResult] = []
@@ -2258,7 +2324,7 @@ class InteractiveProfileUpdateProcessor:
             if not any(submitted.values()):
                 continue
             original_id, original_contact = self._fresh_role_contact(
-                batch, role.account_lookup
+                target_account_id, role.account_lookup
             )
             item: _ContactWorkItem | None = None
             for submission in reversed(submissions):
@@ -2298,9 +2364,14 @@ class InteractiveProfileUpdateProcessor:
                     batch,
                     row,
                     target_object="Account",
-                    target_record_id=batch.account_id,
+                    target_record_id=target_account_id,
                     field_name=role.account_lookup,
-                    label=f"{role.label} Account Role",
+                    label=(
+                        f"{role.label} Account Role — "
+                        f"{target_account_name or target_account_id}"
+                        if parent_routed
+                        else f"{role.label} Account Role"
+                    ),
                     proposed_value=item.contact_id,
                     resolution=item.resolution,
                 ),
@@ -2370,9 +2441,7 @@ class InteractiveProfileUpdateProcessor:
         all_sent = True
         for email, text in emails.items():
             response_writer.append(batch.case_id, email, text)
-            self._display_event(
-                ResponseEmail(ValueFragment(email), text)
-            )
+            self._display_event(ResponseEmail(ValueFragment(email), text))
             sent = self._prompt_yes_no(
                 styled(
                     "Was the response email to ",
@@ -2459,6 +2528,222 @@ class InteractiveProfileUpdateProcessor:
             for source_id in batch.source_submission_ids
         }
 
+    def _preflight_parent_routing(
+        self,
+        batch: CaseBatch,
+        submissions_by_id: dict[str, dict[str, Any]],
+    ) -> _ParentRouting:
+        """Refetch one direct child level and validate all child-specific work."""
+        account = self.client.get_record(
+            "Account", batch.account_id, ACCOUNT_REVIEW_FIELDS
+        )
+        queried_children = self.client.query_records(
+            "Account",
+            ACCOUNT_REVIEW_FIELDS,
+            where=(f"ParentId = '{escape_soql_string(batch.account_id)}'"),
+            order_by="Id ASC",
+        )
+        direct_children = tuple(
+            sorted(
+                (
+                    child
+                    for child in queried_children
+                    if not _display(child.get("ParentId"))
+                    or _display(child.get("ParentId")) == batch.account_id
+                ),
+                key=lambda child: _display(child.get("Id")),
+            )
+        )
+        if not direct_children:
+            routing = _ParentRouting(account, (), (account,))
+            self._refresh_affected_account_queue(batch, routing)
+            return routing
+
+        active_children = tuple(
+            child
+            for child in direct_children
+            if _display(child.get("Cert_Certification_Status__c"))
+            in ACTIVE_CERTIFICATION_STATUSES
+        )
+        conflicts: list[ParentAccountFieldConflict] = []
+        if active_children:
+            seen: set[tuple[str, str]] = set()
+            for field_name, label, requested in self._parent_field_requests(
+                batch, submissions_by_id
+            ):
+                identity = (field_name, requested)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                values = [child.get(field_name) for child in active_children]
+                if all(_values_equal(values[0], value) for value in values[1:]):
+                    continue
+                conflicts.append(
+                    ParentAccountFieldConflict(
+                        label,
+                        ValueFragment(requested),
+                        tuple(
+                            ParentAccountChildValue(
+                                ValueFragment(_display(child.get("Id"))),
+                                ValueFragment(
+                                    _display(child.get("Name")) or "(unnamed)"
+                                ),
+                                ValueFragment(_display(child.get(field_name))),
+                            )
+                            for child in active_children
+                        ),
+                    )
+                )
+        routing = _ParentRouting(
+            account,
+            direct_children,
+            active_children,
+            tuple(conflicts),
+        )
+        self._refresh_affected_account_queue(batch, routing)
+        return routing
+
+    def _refresh_affected_account_queue(
+        self,
+        batch: CaseBatch,
+        routing: _ParentRouting,
+    ) -> None:
+        """Keep child references and child-specific queue IDs fresh before writes."""
+        affected_accounts = json.dumps(
+            [
+                {
+                    "id": _display(account.get("Id")),
+                    "name": _display(account.get("Name")),
+                    "certification_status": _display(
+                        account.get("Cert_Certification_Status__c")
+                    ),
+                }
+                for account in routing.target_accounts
+                if _display(account.get("Id"))
+            ],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        for row in batch.rows:
+            row["is_parent_account"] = "true" if routing.is_parent else "false"
+            row["affected_accounts"] = affected_accounts
+        if self._queue_store is None or self._review_rows is None:
+            return
+        self._queue_store.refresh(build_review_queue(self._review_rows, now=self.now))
+        self._display_event(ReviewQueueSnapshot(self._queue_store.manifest))
+
+    def _parent_field_requests(
+        self,
+        batch: CaseBatch,
+        submissions_by_id: dict[str, dict[str, Any]],
+    ) -> list[tuple[str, str, str]]:
+        """Return only Account fields and role lookups actually submitted."""
+        requests: list[tuple[str, str, str]] = []
+        for row in batch.rows:
+            submissions = [
+                submissions_by_id[source_id]
+                for source_id in _json_string_list(row["source_submission_ids"])
+            ]
+            for _, source_field, account_field, label in ACCOUNT_PROPOSALS:
+                requested = _latest_nonblank(submissions, source_field)
+                if requested:
+                    requests.append((account_field, label, requested))
+            for role in ROLE_DEFINITIONS:
+                submitted = _submitted_role_values(submissions, row, role)
+                has_fresh_role_value = any(
+                    _latest_nonblank(submissions, source_field)
+                    for _, source_field in role.submitted_fields
+                )
+                if not has_fresh_role_value:
+                    continue
+                requested = row.get(f"{role.prefix}_salesforce_contact_id", "").strip()
+                if not requested:
+                    name = " ".join(
+                        value
+                        for value in (
+                            submitted.get("first_name", ""),
+                            submitted.get("last_name", ""),
+                        )
+                        if value
+                    )
+                    email = submitted.get("email", "")
+                    requested = (
+                        f"{name} <{email}>"
+                        if name and email
+                        else name or email or "new Contact"
+                    )
+                requests.append(
+                    (
+                        role.account_lookup,
+                        f"{role.label} Account Role",
+                        requested,
+                    )
+                )
+        return requests
+
+    def _defer_parent_batch(
+        self,
+        batch: CaseBatch,
+        routing: _ParentRouting,
+    ) -> bool:
+        """Explain, acknowledge, audit, and defer one unsafe Parent batch."""
+        parent = routing.submitted_account
+        parent_label = _display(parent.get("Name")) or batch.rows[0].get(
+            "account_name", ""
+        )
+        parent_display = f"{parent_label or '(unnamed)'} ({batch.account_id})"
+        if routing.conflicts:
+            self._display_event(
+                ParentAccountConflict(
+                    ValueFragment(parent_display),
+                    routing.conflicts,
+                )
+            )
+            reason = "Active direct child Account values conflict."
+        else:
+            self._display_event(
+                ParentAccountNoActiveChildren(
+                    ValueFragment(parent_display),
+                    tuple(
+                        ParentAccountChildValue(
+                            ValueFragment(_display(child.get("Id"))),
+                            ValueFragment(_display(child.get("Name")) or "(unnamed)"),
+                            ValueFragment(
+                                _display(child.get("Cert_Certification_Status__c"))
+                            ),
+                        )
+                        for child in routing.direct_children
+                    ),
+                )
+            )
+            reason = "Parent Account has no active direct children."
+        try:
+            self._acknowledge(
+                AcknowledgementQuestion(
+                    styled(
+                        "This Case batch needs manual follow-up and will remain "
+                        "open. Press Enter to acknowledge and continue: "
+                    )
+                )
+            )
+        except (KeyboardInterrupt, EOFError) as error:
+            self._append_batch_event(
+                batch,
+                ActionStatus.INTERRUPTED,
+                action="acknowledge deferred parent Account batch",
+                error="Reviewer interrupted processing.",
+            )
+            raise _ParentPreflightInterrupted(
+                "Profile Update review was interrupted during parent preflight."
+            ) from error
+        self._append_batch_event(
+            batch,
+            ActionStatus.DEFERRED_MANUAL,
+            action="defer parent Account batch for manual follow-up",
+            error=reason,
+        )
+        return True
+
     def _show_case_context(
         self,
         batch: CaseBatch,
@@ -2472,9 +2757,7 @@ class InteractiveProfileUpdateProcessor:
             ),
             batch.account_id,
         )
-        self._display_event(
-            ContextLine("Account", (ValueFragment(account_name),))
-        )
+        self._display_event(ContextLine("Account", (ValueFragment(account_name),)))
         submitters = dict.fromkeys(
             (
                 row.get("submitter_name", "").strip(),
@@ -2507,9 +2790,7 @@ class InteractiveProfileUpdateProcessor:
             comments = _display(submission.get("Comments__c"))
             notes = _display(submission.get("Other_Personnel_Notes__c"))
             if comments:
-                self._display_event(
-                    ContextLine("Comments", (ValueFragment(comments),))
-                )
+                self._display_event(ContextLine("Comments", (ValueFragment(comments),)))
             if notes:
                 self._display_event(
                     ContextLine("Other Personnel notes", (ValueFragment(notes),))
@@ -2575,6 +2856,10 @@ class InteractiveProfileUpdateProcessor:
         batch: CaseBatch,
         row: dict[str, str],
         submissions: list[dict[str, Any]],
+        *,
+        target_account_id: str,
+        target_account_name: str,
+        parent_routed: bool,
     ) -> list[ActionResult]:
         results = []
         for csv_name, source_field, account_field, label in ACCOUNT_PROPOSALS:
@@ -2582,15 +2867,22 @@ class InteractiveProfileUpdateProcessor:
             fresh_value = _latest_nonblank(submissions, source_field)
             if fresh_value:
                 proposed = fresh_value
+            elif parent_routed:
+                # Parent routing intentionally leaves unsubmitted child fields alone.
+                continue
             if not proposed:
                 continue
             proposal = self._proposal(
                 batch,
                 row,
                 target_object="Account",
-                target_record_id=batch.account_id,
+                target_record_id=target_account_id,
                 field_name=account_field,
-                label=label,
+                label=(
+                    f"{label} — {target_account_name or target_account_id}"
+                    if parent_routed
+                    else label
+                ),
                 proposed_value=proposed,
             )
             results.append(self._review_proposal(proposal))
@@ -2598,12 +2890,12 @@ class InteractiveProfileUpdateProcessor:
 
     def _fresh_role_contact(
         self,
-        batch: CaseBatch,
+        account_id: str,
         account_lookup: str,
     ) -> tuple[str, dict[str, Any] | None]:
         account = self.client.get_record(
             "Account",
-            batch.account_id,
+            account_id,
             ["Id", account_lookup],
         )
         contact_id = _display(account.get(account_lookup))
@@ -2658,7 +2950,9 @@ class InteractiveProfileUpdateProcessor:
         )
         self._display_event(
             Notice(
-                styled("Salesforce blocked this Contact create as a possible duplicate.")
+                styled(
+                    "Salesforce blocked this Contact create as a possible duplicate."
+                )
             )
         )
         while True:
@@ -2671,9 +2965,7 @@ class InteractiveProfileUpdateProcessor:
                         "4/ignore this entry]: "
                     ),
                     (
-                        ReviewChoice(
-                            "create_manually", "create manually", ("1",)
-                        ),
+                        ReviewChoice("create_manually", "create manually", ("1",)),
                         ReviewChoice(
                             "update_manually",
                             "update an existing Contact manually",
@@ -3142,8 +3434,7 @@ class InteractiveProfileUpdateProcessor:
                 ),
                 choices,
                 styled(
-                    "Enter A, M, or N, or one of the three complete decision "
-                    "phrases."
+                    "Enter A, M, or N, or one of the three complete decision phrases."
                     if automatic_allowed
                     else "This incomplete Contact cannot be created automatically; "
                     "choose make manually or will not be made."
@@ -3230,9 +3521,7 @@ class InteractiveProfileUpdateProcessor:
             proposed_value=CaseStatus.PENDING,
         )
         try:
-            self._update_record(
-                "Case", batch.case_id, {"Status": CaseStatus.PENDING}
-            )
+            self._update_record("Case", batch.case_id, {"Status": CaseStatus.PENDING})
         except SalesforceError as error:
             self._append_audit(
                 ActionResult(
@@ -3300,7 +3589,15 @@ class InteractiveProfileUpdateProcessor:
             status = QueueStatus.STOPPED_EARLY
         elif result.status in {ActionStatus.FAILED, ActionStatus.INTERRUPTED}:
             status = QueueStatus.FAILED
+        elif result.status is ActionStatus.DEFERRED_MANUAL:
+            status = QueueStatus.BLOCKED
         else:
+            return
+        if (
+            result.status is ActionStatus.DEFERRED_MANUAL
+            and result.proposal.target_object == "CaseBatch"
+        ):
+            self._block_queue_batch(result.proposal, outcome=result.status.value)
             return
         transitioned = self._transition_proposal(
             result.proposal,
@@ -3311,8 +3608,46 @@ class InteractiveProfileUpdateProcessor:
             ActionStatus.STOPPED_EARLY,
             ActionStatus.FAILED,
             ActionStatus.INTERRUPTED,
+            ActionStatus.DEFERRED_MANUAL,
         }:
             self._transition_default(status, outcome=result.status.value)
+
+    def _block_queue_batch(
+        self,
+        proposal: ChangeProposal,
+        *,
+        outcome: str,
+    ) -> None:
+        """Map a manual-follow-up audit event to an explicit blocked batch."""
+        if self._queue_store is None:
+            return
+        source_ids = set(proposal.source_submission_ids)
+        batch = next(
+            (
+                queued
+                for queued in self._queue_store.manifest.batches
+                if queued.case.record_id == proposal.case_id
+                and {
+                    source_id
+                    for row in queued.rows
+                    for source_id in row.source_submission_ids
+                }
+                == source_ids
+            ),
+            None,
+        )
+        if batch is None:
+            return
+        self._queue_store.block_batch(
+            batch.id,
+            QueueBlocker(
+                "parent_account_manual_follow_up",
+                "Parent Account routing requires manual follow-up.",
+            ),
+            outcome=outcome,
+        )
+        self._active_change_id = None
+        self._display_event(ReviewQueueSnapshot(self._queue_store.manifest))
 
     def _transition_default(
         self, status: QueueStatus, *, outcome: str | None = None

--- a/src/aisc_salesforce/queried_fields.py
+++ b/src/aisc_salesforce/queried_fields.py
@@ -121,6 +121,7 @@ ACCOUNT_FIELDS = (
     "BillingPostalCode",
     "BillingCountry",
     "ParentId",
+    "Cert_Certification_Status__c",
     "Cert_Certification_Contact__c",
     "Cert_Principal_Contact__c",
     "Cert_Accounting_Contact__c",
@@ -151,6 +152,8 @@ STAGING_CASE_FIELDS = (
 ACCOUNT_REVIEW_FIELDS = (
     "Id",
     "Name",
+    "ParentId",
+    "Cert_Certification_Status__c",
     "Company_Owner__c",
     "BillingStreet",
     "BillingCity",

--- a/src/aisc_salesforce/review_queue.py
+++ b/src/aisc_salesforce/review_queue.py
@@ -480,6 +480,48 @@ class ReviewQueueStore:
         self.publish()
         return self.manifest
 
+    def block_batch(
+        self,
+        batch_id: str,
+        blocker: QueueBlocker,
+        *,
+        outcome: str,
+    ) -> ReviewQueueManifest:
+        """Block one Case batch while preserving already-completed setup work."""
+        self.publish()
+        batches: list[CaseBatch] = []
+        for batch in self.manifest.batches:
+            if batch.id != batch_id:
+                batches.append(batch)
+                continue
+            rows: list[StagedRow] = []
+            for row in batch.rows:
+                changes = tuple(
+                    replace(change, status=QueueStatus.BLOCKED, outcome=outcome)
+                    if change.status in {QueueStatus.PENDING, QueueStatus.IN_PROGRESS}
+                    else change
+                    for change in row.changes
+                )
+                rows.append(
+                    replace(
+                        row,
+                        blockers=_unique_blockers((*row.blockers, blocker)),
+                        changes=changes,
+                    )
+                )
+            batches.append(
+                replace(
+                    batch,
+                    blockers=_unique_blockers((*batch.blockers, blocker)),
+                    rows=tuple(rows),
+                )
+            )
+        self.manifest = recompute_manifest(
+            replace(self.manifest, batches=tuple(batches))
+        )
+        self.publish()
+        return self.manifest
+
 
 def iter_changes(manifest: ReviewQueueManifest):
     """Yield changes once in manifest order, despite cross-row references."""
@@ -543,6 +585,17 @@ def _build_row_shell(raw: dict[str, str]) -> StagedRow:
         references.append(
             SalesforceReference("Account", account_id, relationship="target_account")
         )
+    references.extend(
+        SalesforceReference(
+            "Account",
+            affected["id"],
+            relationship="affected_account",
+            label=affected["name"],
+            status=affected["certification_status"],
+        )
+        for affected in _affected_accounts(raw)
+        if affected["id"] != account_id or raw.get("is_parent_account") == "true"
+    )
     if case_id:
         references.append(
             SalesforceReference("Case", case_id, relationship="profile_update_case")
@@ -619,23 +672,37 @@ def _setup_changes(raw: dict[str, str], row: StagedRow) -> list[ProposedChange]:
 
 
 def _account_changes(raw: dict[str, str], row: StagedRow) -> list[ProposedChange]:
-    account_id = raw.get("account_id", "").strip()
+    submitted_parent_fields = _submitted_parent_account_fields(raw)
     return [
         _change(
             row,
             phase=QueuePhase.ACCOUNT,
             object_name="Account",
-            record_id=account_id,
-            target_context=account_id
+            record_id=affected["id"],
+            target_context=affected["id"]
             or f"sources:{','.join(row.source_submission_ids)}",
             field=field,
-            label=label,
+            label=(
+                f"{label} — {affected['name'] or affected['id']}"
+                if raw.get("is_parent_account") == "true"
+                else label
+            ),
             current_value=None,
             proposed_value=proposed,
         )
+        for affected in _affected_accounts(raw)
         for csv_name, field, label in ACCOUNT_PROPOSALS
         if (proposed := raw.get(csv_name, "").strip())
+        and (submitted_parent_fields is None or field in submitted_parent_fields)
     ]
+
+
+def _submitted_parent_account_fields(raw: dict[str, str]) -> set[str] | None:
+    """Return staged submitted fields, or None for ordinary/legacy rows."""
+    value = raw.get("submitted_account_fields", "").strip()
+    if raw.get("is_parent_account") != "true" or not value:
+        return None
+    return set(_json_list(value))
 
 
 def _build_contact_changes(
@@ -758,40 +825,80 @@ def _build_contact_changes(
 
 
 def _role_link_changes(raw: dict[str, str], row: StagedRow) -> list[ProposedChange]:
-    account_id = raw.get("account_id", "").strip()
     changes = []
-    for role in ROLE_DEFINITIONS:
-        if not any(
-            raw.get(f"{role.prefix}_{suffix}", "").strip()
-            for suffix, _ in role.submitted_fields
-        ):
-            continue
-        proposed = raw.get(f"{role.prefix}_salesforce_contact_id", "").strip()
-        action = raw.get(f"{role.prefix}_resolution_action", "").strip()
-        blockers: tuple[QueueBlocker, ...] = ()
-        if not proposed and action != "create_contact":
-            blockers = (
-                QueueBlocker(
-                    "unresolved_role_contact", f"{role.label} Contact is unresolved."
-                ),
+    for affected in _affected_accounts(raw):
+        for role in ROLE_DEFINITIONS:
+            if not any(
+                raw.get(f"{role.prefix}_{suffix}", "").strip()
+                for suffix, _ in role.submitted_fields
+            ):
+                continue
+            proposed = raw.get(f"{role.prefix}_salesforce_contact_id", "").strip()
+            action = raw.get(f"{role.prefix}_resolution_action", "").strip()
+            blockers: tuple[QueueBlocker, ...] = ()
+            if not proposed and action != "create_contact":
+                blockers = (
+                    QueueBlocker(
+                        "unresolved_role_contact",
+                        f"{role.label} Contact is unresolved.",
+                    ),
+                )
+            label = f"{role.label} Contact role"
+            if raw.get("is_parent_account") == "true":
+                label += f" — {affected['name'] or affected['id']}"
+            changes.append(
+                _change(
+                    row,
+                    phase=QueuePhase.ROLE_LINK,
+                    object_name="Account",
+                    record_id=affected["id"],
+                    target_context=affected["id"]
+                    or f"sources:{','.join(row.source_submission_ids)}",
+                    field=role.account_lookup,
+                    label=label,
+                    current_value=None,
+                    proposed_value=proposed
+                    or ("new Contact" if action == "create_contact" else None),
+                    extra_blockers=blockers,
+                )
             )
-        changes.append(
-            _change(
-                row,
-                phase=QueuePhase.ROLE_LINK,
-                object_name="Account",
-                record_id=account_id,
-                target_context=account_id
-                or f"sources:{','.join(row.source_submission_ids)}",
-                field=role.account_lookup,
-                label=f"{role.label} Contact role",
-                current_value=None,
-                proposed_value=proposed
-                or ("new Contact" if action == "create_contact" else None),
-                extra_blockers=blockers,
-            )
-        )
     return changes
+
+
+def _affected_accounts(raw: dict[str, str]) -> list[dict[str, str]]:
+    """Return deterministic Account targets, with legacy-row compatibility."""
+    try:
+        loaded = json.loads(raw.get("affected_accounts", "") or "[]")
+    except (TypeError, ValueError):
+        loaded = []
+    affected: list[dict[str, str]] = []
+    if isinstance(loaded, list):
+        for item in loaded:
+            if not isinstance(item, dict):
+                continue
+            account_id = str(item.get("id", "")).strip()
+            if not account_id:
+                continue
+            affected.append(
+                {
+                    "id": account_id,
+                    "name": str(item.get("name", "")).strip(),
+                    "certification_status": str(
+                        item.get("certification_status", "")
+                    ).strip(),
+                }
+            )
+    if not affected and raw.get("is_parent_account") != "true":
+        account_id = raw.get("account_id", "").strip()
+        if account_id:
+            affected.append(
+                {
+                    "id": account_id,
+                    "name": raw.get("account_name", "").strip(),
+                    "certification_status": "",
+                }
+            )
+    return sorted(affected, key=lambda item: item["id"])
 
 
 def _change(
@@ -845,14 +952,12 @@ def _parent_status(items, blockers: tuple[QueueBlocker, ...]) -> QueueStatus:
         return QueueStatus.FAILED
     if any(status is QueueStatus.STOPPED_EARLY for status in statuses):
         return QueueStatus.STOPPED_EARLY
+    if blockers:
+        return QueueStatus.BLOCKED
     if statuses and all(status is QueueStatus.COMPLETED for status in statuses):
         return QueueStatus.COMPLETED
-    if blockers or (
-        statuses
-        and all(
-            status in {QueueStatus.BLOCKED, QueueStatus.COMPLETED}
-            for status in statuses
-        )
+    if statuses and all(
+        status in {QueueStatus.BLOCKED, QueueStatus.COMPLETED} for status in statuses
     ):
         return QueueStatus.BLOCKED
     if not statuses:

--- a/src/aisc_salesforce/review_ui.py
+++ b/src/aisc_salesforce/review_ui.py
@@ -144,6 +144,40 @@ class ContactFieldConflict:
 
 
 @dataclass(frozen=True)
+class ParentAccountChildValue:
+    """One direct child Account and the value relevant to a blocked review."""
+
+    account_id: ValueFragment
+    account_name: ValueFragment
+    current: ValueFragment
+
+
+@dataclass(frozen=True)
+class ParentAccountFieldConflict:
+    """A requested Account value that differs across active direct children."""
+
+    label: str
+    requested: ValueFragment
+    children: tuple[ParentAccountChildValue, ...]
+
+
+@dataclass(frozen=True)
+class ParentAccountConflict:
+    """All child-value conflicts that block one Parent Account Case batch."""
+
+    parent: ValueFragment
+    fields: tuple[ParentAccountFieldConflict, ...]
+
+
+@dataclass(frozen=True)
+class ParentAccountNoActiveChildren:
+    """A Parent Account whose direct children are all inactive."""
+
+    parent: ValueFragment
+    children: tuple[ParentAccountChildValue, ...]
+
+
+@dataclass(frozen=True)
 class StagedRowSummary:
     """The safe-stop checkpoint shown before Salesforce writes."""
 
@@ -190,6 +224,8 @@ type ReviewEvent = (
     | ContactCard
     | ContactComparison
     | ContactFieldConflict
+    | ParentAccountConflict
+    | ParentAccountNoActiveChildren
     | StagedRowSummary
     | AccountHistory
     | ResponseEmail

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -66,6 +66,8 @@ KEY_UPDATE_FIELDS = [
     *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
 ]
 
+ACTIVE_CERTIFICATION_STATUSES = frozenset({"Certified", "Initials"})
+
 
 @dataclass(frozen=True)
 class RoleDefinition:
@@ -158,6 +160,9 @@ SHARED_COLUMNS = [
     "latest_submission_date",
     "account_id",
     "account_name",
+    "is_parent_account",
+    "affected_accounts",
+    "submitted_account_fields",
     "case_id",
     "case_number",
     "case_status",
@@ -256,13 +261,20 @@ class ProfileUpdateStagingService:
             if (account_id := _clean_text(record.get("Id")))
         }
 
+        direct_children = self._query_accounts("ParentId", requested_account_ids)
+        direct_children_by_parent: dict[str, list[dict[str, Any]]] = {}
+        for child in direct_children:
+            parent_id = _clean_text(child.get("ParentId"))
+            if parent_id in requested_account_ids:
+                direct_children_by_parent.setdefault(parent_id, []).append(child)
+
         parent_ids = _unique_text_values(
             account.get("ParentId") for account in accounts
         )
         parents = self._query_accounts("Id", parent_ids)
         siblings = self._query_accounts("ParentId", parent_ids)
         all_accounts_by_id = dict(accounts_by_id)
-        for family_account in [*parents, *siblings]:
+        for family_account in [*parents, *siblings, *direct_children]:
             family_account_id = _clean_text(family_account.get("Id"))
             if family_account_id:
                 all_accounts_by_id.setdefault(family_account_id, family_account)
@@ -275,6 +287,7 @@ class ProfileUpdateStagingService:
                 records,
                 accounts_by_id,
                 all_accounts_by_id,
+                direct_children_by_parent,
                 contacts,
                 cases,
             )
@@ -344,6 +357,7 @@ class ProfileUpdateStagingService:
         records: list[dict[str, Any]],
         accounts_by_id: dict[str, dict[str, Any]],
         all_accounts_by_id: dict[str, dict[str, Any]],
+        direct_children_by_parent: dict[str, list[dict[str, Any]]],
         contacts: list[dict[str, Any]],
         cases: list[dict[str, Any]],
     ) -> dict[str, str]:
@@ -353,6 +367,20 @@ class ProfileUpdateStagingService:
 
         account_id = _clean_text(merged.get("Account__c"))
         account = accounts_by_id.get(account_id)
+        direct_children = sorted(
+            direct_children_by_parent.get(account_id, []),
+            key=lambda child: _clean_text(child.get("Id")),
+        )
+        affected_accounts = (
+            [
+                child
+                for child in direct_children
+                if _clean_text(child.get("Cert_Certification_Status__c"))
+                in ACTIVE_CERTIFICATION_STATUSES
+            ]
+            if direct_children
+            else ([account] if account is not None else [])
+        )
         key_records = [record for record in records if _is_key_update(record)]
         row.update(
             {
@@ -368,6 +396,37 @@ class ProfileUpdateStagingService:
                 "latest_submission_date": _clean_text(records[-1].get("CreatedDate")),
                 "account_id": account_id,
                 "account_name": _account_name(account, merged),
+                "is_parent_account": "true" if direct_children else "false",
+                "affected_accounts": json.dumps(
+                    [
+                        {
+                            "id": _clean_text(affected.get("Id")),
+                            "name": _clean_text(affected.get("Name")),
+                            "certification_status": _clean_text(
+                                affected.get("Cert_Certification_Status__c")
+                            ),
+                        }
+                        for affected in affected_accounts
+                        if _clean_text(affected.get("Id"))
+                    ],
+                    ensure_ascii=False,
+                    sort_keys=True,
+                ),
+                "submitted_account_fields": json.dumps(
+                    [
+                        account_field
+                        for source_field, account_field in (
+                            ("Revised_Company_Name__c", "Name"),
+                            ("Revised_Company_Owner__c", "Company_Owner__c"),
+                            *(
+                                (source_field, account_field)
+                                for _, source_field, account_field in ADDRESS_FIELDS
+                            ),
+                        )
+                        if _has_value(merged.get(source_field))
+                    ],
+                    ensure_ascii=False,
+                ),
                 "has_key_updates": "true" if key_records else "false",
                 "earliest_key_update_date": (
                     _clean_text(key_records[0].get("CreatedDate"))

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -141,7 +141,15 @@ class Feeder:
 
 
 class FakeClient:
-    def __init__(self, *, source=None, account=None, contacts=None, history=None):
+    def __init__(
+        self,
+        *,
+        source=None,
+        account=None,
+        children=None,
+        contacts=None,
+        history=None,
+    ):
         self.records = {
             ("Company_Profile_Change__c", "submission-1"): source or source_record(),
             ("Account", "account-1"): account or account_record(),
@@ -161,6 +169,9 @@ class FakeClient:
             },
         }
         self.contacts = contacts or []
+        self.children = children or []
+        for child in self.children:
+            self.records[("Account", child["Id"])] = child
         for contact in self.contacts:
             self.records[("Contact", contact["Id"])] = contact
         self.history = history or []
@@ -185,6 +196,12 @@ class FakeClient:
             return [dict(contact) for contact in self.contacts]
         if object_name == "AccountHistory":
             return [dict(item) for item in self.history]
+        if object_name == "Account":
+            return [
+                dict(item)
+                for item in self.children
+                if item.get("ParentId") == "account-1"
+            ]
         raise AssertionError(object_name)
 
     def get_record(self, object_name, record_id, fields):
@@ -814,6 +831,7 @@ def test_decision_shortcuts_are_case_insensitive_but_audit_full_phrases(
             account_record(),
             account_record(),
             account_record(),
+            account_record(),
             account_record(Name="Acme Steel LLC"),
         ]
         answers.extend(["", "yes"])
@@ -916,6 +934,484 @@ def test_account_change_uses_fresh_context_audits_and_closes_completed_batch(tmp
     assert "CreatedDate <" in history_query[2]
 
 
+def test_parent_routes_account_updates_to_active_direct_children_only(tmp_path):
+    children = [
+        account_record(
+            Id="child-1",
+            Name="Shared Old Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+        account_record(
+            Id="child-2",
+            Name=" Shared Old Name ",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+        ),
+        account_record(
+            Id="child-dropped",
+            Name="Different Dropped Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Dropped",
+        ),
+        account_record(
+            Id="grandchild",
+            Name="Different Grandchild Name",
+            ParentId="child-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+    ]
+    client = FakeClient(
+        source=source_record(Revised_Company_Name__c="New Shared Name"),
+        children=children,
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["a", "a", "yes"], row_answers=[""]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    affected = json.dumps(
+        [
+            {
+                "id": "child-1",
+                "name": "Shared Old Name",
+                "certification_status": "Certified",
+            },
+            {
+                "id": "child-2",
+                "name": "Shared Old Name",
+                "certification_status": "Initials",
+            },
+        ]
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                is_parent_account="true",
+                affected_accounts=affected,
+                revised_company_name="New Shared Name",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert ("Account", "child-1", {"Name": "New Shared Name"}) in client.updated
+    assert ("Account", "child-2", {"Name": "New Shared Name"}) in client.updated
+    assert not any(
+        object_name == "Account"
+        and record_id in {"account-1", "child-dropped", "grandchild"}
+        and "Name" in values
+        for object_name, record_id, values in client.updated
+    )
+    queue = json.loads(result.queue_path.read_text(encoding="utf-8"))
+    name_changes = [
+        change
+        for batch in queue["batches"]
+        for queued_row in batch["rows"]
+        for change in queued_row["changes"]
+        if change["field"] == "Name"
+    ]
+    assert {change["salesforce"]["record_id"] for change in name_changes} == {
+        "child-1",
+        "child-2",
+    }
+    assert {change["outcome"] for change in name_changes} == {"applied"}
+
+
+def test_parent_conflict_is_acknowledged_and_blocks_whole_case_without_writes(
+    tmp_path,
+):
+    children = [
+        account_record(
+            Id="child-1",
+            Name="First Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+        account_record(
+            Id="child-2",
+            Name="Second Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+        ),
+        account_record(
+            Id="child-dropped",
+            Name="Dropped Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Dropped",
+        ),
+    ]
+    client = FakeClient(
+        source=source_record(Revised_Company_Name__c="Requested Name"),
+        children=children,
+    )
+    output = []
+    feeder = Feeder([""])
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=feeder,
+        output_fn=output.append,
+        now=NOW,
+    )
+    affected = json.dumps(
+        [
+            {
+                "id": child["Id"],
+                "name": child["Name"],
+                "certification_status": child["Cert_Certification_Status__c"],
+            }
+            for child in children[:2]
+        ]
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                is_parent_account="true",
+                affected_accounts=affected,
+                revised_company_name="Requested Name",
+            )
+        ],
+        tmp_path,
+    )
+
+    rendered = "\n".join(output)
+    assert "Requested value: Requested Name" in rendered
+    assert "First Child" not in rendered
+    assert "First Current Name" in rendered
+    assert "Second Current Name" in rendered
+    assert "Dropped Current Name" not in rendered
+    assert any("manual follow-up" in prompt.casefold() for prompt in feeder.prompts)
+    assert client.updated == []
+    assert client.created == []
+    assert (
+        client.records[("Company_Profile_Change__c", "submission-1")]["Status__c"]
+        == "New"
+    )
+    assert client.records[("Case", "case-1")]["Status"] == "Pending"
+    audit = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(entry["result"] == "deferred manual follow-up" for entry in audit)
+    queue = json.loads(result.queue_path.read_text(encoding="utf-8"))
+    assert queue["batches"][0]["status"] == "blocked"
+    assert all(
+        change["status"] in {"blocked", "completed"}
+        for row in queue["batches"][0]["rows"]
+        for change in row["changes"]
+    )
+
+
+def test_parent_with_no_active_children_is_acknowledged_without_salesforce_writes(
+    tmp_path,
+):
+    client = FakeClient(
+        source=source_record(Revised_Company_Name__c="Requested Name"),
+        children=[
+            account_record(
+                Id="child-dropped",
+                Name="Dropped Child",
+                ParentId="account-1",
+                Cert_Certification_Status__c="Dropped",
+            ),
+            account_record(
+                Id="child-suspended",
+                Name="Suspended Child",
+                ParentId="account-1",
+                Cert_Certification_Status__c="Suspended",
+            ),
+        ],
+    )
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder([""]),
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                is_parent_account="true",
+                affected_accounts="[]",
+                revised_company_name="Requested Name",
+            )
+        ],
+        tmp_path,
+    )
+
+    rendered = "\n".join(output)
+    assert "no direct child with status Certified or Initials" in rendered
+    assert "Dropped Child" in rendered
+    assert "Suspended Child" in rendered
+    assert client.updated == []
+    assert client.created == []
+    assert result.pending_batches == 1
+
+
+def test_parent_preflight_compares_only_submitted_fields_and_normalizes_display_values():
+    children = [
+        account_record(
+            Id="child-1",
+            Name="Different One",
+            Company_Owner__c=" Shared Owner ",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+            Cert_Certification_Contact__c=None,
+        ),
+        account_record(
+            Id="child-2",
+            Name="Different Two",
+            Company_Owner__c="Shared Owner",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+            Cert_Certification_Contact__c=" ",
+        ),
+        account_record(
+            Id="child-dropped",
+            Name="Different Dropped",
+            Company_Owner__c="Other Owner",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Dropped",
+            Cert_Certification_Contact__c="other-contact",
+        ),
+    ]
+    source = source_record(
+        Revised_Company_Owner__c="Requested Owner",
+        Cert_Email__c="cert@example.com",
+    )
+    row = staged_row(
+        is_parent_account="true",
+        affected_accounts="[]",
+        revised_company_owner="Requested Owner",
+        certification_email="cert@example.com",
+        certification_resolution_action="create_contact",
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        FakeClient(source=source, children=children),
+        input_fn=Feeder([]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    batch = build_case_batches([row], now=NOW)[0]
+
+    routing = processor._preflight_parent_routing(batch, {"submission-1": source})
+
+    assert routing.is_parent is True
+    assert routing.blocked is False
+    assert routing.conflicts == ()
+    assert {child["Id"] for child in routing.target_accounts} == {
+        "child-1",
+        "child-2",
+    }
+
+
+def test_parent_role_lookup_conflict_blocks_before_contact_or_case_writes(tmp_path):
+    children = [
+        account_record(
+            Id="child-1",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+            Cert_Certification_Contact__c="contact-1",
+        ),
+        account_record(
+            Id="child-2",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+            Cert_Certification_Contact__c="contact-2",
+        ),
+    ]
+    client = FakeClient(
+        source=source_record(Cert_Email__c="cert@example.com"),
+        children=children,
+    )
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder([""]),
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    processor.review(
+        [
+            staged_row(
+                is_parent_account="true",
+                affected_accounts=json.dumps(
+                    [
+                        {
+                            "id": child["Id"],
+                            "name": child["Name"],
+                            "certification_status": child[
+                                "Cert_Certification_Status__c"
+                            ],
+                        }
+                        for child in children
+                    ]
+                ),
+                certification_email="cert@example.com",
+                certification_salesforce_contact_id="requested-contact",
+                certification_resolution_action="use_existing",
+            )
+        ],
+        tmp_path,
+    )
+
+    rendered = "\n".join(output)
+    assert "Certification Account Role" in rendered
+    assert "Requested value: requested-contact" in rendered
+    assert "contact-1" in rendered
+    assert "contact-2" in rendered
+    assert client.updated == []
+    assert client.created == []
+
+
+def test_blocked_parent_batch_advances_to_the_next_case(tmp_path):
+    children = [
+        account_record(
+            Id="child-1",
+            Name="First Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+        account_record(
+            Id="child-2",
+            Name="Second Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+        ),
+    ]
+    client = FakeClient(
+        source=source_record(Revised_Company_Name__c="Parent Requested Name"),
+        children=children,
+    )
+    client.records.update(
+        {
+            ("Company_Profile_Change__c", "submission-2"): source_record(
+                Id="submission-2",
+                Name="PU-200",
+                Account__c="account-2",
+                CreatedDate="2026-07-16T14:30:00.000+0000",
+                Revised_Company_Name__c="Ordinary New Name",
+            ),
+            ("Account", "account-2"): account_record(
+                Id="account-2", Name="Ordinary Old Name"
+            ),
+            ("Case", "case-2"): {
+                "Id": "case-2",
+                "CaseNumber": "00010002",
+                "Status": "Pending",
+            },
+        }
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["", "a", "yes"], row_answers=[""]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    rows = [
+        staged_row(
+            is_parent_account="true",
+            affected_accounts=json.dumps(
+                [
+                    {
+                        "id": child["Id"],
+                        "name": child["Name"],
+                        "certification_status": child["Cert_Certification_Status__c"],
+                    }
+                    for child in children
+                ]
+            ),
+            revised_company_name="Parent Requested Name",
+        ),
+        staged_row(
+            source_submission_ids='["submission-2"]',
+            source_submission_names='["PU-200"]',
+            earliest_submission_date="2026-07-16T14:30:00.000+0000",
+            latest_submission_date="2026-07-16T14:30:00.000+0000",
+            account_id="account-2",
+            account_name="Ordinary Old Name",
+            case_id="case-2",
+            case_number="00010002",
+            revised_company_name="Ordinary New Name",
+        ),
+    ]
+
+    result = processor.review(rows, tmp_path)
+
+    assert ("Account", "account-2", {"Name": "Ordinary New Name"}) in client.updated
+    assert not any(
+        object_name == "Account"
+        and record_id in {"account-1", "child-1", "child-2"}
+        and "Name" in values
+        for object_name, record_id, values in client.updated
+    )
+    assert result.completed_batches == 2
+    assert result.pending_batches == 1
+
+
+def test_parent_acknowledgement_interruption_writes_nothing_and_retry_refetches(
+    tmp_path,
+):
+    children = [
+        account_record(
+            Id="child-1",
+            Name="First Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+        account_record(
+            Id="child-2",
+            Name="Second Current Name",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+        ),
+    ]
+    client = FakeClient(
+        source=source_record(Revised_Company_Name__c="Requested Name"),
+        children=children,
+    )
+    row = staged_row(
+        is_parent_account="true",
+        affected_accounts="[]",
+        revised_company_name="Requested Name",
+    )
+    interrupted = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder([KeyboardInterrupt()]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    with pytest.raises(ProcessingInterrupted, match="parent preflight"):
+        interrupted.review([dict(row)], tmp_path / "interrupted")
+
+    assert client.updated == []
+    assert client.created == []
+    interrupted_audit = (tmp_path / "interrupted" / "review_audit.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert '"result": "interrupted"' in interrupted_audit
+
+    client.children[1]["Name"] = "First Current Name"
+    retry = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["a", "a", "yes"], row_answers=[""]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+    result = retry.review([dict(row)], tmp_path / "retry")
+
+    assert ("Account", "child-1", {"Name": "Requested Name"}) in client.updated
+    assert ("Account", "child-2", {"Name": "Requested Name"}) in client.updated
+    assert result.pending_batches == 0
+
+
 def test_current_value_is_an_audited_noop_without_prompt_or_email_item(tmp_path):
     client = FakeClient(account=account_record(Name="Acme Steel LLC"))
     feeder = Feeder([])
@@ -955,6 +1451,7 @@ def test_current_value_is_an_audited_noop_without_prompt_or_email_item(tmp_path)
 def test_manual_change_is_refetched_and_must_match(tmp_path):
     client = FakeClient()
     client.get_sequences[("Account", "account-1")] = [
+        account_record(),
         account_record(),
         account_record(),
         account_record(),
@@ -1190,9 +1687,7 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
         {"Cert_Certification_Contact__c": "created-1"},
     ) in client.updated
     displayed = "\n".join(output)
-    assert (
-        "Reconciled Contact: New Person <new.person@example.com>" in displayed
-    )
+    assert "Reconciled Contact: New Person <new.person@example.com>" in displayed
     assert "First Name | (blank) | New | submission-1 / Certification" in displayed
     assert (
         "Email | (blank) | new.person@example.com | submission-1 / Certification"
@@ -1810,9 +2305,7 @@ def test_contact_updates_use_tim_and_stacy_emails_before_assigning_roles(tmp_pat
         {"Cert_Principal_Contact__c": "contact-tim"},
     ) in client.updated
     displayed = "\n".join(output)
-    assert (
-        "Reconciled Contact: Stacy Morgan <stacy@wsfabrication.com>" in displayed
-    )
+    assert "Reconciled Contact: Stacy Morgan <stacy@wsfabrication.com>" in displayed
     assert "Reconciled Contact: Tim Ryan <tim@wsfabrication.com>" in displayed
     assert "Current Salesforce value: {" not in displayed
     assert "Proposed value: {" not in displayed

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -199,6 +199,50 @@ def test_contact_change_is_shared_across_source_rows():
     assert len(set(contact_ids)) == 1
 
 
+def test_parent_account_and_role_changes_expand_to_active_children_only():
+    affected = json.dumps(
+        [
+            {
+                "id": "child-2",
+                "name": "Second Child",
+                "certification_status": "Initials",
+            },
+            {
+                "id": "child-1",
+                "name": "First Child",
+                "certification_status": "Certified",
+            },
+        ]
+    )
+    row = queue_row(
+        is_parent_account="true",
+        affected_accounts=affected,
+        revised_company_name="New Name",
+        certification_email="cert@example.com",
+        certification_salesforce_contact_id="contact-1",
+        certification_resolution_action="use_existing",
+    )
+
+    manifest = build_review_queue([row], now=NOW)
+    routed = [
+        change
+        for change in iter_changes(manifest)
+        if change.phase in {"account", "role_link"}
+    ]
+
+    assert [change.salesforce.record_id for change in routed] == [
+        "child-1",
+        "child-2",
+        "child-1",
+        "child-2",
+    ]
+    assert {
+        reference.record_id
+        for reference in manifest.batches[0].references
+        if reference.relationship == "affected_account"
+    } == {"child-1", "child-2"}
+
+
 def test_contact_json_is_deterministic_and_prior_cases_remain_references():
     first_resolution = {
         "classification": "ambiguous",

--- a/tests/test_review_ui.py
+++ b/tests/test_review_ui.py
@@ -15,6 +15,10 @@ from aisc_salesforce.review_ui import (
     ChoiceQuestion,
     MappingComparison,
     MappingComparisonRow,
+    ParentAccountChildValue,
+    ParentAccountConflict,
+    ParentAccountFieldConflict,
+    ParentAccountNoActiveChildren,
     ReviewChoice,
     ReviewQueueSnapshot,
     ScalarComparison,
@@ -75,8 +79,7 @@ def test_cli_renders_scalar_and_mapping_comparisons_compatibly():
     )
 
     assert output == [
-        "\nCompany Name\nCurrent Salesforce value: Acme\n"
-        "Proposed value: Acme Steel",
+        "\nCompany Name\nCurrent Salesforce value: Acme\nProposed value: Acme Steel",
         "\nContact: Alex Smith\nSalesforce changes:\n"
         "Email: old@example.com -> new@example.com",
     ]
@@ -89,6 +92,54 @@ def test_cli_renders_a_concise_summary_from_the_complete_queue_event():
     ui.display(ReviewQueueSnapshot(build_review_queue([])))
 
     assert output == ["Review queue: 0 batch(es), 0 pending change(s); next: none"]
+
+
+def test_cli_renders_parent_conflict_and_no_active_child_events():
+    output = []
+    ui = CLIReviewUI(output_fn=output.append)
+    children = (
+        ParentAccountChildValue(
+            ValueFragment("child-1"),
+            ValueFragment("First Child"),
+            ValueFragment("Old Name"),
+        ),
+        ParentAccountChildValue(
+            ValueFragment("child-2"),
+            ValueFragment("Second Child"),
+            ValueFragment("Other Name"),
+        ),
+    )
+
+    ui.display(
+        ParentAccountConflict(
+            ValueFragment("Parent Account (parent-1)"),
+            (
+                ParentAccountFieldConflict(
+                    "Company Name", ValueFragment("Requested Name"), children
+                ),
+            ),
+        )
+    )
+    ui.display(
+        ParentAccountNoActiveChildren(
+            ValueFragment("Parent Account (parent-1)"),
+            (
+                ParentAccountChildValue(
+                    ValueFragment("child-dropped"),
+                    ValueFragment("Dropped Child"),
+                    ValueFragment("Dropped"),
+                ),
+            ),
+        )
+    )
+
+    rendered = "\n".join(output)
+    assert "Company Name" in rendered
+    assert "Requested value: Requested Name" in rendered
+    assert "First Child (child-1): Old Name" in rendered
+    assert "Second Child (child-2): Other Name" in rendered
+    assert "no direct child with status Certified or Initials" in rendered
+    assert "Dropped Child (child-dropped): Dropped" in rendered
 
 
 def test_cli_retries_invalid_choice_with_question_feedback():
@@ -153,7 +204,9 @@ def test_processor_rejects_mismatched_answer_type():
     ui = RecordingUI(AcknowledgementAnswer())
     processor = InteractiveProfileUpdateProcessor(object(), ui)
 
-    with pytest.raises(UnsupportedReviewInteractionError, match="requires ChoiceAnswer"):
+    with pytest.raises(
+        UnsupportedReviewInteractionError, match="requires ChoiceAnswer"
+    ):
         processor._prompt_yes_no(styled("Continue? "))
 
 

--- a/tests/test_stage_profile_updates.py
+++ b/tests/test_stage_profile_updates.py
@@ -56,12 +56,14 @@ class FakeClient:
         submissions,
         accounts=None,
         siblings=None,
+        direct_children=None,
         contacts=None,
         cases=None,
     ):
         self.submissions = submissions
         self.accounts = accounts or []
         self.siblings = siblings or []
+        self.direct_children = direct_children or []
         self.contacts = contacts or []
         self.cases = (
             cases
@@ -93,6 +95,8 @@ class FakeClient:
         if object_name == "Company_Profile_Change__c":
             return list(self.submissions)
         if object_name == "Account":
+            if where == "ParentId IN ('account-1')":
+                return list(self.direct_children)
             if where and where.startswith("Id IN"):
                 return list(self.accounts)
             return list(self.siblings)
@@ -103,8 +107,18 @@ class FakeClient:
         raise AssertionError(object_name)
 
 
-def stage(submissions, *, accounts=None, siblings=None, contacts=None, cases=None):
-    client = FakeClient(submissions, accounts, siblings, contacts, cases)
+def stage(
+    submissions,
+    *,
+    accounts=None,
+    siblings=None,
+    direct_children=None,
+    contacts=None,
+    cases=None,
+):
+    client = FakeClient(
+        submissions, accounts, siblings, direct_children, contacts, cases
+    )
     result = ProfileUpdateStagingService(client).stage()
     return result, client
 
@@ -275,6 +289,61 @@ def test_staging_queries_the_parent_account_as_part_of_the_family():
     account_queries = [query for query in client.queries if query[0] == "Account"]
     assert any(query[2] == "Id IN ('parent-1')" for query in account_queries)
     assert any(query[2] == "ParentId IN ('parent-1')" for query in account_queries)
+
+
+def test_staging_records_only_direct_active_children_as_affected_accounts():
+    children = [
+        account(
+            Id="child-certified",
+            Name="Certified Child",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Certified",
+        ),
+        account(
+            Id="child-initials",
+            Name="Initials Child",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Initials",
+        ),
+        account(
+            Id="child-dropped",
+            Name="Dropped Child",
+            ParentId="account-1",
+            Cert_Certification_Status__c="Dropped",
+        ),
+        account(
+            Id="grandchild",
+            Name="Grandchild",
+            ParentId="child-certified",
+            Cert_Certification_Status__c="Certified",
+        ),
+    ]
+
+    result, client = stage(
+        [submission()],
+        accounts=[account(ParentId="")],
+        direct_children=children,
+    )
+
+    row = result.rows[0]
+    assert row["is_parent_account"] == "true"
+    assert json.loads(row["affected_accounts"]) == [
+        {
+            "id": "child-certified",
+            "name": "Certified Child",
+            "certification_status": "Certified",
+        },
+        {
+            "id": "child-initials",
+            "name": "Initials Child",
+            "certification_status": "Initials",
+        },
+    ]
+    assert any(
+        query[2] == "ParentId IN ('account-1')"
+        for query in client.queries
+        if query[0] == "Account"
+    )
 
 
 def test_merges_all_nonblank_notes_in_submission_order():


### PR DESCRIPTION
## Summary
- Add one-level parent Account child detection and active-child routing for Account and role updates.
- Preflight child values and defer conflicting or no-active-child batches for manual follow-up without Salesforce writes.
- Preserve shared Contact reconciliation, expand queue/audit behavior, and document the workflow with comprehensive tests.

Closes #29