### PR TITLE
Clarify and strengthen Certification ID account lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,11 @@ directories being on the same filesystem; POSIX refuses a non-empty destination
 directory and Windows refuses any existing destination.
 
 For a New Profile Update with a blank Account, the command looks up Accounts
-using the submitted Profile ID. It presents every match as a structured choice;
-press Enter to use the first Account, enter its displayed number to choose a
-different match, or enter `P` to look up a different Profile ID. The Account is
+using the submitted Certification ID. If exactly one Account matches, it is
+linked automatically. Ambiguous matches are presented as a structured choice;
+enter the displayed number, or enter `P` to look up a different Certification
+ID. If the submitted ID is missing or has no match, review requests a
+Certification ID specifically to find the Salesforce Account. The Account is
 saved on the Profile Update before Case preparation begins.
 After a scoped Salesforce refresh verifies the repaired submission now has an
 Account, `review` includes that submission in Case preparation before the final

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -697,11 +697,13 @@ artifacts, malformed CSVs, unsupported queue schemas, and mismatched CSV/queue
 submission IDs fail before writes.
 
 For blank Submission Accounts, review looks up Accounts using the submitted
-Profile ID and presents typed choices. Press Enter for the first Account, enter
-another displayed number, or enter `P` for a different Profile ID. Setup
-outcomes and source-submission references survive the following refresh. A
-required setup failure marks the affected queue item `failed` and stops before
-change review.
+Certification ID. One matching Account is linked automatically. Multiple
+matches present typed choices with the Account Name and Certification ID; enter
+the displayed number, or enter `P` for a different Certification ID. When the
+submitted ID is missing or has no match, review requests a Certification ID to
+find the Salesforce Account. Setup outcomes and source-submission references
+survive the following refresh. A required setup failure marks the affected queue
+item `failed` and stops before change review.
 
 Sessions are safely resumable. Completed and blocked work stays durable;
 interrupted, failed, `in_progress`, and `stopped_early` work resets to pending

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -1408,8 +1408,8 @@ class InteractiveProfileUpdateProcessor:
         for submission in submissions:
             submission_id = _required_record_text(submission, "Id", "Profile Update ID")
             submission_name = _display(submission.get("Name") or submission_id)
