### PR TITLE
Preserve original role-contact details in response emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,12 @@ Account-information changes keep the `ITEM: NEW INFORMATION` and
 `Replaces OLD INFORMATION` format. Each submitted Contact role is consolidated
 into one contact-information line. An unchanged role ends with `- no change`;
 `Replaces ...` appears only when existing role information was actually
-replaced. The command prints the text but does not send email itself; after
+replaced. The previous name, title, email, and phone come from an in-memory
+snapshot taken at the beginning of the Case batch, before any Contact or role
+write. This keeps replacement details accurate when an earlier update in the
+same batch changes the previous role holder. The snapshot lasts only for the
+current processing attempt and is not added to CSV, queue, audit, or Salesforce
+schemas. The command prints the text but does not send email itself; after
 sending it through the normal email system, the reviewer confirms `yes` or
 `no`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -975,8 +975,15 @@ in response text using `ITEM: NEW INFORMATION` followed by
 `Replaces OLD INFORMATION`. Each submitted Contact role is instead summarized
 as one line containing its name, title, email, and phone. A role that required
 no change ends with `- no change`. A following `Replaces OLD INFORMATION` line
-is included only when prior role information was actually replaced. The
-Account paragraph begins:
+is included only when prior role information was actually replaced. The prior
+role Contact's name, title, email, and phone are copied into memory at the
+beginning of the Case batch, after routing and row checkpoints but before the
+first Salesforce write. Response-email replacement details therefore remain
+the values from the beginning of the batch even if that Contact is updated
+earlier in the same batch. Parent-routed Accounts each use their own role
+Contact snapshot. These temporary snapshots do not survive a process restart
+and are not written to staging CSVs, review queues, audit events, or Salesforce.
+The Account paragraph begins:
 
 > Thank you for updating your information with AISC. The changes are summarized
 > below. An updated Participant Portal login will be sent by a separate email,

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -319,6 +319,14 @@ class _RoleResponse:
     changed: bool
 
 
+@dataclass(frozen=True)
+class _RoleContactSnapshot:
+    """One Account role and Contact copied before the batch starts writing."""
+
+    contact_id: str
+    contact: dict[str, Any] | None
+
+
 @dataclass
 class _ResolvedContact:
     """The runtime outcome for one batch-wide email resolution."""
@@ -1691,6 +1699,10 @@ class InteractiveProfileUpdateProcessor:
         for row in batch.rows:
             self._checkpoint_row(row)
 
+        role_contact_snapshots = self._capture_role_contact_snapshots(
+            routing.target_accounts
+        )
+
         self._update_status_with_audit(
             batch,
             batch.case_id,
@@ -1777,6 +1789,7 @@ class InteractiveProfileUpdateProcessor:
                     target_account_id=target_account_id,
                     target_account_name=target_account_name,
                     parent_routed=routing.is_parent,
+                    role_contact_snapshots=role_contact_snapshots,
                 )
                 results.extend(reviewed)
                 if target_index == 0:
@@ -2884,6 +2897,7 @@ class InteractiveProfileUpdateProcessor:
         target_account_id: str,
         target_account_name: str,
         parent_routed: bool,
+        role_contact_snapshots: dict[tuple[str, str], _RoleContactSnapshot],
     ) -> tuple[list[ActionResult], list[_RoleResponse]]:
         """Link roles using the preserved source mapping; never mutate Contacts."""
         results: list[ActionResult] = []
@@ -2893,9 +2907,8 @@ class InteractiveProfileUpdateProcessor:
             submitted = _submitted_role_values(submissions, row, role)
             if not any(submitted.values()):
                 continue
-            original_id, original_contact = self._fresh_role_contact(
-                target_account_id, role.account_lookup
-            )
+            original = role_contact_snapshots[(target_account_id, role.prefix)]
+            original_contact = original.contact
             item: _ContactWorkItem | None = None
             for submission in reversed(submissions):
                 if not any(
@@ -2949,11 +2962,7 @@ class InteractiveProfileUpdateProcessor:
                 proposed_display=_contact_name_email(final_contact),
             )
             results.append(result)
