### PR TITLE
Fix concurrent staging session ID collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,9 @@ uv run aisc_salesforce process-profile-updates \
 ```
 
 `stage` prints the generated session ID and both artifact paths. If two stages
-start in the same UTC second, later IDs use `-01`, `-02`, and so on. `prepare`
+start in the same UTC second, the final atomic rename claims each ID; a
+collision retries with `-01`, `-02`, and so on without replacing an existing
+published session. `prepare`
 and `review` accept only that exact folder name as a direct child of
 `--output-dir`; absolute paths, separators, `..`, symlinks, missing files,
 unsupported queue schemas, malformed CSV data, and CSV/queue submission-ID
@@ -422,7 +424,9 @@ Every platform flushes staged CSV and review-queue file data with `flush()` and
 `os.fsync()` before publication. POSIX systems also sync the containing
 directories so rename metadata is durable. Windows safely skips directory
 syncing because it does not support opening directories this way; file flushing
-and atomic replacement still occur.
+and atomic publication still occur. This relies on the temporary and output
+directories being on the same filesystem; POSIX refuses a non-empty destination
+directory and Windows refuses any existing destination.
 
 For a New Profile Update with a blank Account, the command looks up Accounts
 using the submitted Profile ID. It presents every match as a structured choice;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -669,15 +669,18 @@ uv run aisc_salesforce process-profile-updates review \
 
 `stage` reads New submissions and publishes both `profile_updates.csv` and
 `review_queue.json` through one temporary directory and one final rename. The
-printed UTC timestamp folder name is the session ID. Same-second collisions use
-the existing `-01`, `-02`, and later suffixes. Publication finishes before any
-Salesforce write, allowing a reviewer or TUI to inspect a stable queue.
+printed UTC timestamp folder name is the session ID. The final rename claims an
+ID, so same-second collisions retry with `-01`, `-02`, and later suffixes
+without replacing an existing published session. Publication finishes before
+any Salesforce write, allowing a reviewer or TUI to inspect a stable queue.
 
 File contents are flushed with `flush()` and `os.fsync()` on every supported
 platform before they are published. On POSIX, the temporary and output
 directories are also synced to make the rename metadata durable. Windows skips
 that unsupported directory-handle operation while keeping the file flushes and
-atomic rename.
+atomic rename. This assumes the temporary and output directories share a
+filesystem: POSIX refuses to replace a non-empty destination directory, and
+Windows refuses an existing destination.
 
 `prepare SESSION_ID` loads and validates that saved session, then creates or
 reuses Cases only for captured submissions that already have Accounts. It does

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import errno
 import json
 import os
 import re
@@ -800,44 +801,60 @@ def publish_staging_session(
     warning_count: int = 0,
     now: datetime | None = None,
 ) -> StagingSession:
-    """Publish the CSV and queue together using one final directory rename."""
+    """Publish a complete session with an atomically claimed ID.
+
+    On POSIX, ``os.rename`` atomically publishes a directory and refuses to
+    replace a non-empty destination. On Windows, it refuses every existing
+    destination. Published sessions are non-empty, so a collision can safely
+    retry the next suffix. The temporary and output directories must share a
+    filesystem.
+    """
     timestamp = _aware_datetime(now or datetime.now(UTC)).astimezone(UTC)
     base_session_id = timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
     output_dir.mkdir(parents=True, exist_ok=True)
-    final_path = output_dir / base_session_id
-    suffix = 1
-    while final_path.exists():
-        final_path = output_dir / f"{base_session_id}-{suffix:02d}"
-        suffix += 1
-    session_id = final_path.name
-    temporary_path = output_dir / f".{session_id}-{uuid4().hex}.tmp"
-    try:
-        temporary_path.mkdir()
-        csv_path = temporary_path / "profile_updates.csv"
-        with csv_path.open("w", newline="", encoding="utf-8") as output:
-            writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
-            writer.writeheader()
-            writer.writerows(rows)
-            output.flush()
-            os.fsync(output.fileno())
-        write_review_queue(
-            build_review_queue(rows, now=timestamp),
-            temporary_path / "review_queue.json",
+    suffix = 0
+    while True:
+        session_id = (
+            base_session_id if suffix == 0 else f"{base_session_id}-{suffix:02d}"
         )
-        sync_directory(temporary_path)
-        os.replace(temporary_path, final_path)
+        final_path = output_dir / session_id
+        temporary_path = output_dir / f".{session_id}-{uuid4().hex}.tmp"
+        try:
+            temporary_path.mkdir()
+            csv_path = temporary_path / "profile_updates.csv"
+            with csv_path.open("w", newline="", encoding="utf-8") as output:
+                writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS)
+                writer.writeheader()
+                writer.writerows(rows)
+                output.flush()
+                os.fsync(output.fileno())
+            write_review_queue(
+                build_review_queue(rows, now=timestamp),
+                temporary_path / "review_queue.json",
+            )
+            sync_directory(temporary_path)
+        except Exception:
+            shutil.rmtree(temporary_path, ignore_errors=True)
+            raise
+
+        try:
+            os.rename(temporary_path, final_path)
+        except OSError as error:
+            shutil.rmtree(temporary_path, ignore_errors=True)
+            if error.errno in {errno.EEXIST, errno.ENOTEMPTY}:
+                suffix += 1
+                continue
+            raise
+
         sync_directory(output_dir)
-    except Exception:
-        shutil.rmtree(temporary_path, ignore_errors=True)
-        raise
-    return StagingSession(
-        session_id=session_id,
-        path=final_path,
-        csv_path=final_path / "profile_updates.csv",
-        queue_path=final_path / "review_queue.json",
-        row_count=len(rows),
-        warning_count=warning_count,
-    )
+        return StagingSession(
+            session_id=session_id,
+            path=final_path,
+            csv_path=final_path / "profile_updates.csv",
+            queue_path=final_path / "review_queue.json",
+            row_count=len(rows),
+            warning_count=warning_count,
+        )
 
 
 def load_staging_session(

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -379,22 +379,45 @@ def test_session_publication_writes_csv_and_queue_under_one_generated_id(tmp_pat
     assert manifest.batches
 
 
+def test_session_publication_retries_when_publication_collides(tmp_path, monkeypatch):
+    real_rename = profile_update_processing.os.rename
+    base_path = tmp_path / "2026-07-17T18-00-00Z"
+
+    def collide_before_first_publication(source, target):
+        if target == base_path and not target.exists():
+            base_path.mkdir()
+            (base_path / "published-by-other-process").write_text("claimed")
+        real_rename(source, target)
+
+    monkeypatch.setattr(
+        profile_update_processing.os, "rename", collide_before_first_publication
+    )
+
+    result = publish_staging_session([staged_row()], tmp_path, now=NOW)
+
+    assert result.session_id == "2026-07-17T18-00-00Z-01"
+    assert (base_path / "published-by-other-process").read_text() == "claimed"
+    assert result.csv_path.is_file()
+    assert result.queue_path.is_file()
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
 def test_session_publication_syncs_before_and_after_directory_rename(
     tmp_path, monkeypatch
 ):
     events = []
-    real_replace = profile_update_processing.os.replace
+    real_rename = profile_update_processing.os.rename
 
     def recording_sync(path):
         events.append(("sync", path, path.exists()))
 
-    def recording_replace(source, target):
+    def recording_rename(source, target):
         if source.is_dir():
             events.append(("rename", source, target))
-        real_replace(source, target)
+        real_rename(source, target)
 
     monkeypatch.setattr(profile_update_processing, "sync_directory", recording_sync)
-    monkeypatch.setattr(profile_update_processing.os, "replace", recording_replace)
+    monkeypatch.setattr(profile_update_processing.os, "rename", recording_rename)
 
     result = publish_staging_session([staged_row()], tmp_path, now=NOW)
 


### PR DESCRIPTION
## Summary
- claim staging session IDs atomically during directory publication
- retry same-second collisions with incrementing suffixes without replacing published sessions
- document filesystem requirements and cover the race with a regression test

## Testing
- uv run pytest

Closes #35