-            profile_id = _display(submission.get("Certification_ID__c")).strip()
-            account = self._choose_submission_account(submission_name, profile_id)
+            certification_id = _display(submission.get("Certification_ID__c")).strip()
+            account = self._choose_submission_account(submission_name, certification_id)
             account_id = _required_record_text(account, "Id", "Account ID")
             self._update_record(
                 "Company_Profile_Change__c",
@@ -1431,30 +1431,43 @@ class InteractiveProfileUpdateProcessor:
         return repaired
 
     def _choose_submission_account(
-        self, submission_name: str, profile_id: str
+        self, submission_name: str, certification_id: str
     ) -> dict[str, Any]:
-        """Choose an Account, defaulting to the first Profile ID match."""
+        """Find an Account by Certification ID, asking only when needed."""
         while True:
-            if not profile_id:
-                profile_id = self._ask_free_text(
+            if not certification_id:
+                certification_id = self._ask_free_text(
                     FreeTextQuestion(
                         styled(
                             "Profile Update ",
                             ValueFragment(submission_name),
-                            " has no Submission Account. Enter its Profile ID: ",
+                            " has no Submission Account. Enter its Certification ID to "
+                            "find the Salesforce Account: ",
                         )
                     )
                 ).strip()
-                if not profile_id:
+                if not certification_id:
                     self._display_event(
-                        ValidationFeedback(styled("Profile ID cannot be blank."))
+                        ValidationFeedback(styled("Certification ID cannot be blank."))
                     )
                     continue
+
+            lookup_ids = _certification_id_lookup_candidates(certification_id)
+            if len(lookup_ids) == 1:
+                account_where = (
+                    "Certification_ID__c = "
+                    f"'{escape_soql_string(lookup_ids[0])}'"
+                )
+            else:
+                quoted_lookup_ids = ", ".join(
+                    f"'{escape_soql_string(lookup_id)}'" for lookup_id in lookup_ids
+                )
+                account_where = f"Certification_ID__c IN ({quoted_lookup_ids})"
 
             accounts = self.client.query_records(
                 "Account",
                 ["Id", "Name", "Certification_ID__c"],
-                where=(f"Certification_ID__c = '{escape_soql_string(profile_id)}'"),
+                where=account_where,
                 order_by="Name ASC, Id ASC",
             )
             accounts = [account for account in accounts if _display(account.get("Id"))]
@@ -1462,14 +1475,17 @@ class InteractiveProfileUpdateProcessor:
                 self._display_event(
                     ValidationFeedback(
                         styled(
-                            "No Account was found for Profile ID ",
-                            ValueFragment(profile_id),
+                            "No Account was found for Certification ID ",
+                            ValueFragment(certification_id),
                             ".",
                         )
                     )
                 )
-                profile_id = ""
+                certification_id = ""
                 continue
+
+            if len(accounts) == 1:
+                return accounts[0]
 
             choices = tuple(
                 ReviewChoice(
@@ -1479,8 +1495,8 @@ class InteractiveProfileUpdateProcessor:
                 for index, account in enumerate(accounts, start=1)
             ) + (
                 ReviewChoice(
-                    "different_profile_id",
-                    "Use a different Profile ID",
+                    "different_certification_id",
+                    "Use a different Certification ID",
                     ("p",),
                 ),
             )
@@ -1490,7 +1506,7 @@ class InteractiveProfileUpdateProcessor:
                 ":\n",
             ]
             for choice in choices:
-                marker = "P" if choice.key == "different_profile_id" else choice.key
+                marker = "P" if choice.key == "different_certification_id" else choice.key
                 prompt_fragments.extend(
                     (f"{marker}. ", ValueFragment(choice.label), "\n")
                 )
@@ -1499,12 +1515,14 @@ class InteractiveProfileUpdateProcessor:
                 ChoiceQuestion(
                     styled(*prompt_fragments),
                     choices,
-                    styled("Enter an Account number or P for a different Profile ID."),
+                    styled(
+                        "Enter an Account number or P for a different Certification ID."
+                    ),
                     default_key="1",
                 )
             )
-            if selected == "different_profile_id":
-                profile_id = ""
+            if selected == "different_certification_id":
+                certification_id = ""
                 continue
             return accounts[int(selected) - 1]
 
@@ -4452,8 +4470,24 @@ def _section_heading(title: str, separator: str = STAGE_SEPARATOR) -> str:
 def _account_choice_label(account: dict[str, Any]) -> str:
     """Return the identifying Account text shown in a selection control."""
     name = _display(account.get("Name")) or "(name unavailable)"
-    profile_id = _display(account.get("Certification_ID__c")) or "(blank)"
-    return f"{name} (Profile ID {profile_id})"
+    certification_id = _display(account.get("Certification_ID__c")) or "(blank)"
+    return f"{name} (Certification ID {certification_id})"
+
+
+def _certification_id_lookup_candidates(certification_id: str) -> tuple[str, ...]:
+    """Return exact and known equivalent Certification IDs for Account lookup."""
+    match = re.fullmatch(r"(\d{1,4})-(\d{1,2})-(\d{1,2})-(\d{1,6})([A-Za-z])", certification_id)
+    if match is None:
+        return (certification_id,)
+
+    year, month, day, sequence, suffix = match.groups()
+    normalized = (
+        f"{year.zfill(4)}-{month.zfill(2)}-{day.zfill(2)}-{sequence.zfill(6)}"
+    )
+    candidates = [certification_id, f"{normalized}{suffix.upper()}"]
+    if suffix.upper() == "O":
+        candidates.extend(f"{normalized}{replacement}" for replacement in ("F", "E", "P"))
+    return tuple(dict.fromkeys(candidates))
 
 
 def _contact_name_email(contact: dict[str, Any] | None) -> str:

--- a/src/aisc_salesforce/review_queue.py
+++ b/src/aisc_salesforce/review_queue.py
@@ -935,7 +935,10 @@ def _setup_changes(raw: dict[str, str], row: StagedRow) -> list[ProposedChange]:
                     label="Resolve Submission Account",
                     current_value=None,
                     proposed_value=raw.get("certification_id", "").strip() or None,
-                    context="Proposed value is the Profile ID used to choose an Account.",
+                    context=(
+                        "Proposed value is the Certification ID used to find the "
+                        "Salesforce Account."
+                    ),
                     ignore_parent_blockers={"missing_account", "missing_case"},
                 )
             )

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import re
 from datetime import UTC, datetime
 
 import pytest