-            previous_contact = (
-                item.original_contact
-                if original_id == item.contact_id and item.original_contact
-                else original_contact
-            )
+            previous_contact = original_contact
             contact_changed = item.result is not None and item.result.status in {
                 ActionStatus.APPLIED,
                 ActionStatus.VERIFIED_MANUAL,
@@ -3458,25 +3467,33 @@ class InteractiveProfileUpdateProcessor:
             results.append(self._review_proposal(proposal))
         return results
 
-    def _fresh_role_contact(
+    def _capture_role_contact_snapshots(
         self,
-        account_id: str,
-        account_lookup: str,
-    ) -> tuple[str, dict[str, Any] | None]:
-        account = self.client.get_record(
-            "Account",
-            account_id,
-            ["Id", account_lookup],
-        )
-        contact_id = _display(account.get(account_lookup))
-        if not contact_id:
-            return "", None
-        contact = self.client.get_record(
-            "Contact",
-            contact_id,
-            CONTACT_REVIEW_FIELDS,
-        )
-        return contact_id, contact
+        target_accounts: tuple[dict[str, Any], ...],
+    ) -> dict[tuple[str, str], _RoleContactSnapshot]:
+        """Copy every target Account's role Contacts before the first write."""
+        snapshots: dict[tuple[str, str], _RoleContactSnapshot] = {}
+        contacts_by_id: dict[str, dict[str, Any]] = {}
+        for account in target_accounts:
+            account_id = _required_record_text(account, "Id", "Affected Account ID")
+            for role in ROLE_DEFINITIONS:
+                contact_id = _display(account.get(role.account_lookup))
+                contact = None
+                if contact_id:
+                    if contact_id not in contacts_by_id:
+                        contacts_by_id[contact_id] = dict(
+                            self.client.get_record(
+                                "Contact",
+                                contact_id,
+                                CONTACT_REVIEW_FIELDS,
+                            )
+                        )
+                    contact = dict(contacts_by_id[contact_id])
+                snapshots[(account_id, role.prefix)] = _RoleContactSnapshot(
+                    contact_id,
+                    contact,
+                )
+        return snapshots
 
     def _build_role_response(
         self,

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -3446,6 +3446,238 @@ def test_role_response_is_consolidated_and_marks_unchanged_roles(tmp_path):
     assert "Cert_Certification_Contact__c" not in response
 
 
+def test_role_response_uses_contact_details_from_start_of_batch(tmp_path):
+    mike = {
+        "Id": "contact-mike",
+        "AccountId": "account-1",
+        "FirstName": "Mike",
+        "LastName": "Miller",
+        "Title": "Certification Manager",
+        "Email": "mike@example.com",
+        "Phone": "555-555-5555",
+    }
+    mary = {
+        "Id": "contact-mary",
+        "AccountId": "account-1",
+        "FirstName": "Mary",
+        "LastName": "Martin",
+        "Title": "Quality Director",
+        "Email": "mary@example.com",
+        "Phone": "312.555.0100",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-mike"),
+        contacts=[mike, mary],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_Email__c": "mike@example.com",
+            "Cert_Phone__c": "222.222.2222",
+        }
+    )
+    client.records[("Company_Profile_Change__c", "submission-2")] = source_record(
+        Id="submission-2",
+        Name="PU-101",
+        CreatedDate="2026-07-15T15:30:00.000+0000",
+        Cert_First_Name__c="Mary",
+        Cert_Last_Name__c="Martin",
+        Cert_Title__c="Quality Director",
+        Cert_Email__c="mary@example.com",
+        Cert_Phone__c="312.555.0100",
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically", "apply automatically", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                source_submission_ids=json.dumps(["submission-1", "submission-2"]),
+                source_submission_names=json.dumps(["PU-100", "PU-101"]),
+                latest_submission_date="2026-07-15T15:30:00.000+0000",
+                certification_first_name="Mary",
+                certification_last_name="Martin",
+                certification_title="Quality Director",
+                certification_email="mary@example.com",
+                certification_phone="312.555.0100",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert ("Contact", "contact-mike", {"Phone": "222.222.2222"}) in client.updated
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "contact-mary"},
+    ) in client.updated
+    response = result.response_path.read_text(encoding="utf-8")
+    assert (
+        "Certification Contact: Mary Martin, Quality Director, "
+        "mary@example.com, 312.555.0100"
+    ) in response
+    assert (
+        "Replaces Mike Miller, Certification Manager, "
+        "mike@example.com, 555-555-5555"
+    ) in response
+    assert (
+        "Replaces Mike Miller, Certification Manager, "
+        "mike@example.com, 222.222.2222"
+    ) not in response
+    persisted_artifacts = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (result.queue_path, result.audit_path)
+    )
+    assert "role_contact_snapshot" not in persisted_artifacts
+    assert all("snapshot" not in column.casefold() for column in CSV_COLUMNS)
+    salesforce_values = [
+        values
+        for _, _, values in client.updated
+    ] + [values for _, values in client.created]
+    assert all(
+        "snapshot" not in field_name.casefold()
+        for values in salesforce_values
+        for field_name in values
+    )
+
+
+def test_role_contact_snapshot_reads_happen_before_first_batch_write(tmp_path):
+    operations = []
+
+    class OrderingClient(FakeClient):
+        def get_record(self, object_name, record_id, fields):
+            operations.append(("read", object_name, record_id))
+            return super().get_record(object_name, record_id, fields)
+
+        def update_record(self, object_name, record_id, values):
+            operations.append(("write", object_name, record_id))
+            return super().update_record(object_name, record_id, values)
+
+        def create_record(self, object_name, values):
+            operations.append(("write", object_name, "(new)"))
+            return super().create_record(object_name, values)
+
+    role_contact_ids = (
+        "cert-contact",
+        "principal-contact",
+        "accounting-contact",
+        "quality-contact",
+        "new-york-contact",
+    )
+    client = OrderingClient(
+        account=account_record(
+            Cert_Certification_Contact__c=role_contact_ids[0],
+            Cert_Principal_Contact__c=role_contact_ids[1],
+            Cert_Accounting_Contact__c=role_contact_ids[2],
+            Cert_Marketing_Contact__c=role_contact_ids[3],
+            Cert_Safety_Contact__c=role_contact_ids[4],
+        ),
+        contacts=[
+            {
+                "Id": contact_id,
+                "AccountId": "account-1",
+                "FirstName": "Role",
+                "LastName": "Contact",
+                "Title": "Manager",
+                "Email": f"{contact_id}@example.com",
+                "Phone": "312.555.0100",
+            }
+            for contact_id in role_contact_ids
+        ],
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    processor.review([staged_row()], tmp_path)
+
+    first_write = next(
+        index for index, operation in enumerate(operations) if operation[0] == "write"
+    )
+    snapshot_reads = [
+        operations.index(("read", "Contact", contact_id))
+        for contact_id in role_contact_ids
+    ]
+    assert max(snapshot_reads) < first_write
+
+
+def test_parent_role_response_uses_target_accounts_original_contact(tmp_path):
+    child = account_record(
+        Id="child-1",
+        Name="Acme Chicago",
+        ParentId="account-1",
+        Cert_Certification_Status__c="Certified",
+        Cert_Certification_Contact__c="child-mike",
+    )
+    child_mike = {
+        "Id": "child-mike",
+        "AccountId": "child-1",
+        "FirstName": "Mike",
+        "LastName": "Child",
+        "Title": "Certification Manager",
+        "Email": "mike.child@example.com",
+        "Phone": "555-555-5555",
+    }
+    mary = {
+        "Id": "contact-mary",
+        "AccountId": "account-1",
+        "FirstName": "Mary",
+        "LastName": "Martin",
+        "Title": "Quality Director",
+        "Email": "mary@example.com",
+        "Phone": "312.555.0100",
+    }
+    client = FakeClient(
+        source=source_record(
+            Cert_First_Name__c="Mary",
+            Cert_Last_Name__c="Martin",
+            Cert_Title__c="Quality Director",
+            Cert_Email__c="mary@example.com",
+            Cert_Phone__c="312.555.0100",
+        ),
+        children=[child],
+        contacts=[child_mike, mary],
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["apply automatically", "yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                is_parent_account="true",
+                certification_first_name="Mary",
+                certification_last_name="Martin",
+                certification_title="Quality Director",
+                certification_email="mary@example.com",
+                certification_phone="312.555.0100",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert (
+        "Account",
+        "child-1",
+        {"Cert_Certification_Contact__c": "contact-mary"},
+    ) in client.updated
+    response = result.response_path.read_text(encoding="utf-8")
+    assert (
+        "Replaces Mike Child, Certification Manager, "
+        "mike.child@example.com, 555-555-5555"
+    ) in response
+    assert "Replaces Old Contact" not in response
+
+
 def test_email_formatter_creates_one_paragraph_per_submitter():
     first = ChangeProposal(
         source_submission_ids=("one",),


### PR DESCRIPTION
## Summary
- snapshot each target Account's role Contacts before the first batch write
- use original Contact details for replacement text while keeping the final resolved Contact as the new role value
- cover same-batch Contact updates, read ordering, parent routing, schema isolation, and existing unchanged-role behavior
- document the temporary beginning-of-batch snapshot behavior

## Testing
- uv run pytest
- uv run ruff check .
- git diff --check

Closes #42