@@ -821,8 +822,8 @@ def test_key_update_exactly_seven_days_old_is_not_in_the_priority_group():
 
 
 class AccountResolutionUI:
-    def __init__(self, *, entered_profile_id=""):
-        self.entered_profile_id = entered_profile_id
+    def __init__(self, *, entered_certification_ids=()):
+        self.entered_certification_ids = iter(entered_certification_ids)
         self.events = []
         self.questions = []
 
@@ -832,15 +833,16 @@ class AccountResolutionUI:
     def ask(self, question):
         self.questions.append(question)
         if isinstance(question, FreeTextQuestion):
-            return FreeTextAnswer(self.entered_profile_id)
+            return FreeTextAnswer(next(self.entered_certification_ids))
         if isinstance(question, ChoiceQuestion):
             return ChoiceAnswer(question.choices[0])
         raise AssertionError(type(question))
 
 
 class AccountResolutionClient:
-    def __init__(self, *, profile_id="C-100"):
-        self.profile_id = profile_id
+    def __init__(self, *, certification_id="C-100", accounts_by_certification_id=None):
+        self.certification_id = certification_id
+        self.accounts_by_certification_id = accounts_by_certification_id
         self.queries = []
         self.updated = []
 
@@ -853,20 +855,29 @@ class AccountResolutionClient:
                     "Name": "PU-100",
                     "CreatedDate": "2026-07-15T14:30:00.000+0000",
                     "Account__c": None,
-                    "Certification_ID__c": self.profile_id,
+                    "Certification_ID__c": self.certification_id,
                 }
             ]
         if object_name == "Account":
+            if self.accounts_by_certification_id is not None:
+                certification_ids = re.findall(r"'([^']*)'", where)
+                return [
+                    account
+                    for certification_id in certification_ids
+                    for account in self.accounts_by_certification_id.get(
+                        certification_id, []
+                    )
+                ]
             return [
                 {
                     "Id": "account-1",
                     "Name": "Acme Steel",
-                    "Certification_ID__c": self.profile_id or "C-200",
+                    "Certification_ID__c": self.certification_id or "C-200",
                 },
                 {
                     "Id": "account-2",
                     "Name": "Beta Steel",
-                    "Certification_ID__c": self.profile_id or "C-200",
+                    "Certification_ID__c": self.certification_id or "C-200",
                 },
             ]
         raise AssertionError(object_name)
@@ -875,8 +886,14 @@ class AccountResolutionClient:
         self.updated.append((object_name, record_id, values))
 
 
-def test_missing_submission_account_defaults_to_first_profile_id_match():
-    client = AccountResolutionClient()
+def test_missing_submission_account_unique_certification_id_is_assigned_automatically():
+    client = AccountResolutionClient(
+        accounts_by_certification_id={
+            "C-100": [
+                {"Id": "account-1", "Name": "Acme Steel", "Certification_ID__c": "C-100"}
+            ]
+        }
+    )
     ui = AccountResolutionUI()
     processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
 
@@ -893,27 +910,111 @@ def test_missing_submission_account_defaults_to_first_profile_id_match():
     account_query = next(query for query in client.queries if query[0] == "Account")
     assert account_query[2] == "Certification_ID__c = 'C-100'"
     assert account_query[3] == "Name ASC, Id ASC"
-    question = next(
-        question for question in ui.questions if isinstance(question, ChoiceQuestion)
+    assert ui.questions == []
+    assignment = "".join(
+        fragment.value if hasattr(fragment, "value") else fragment.text
+        for fragment in ui.events[0].message
     )
-    assert question.default_key == "1"
-    assert [choice.key for choice in question.choices] == [
-        "1",
-        "2",
-        "different_profile_id",
+    assert assignment == "Assigned Profile Update PU-100 to Acme Steel."
+
+
+def test_multiple_submission_account_matches_offer_numbered_certification_id_choices():
+    client = AccountResolutionClient()
+    ui = AccountResolutionUI()
+    processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
+
+    processor.resolve_missing_submission_accounts()
+
+    question = next(question for question in ui.questions if isinstance(question, ChoiceQuestion))
+    assert [choice.key for choice in question.choices] == ["1", "2", "different_certification_id"]
+    assert [choice.label for choice in question.choices[:2]] == [
+        "Acme Steel (Certification ID C-100)",
+        "Beta Steel (Certification ID C-100)",
     ]
 
 
-def test_missing_submission_account_accepts_profile_id_when_form_value_is_blank():
-    client = AccountResolutionClient(profile_id="")
-    ui = AccountResolutionUI(entered_profile_id="C-200")
+def test_submission_account_lookup_zero_pads_certification_id_sections():
+    client = AccountResolutionClient(
+        certification_id="2015-9-11-3893F",
+        accounts_by_certification_id={
+            "2015-09-11-003893F": [
+                {
+                    "Id": "account-1",
+                    "Name": "Acme Steel",
+                    "Certification_ID__c": "2015-09-11-003893F",
+                }
+            ]
+        },
+    )
+    ui = AccountResolutionUI()
+    processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
+
+    processor.resolve_missing_submission_accounts()
+
+    account_query = next(query for query in client.queries if query[0] == "Account")
+    assert account_query[2] == (
+        "Certification_ID__c IN ('2015-9-11-3893F', '2015-09-11-003893F')"
+    )
+    assert client.updated[0][2] == {"Account__c": "account-1"}
+    assert ui.questions == []
+
+
+def test_certification_id_lookup_candidates_include_known_o_suffix_replacements():
+    assert profile_update_processing._certification_id_lookup_candidates(
+        "2015-9-11-3893O"
+    ) == (
+        "2015-9-11-3893O",
+        "2015-09-11-003893O",
+        "2015-09-11-003893F",
+        "2015-09-11-003893E",
+        "2015-09-11-003893P",
+    )
+
+
+def test_missing_submission_certification_id_requests_and_validates_certification_id():
+    client = AccountResolutionClient(
+        certification_id="",
+        accounts_by_certification_id={
+            "C-200": [
+                {"Id": "account-2", "Name": "Beta Steel", "Certification_ID__c": "C-200"}
+            ]
+        },
+    )
+    ui = AccountResolutionUI(entered_certification_ids=("", "C-200"))
     processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
 
     processor.resolve_missing_submission_accounts()
 
     account_query = next(query for query in client.queries if query[0] == "Account")
     assert account_query[2] == "Certification_ID__c = 'C-200'"
-    assert isinstance(ui.questions[0], FreeTextQuestion)
+    assert len(ui.questions) == 2
+    assert all(isinstance(question, FreeTextQuestion) for question in ui.questions)
+    prompt = "".join(fragment.text for fragment in ui.questions[0].prompt if hasattr(fragment, "text"))
+    assert "Certification ID" in prompt
+    feedback = "".join(fragment.text for fragment in ui.events[0].message if hasattr(fragment, "text"))
+    assert feedback == "Certification ID cannot be blank."
+
+
+def test_unmatched_certification_id_reports_and_allows_retry():
+    client = AccountResolutionClient(
+        certification_id="C-missing",
+        accounts_by_certification_id={
+            "C-missing": [],
+            "C-200": [
+                {"Id": "account-2", "Name": "Beta Steel", "Certification_ID__c": "C-200"}
+            ],
+        },
+    )
+    ui = AccountResolutionUI(entered_certification_ids=("C-200",))
+    processor = InteractiveProfileUpdateProcessor(client, ui, now=NOW)
+
+    processor.resolve_missing_submission_accounts()
+
+    assert client.updated[0][2] == {"Account__c": "account-2"}
+    feedback = "".join(fragment.value if hasattr(fragment, "value") else fragment.text for fragment in ui.events[0].message)
+    assert feedback == "No Account was found for Certification ID C-missing."
+    prompt = "".join(fragment.text for fragment in ui.questions[0].prompt if hasattr(fragment, "text"))
+    assert "to find the Salesforce Account" in prompt
 
 
 def test_blocking_case_match_is_never_guessed():


### PR DESCRIPTION
## Summary
- automatically link unique Submission Account matches and clarify Certification ID prompts
- show Account Name and Certification ID for ambiguous matches
- normalize zero-padded Certification ID sections and try known O-to-F/E/P suffix variants

## Validation
- uv run pytest
- uv run ruff check .

Closes #39