### PR TITLE
Add profile update color coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,29 @@ uv run aisc_salesforce process-profile-updates \
   --output-dir /secure/staged-profile-updates
 ```
 
+On a supported interactive terminal, review output uses a small semantic color
+palette while keeping every existing label: submitted values are bright green,
+script-supplemented values and `Note` lines are bright yellow, warnings and
+validation feedback are bright red, and response-email bodies are bright blue.
+Headings, current Salesforce values, progress messages, and record counts stay
+uncolored, so color is never the only way meaning is communicated.
+
+Disable colors with `--no-color`. For a nested command, the option may appear
+before or after the operation:
+
+```bash
+uv run aisc_salesforce process-profile-updates --no-color review SESSION_ID
+uv run aisc_salesforce process-profile-updates review SESSION_ID --no-color
+```
+
+The standard `NO_COLOR` environment variable also disables colors. Redirected
+output and custom `output_fn` callbacks use plain text automatically. Rich
+provides the terminal detection and rendering fallback; see its
+[Console documentation](https://rich.readthedocs.io/en/stable/console.html) and
+[style/theme documentation](https://rich.readthedocs.io/en/stable/style.html).
+Generated artifacts, including `response_emails.txt`, are always plain text and
+never contain terminal escape codes.
+
 `stage` prints the generated session ID and both artifact paths. If two stages
 start in the same UTC second, the final atomic rename claims each ID; a
 collision retries with `-01`, `-02`, and so on without replacing an existing

--- a/docs/api.md
+++ b/docs/api.md
@@ -202,12 +202,14 @@ completed and blocked outcomes while resetting interrupted statuses to pending.
       show_root_heading: true
       members:
         - TextFragment
+        - ValueOrigin
         - ValueFragment
         - StyledFragment
         - StyledText
         - ReviewChoice
         - Heading
         - Notice
+        - WarningNotice
         - ValidationFeedback
         - ContextLine
         - ScalarComparison
@@ -240,7 +242,12 @@ completed and blocked outcomes while resetting interrupted statuses to pending.
 
 The frozen review dataclasses form the supported renderer boundary.
 `ValueFragment` distinguishes interpolated domain values from explanatory text,
-so a visual UI can style values without parsing sentences. `ChoiceQuestion`
+so a visual UI can style values without parsing sentences. Its
+backward-compatible `origin` field defaults to `ValueOrigin.NEUTRAL`;
+processors and adapters explicitly mark submitted and script-supplemented
+values with `SUBMITTED` and `SUPPLEMENTED`.
+`WarningNotice` distinguishes actionable warnings from an ordinary `Notice`,
+while `ValidationFeedback` remains a separate retry event. `ChoiceQuestion`
 contains only its available `ReviewChoice` objects. Questions and answers have
 separate choice, free-text, and acknowledgement shapes; an unknown interaction
 or mismatched answer raises `UnsupportedReviewInteractionError` explicitly.
@@ -249,12 +256,24 @@ or mismatched answer raises `UnsupportedReviewInteractionError` explicitly.
     options:
       show_root_heading: true
       members:
+        - ColorMode
         - CLIReviewUI
 
 `CLIReviewUI` adapts the typed boundary to terminal `input_fn` and `output_fn`
 callbacks. It preserves the command's headings, comparisons, Contact tables,
 shortcuts, complete phrases, invalid-input retries, and interruption behavior.
-It contains no Salesforce or audit logic.
+Its single Rich theme maps submitted values to bright green, supplemented
+values and notes to bright yellow, warnings to bright red, and response bodies
+to bright blue. Headings, current Salesforce values, progress, and counts stay
+neutral, retaining their existing non-color labels. `ColorMode.AUTO` uses Rich
+terminal detection and honors `NO_COLOR`; `NEVER` backs `--no-color`, and
+`ALWAYS` supports explicit renderer tests. Custom callbacks default to plain
+text. Values are assembled as literal Rich `Text` fragments rather than parsed
+markup. See the Rich [Console](https://rich.readthedocs.io/en/stable/console.html)
+and [theme style](https://rich.readthedocs.io/en/stable/style.html)
+documentation. The adapter contains no Salesforce or audit logic, and saved
+`response_emails.txt` content never passes through it or contains ANSI terminal
+codes.
 
 ::: aisc_salesforce.process_profile_updates
     options:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -667,6 +667,38 @@ uv run aisc_salesforce process-profile-updates review \
   --output-dir /secure/staged-profile-updates
 ```
 
+### Accessible terminal colors
+
+On supported interactive terminals, only review semantics are colored:
+
+| Meaning | Terminal color | Non-color label or context |
+|---|---|---|
+| Submitted values | Bright green | `Proposed value`, submission context, and existing field labels |
+| Script-supplemented values or notes | Bright yellow | `Note` |
+| Warnings and validation feedback | Bright red | `Warnings` and the complete feedback text |
+| Response-email body | Bright blue | `Response email for ...` heading |
+
+Headings, current Salesforce values, progress messages, and record counts are
+neutral. The labels remain the primary meaning, so the workflow is readable
+without color.
+
+Use `--no-color` on the combined command or before/after any nested operation:
+
+```bash
+uv run aisc_salesforce process-profile-updates --no-color stage
+uv run aisc_salesforce process-profile-updates prepare SESSION_ID --no-color
+uv run aisc_salesforce process-profile-updates --no-color review SESSION_ID
+```
+
+Setting the standard `NO_COLOR` environment variable has the same effect.
+Redirection, unsupported terminals, and custom `output_fn` callbacks fall back
+to plain text automatically. The adapter uses Rich's
+[Console](https://rich.readthedocs.io/en/stable/console.html) and
+[theme styles](https://rich.readthedocs.io/en/stable/style.html) without parsing
+markup, so brackets and other characters in submitted values stay literal.
+Terminal styling is never written to `profile_updates.csv`,
+`review_audit.jsonl`, `review_queue.json`, or `response_emails.txt`.
+
 `stage` reads New submissions and publishes both `profile_updates.csv` and
 `review_queue.json` through one temporary directory and one final rename. The
 printed UTC timestamp folder name is the session ID. The final rename claims an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.13"
 dependencies = [
     "loguru>=0.7",
     "requests>=2.32",
+    "rich>=14.0",
     "tzdata>=2025.2",
 ]
 

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -14,7 +14,7 @@ from .application_snapshot import (
     ApplicationSnapshotService,
     write_application_snapshot,
 )
-from .cli_review_ui import CLIReviewUI
+from .cli_review_ui import CLIReviewUI, ColorMode, print_profile_error
 from .dictionary import DictionaryError, load_export_plan
 from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
 from .picklist_audit import (
@@ -100,11 +100,22 @@ def main(
         default=Path("staged_profile_updates"),
         help="Directory to contain staging, audit, and response artifacts.",
     )
+    process_parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colored terminal output.",
+    )
     process_operations = process_parser.add_subparsers(dest="process_operation")
     for operation in ("stage", "prepare", "review"):
         operation_parser = process_operations.add_parser(
             operation,
             help=f"Run only the {operation} phase of a staging session.",
+        )
+        operation_parser.add_argument(
+            "--no-color",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="Disable colored terminal output.",
         )
         if operation != "stage":
             operation_parser.add_argument(
@@ -169,17 +180,23 @@ def main(
             print(f"Stage profile updates failed: {error}", file=sys.stderr)
             return 1
     if args.command == "process-profile-updates":
+        color_mode = ColorMode.NEVER if args.no_color else ColorMode.AUTO
+        color_kwargs = (
+            {"color_mode": color_mode} if color_mode is ColorMode.NEVER else {}
+        )
         try:
             if args.process_operation == "stage":
                 return _run_stage_profile_update_session(
                     args.output_dir,
                     output_fn=output_fn,
+                    **color_kwargs,
                 )
             if args.process_operation == "prepare":
                 return _run_prepare_profile_update_session(
                     args.session_id,
                     args.output_dir,
                     output_fn=output_fn,
+                    **color_kwargs,
                 )
             if args.process_operation == "review":
                 return _run_review_profile_update_session(
@@ -187,11 +204,13 @@ def main(
                     args.output_dir,
                     input_fn=input_fn,
                     output_fn=output_fn,
+                    **color_kwargs,
                 )
             return _run_process_profile_updates(
                 args.output_dir,
                 input_fn=input_fn,
                 output_fn=output_fn,
+                **color_kwargs,
             )
         except (
             ProcessingError,
@@ -199,7 +218,10 @@ def main(
             UnsupportedReviewInteractionError,
             OSError,
         ) as error:
-            print(f"Process profile updates failed: {error}", file=sys.stderr)
+            print_profile_error(
+                f"Process profile updates failed: {error}",
+                color_mode=color_mode,
+            )
             return 1
     if args.command == "rename-profile-update-cases":
         try:
@@ -364,6 +386,7 @@ def _run_process_profile_updates(
     *,
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
+    color_mode: ColorMode | str | bool | None = None,
 ) -> int:
     """Connect to Salesforce and run the interactive Profile Update workflow."""
     _load_dotenv(Path(".env"))
@@ -380,7 +403,11 @@ def _run_process_profile_updates(
     if "ui" in processor_parameters:
         processor = InteractiveProfileUpdateProcessor(
             client,
-            CLIReviewUI(input_fn=input_fn, output_fn=output_fn),
+            CLIReviewUI(
+                input_fn=input_fn,
+                output_fn=output_fn,
+                color_mode=color_mode,
+            ),
         )
     else:  # Compatibility for injected processors using the former constructor.
         processor = InteractiveProfileUpdateProcessor(
@@ -414,6 +441,7 @@ def _run_stage_profile_update_session(
     output_dir: Path,
     *,
     output_fn: Callable[[str], None] = print,
+    color_mode: ColorMode | str | bool | None = None,
 ) -> int:
     """Authenticate, capture New submissions, and publish one stable session."""
     client = _profile_update_client(output_fn)
@@ -436,6 +464,7 @@ def _run_prepare_profile_update_session(
     output_dir: Path,
     *,
     output_fn: Callable[[str], None] = print,
+    color_mode: ColorMode | str | bool | None = None,
 ) -> int:
     """Authenticate and prepare Cases for one published session."""
     client, queue_id, responder_id = _profile_update_client_with_configuration(
@@ -443,7 +472,11 @@ def _run_prepare_profile_update_session(
     )
     processor = InteractiveProfileUpdateProcessor(
         client,
-        CLIReviewUI(input_fn=input, output_fn=output_fn),
+        CLIReviewUI(
+            input_fn=input,
+            output_fn=output_fn,
+            color_mode=color_mode,
+        ),
     )
     workflow = ProfileUpdateProcessingWorkflow(
         ProfileUpdateService(client, queue_id, responder_id),
@@ -462,6 +495,7 @@ def _run_review_profile_update_session(
     *,
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
+    color_mode: ColorMode | str | bool | None = None,
 ) -> int:
     """Authenticate and resume interactive review for one published session."""
     client, queue_id, responder_id = _profile_update_client_with_configuration(
@@ -469,7 +503,11 @@ def _run_review_profile_update_session(
     )
     processor = InteractiveProfileUpdateProcessor(
         client,
-        CLIReviewUI(input_fn=input_fn, output_fn=output_fn),
+        CLIReviewUI(
+            input_fn=input_fn,
+            output_fn=output_fn,
+            color_mode=color_mode,
+        ),
     )
     workflow = ProfileUpdateProcessingWorkflow(
         ProfileUpdateService(client, queue_id, responder_id),

--- a/src/aisc_salesforce/cli_review_ui.py
+++ b/src/aisc_salesforce/cli_review_ui.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from collections.abc import Callable
+from enum import StrEnum
+from io import StringIO
+
+from rich.console import Console
+from rich.text import Text
+from rich.theme import Theme
 
 from .review_queue import QueueStatus, iter_changes
 from .review_ui import (
@@ -33,141 +41,210 @@ from .review_ui import (
     UnsupportedReviewInteractionError,
     ValidationFeedback,
     ValueFragment,
+    ValueOrigin,
+    WarningNotice,
 )
 
 
+class ColorMode(StrEnum):
+    """How the terminal adapter decides whether to emit ANSI color codes."""
+
+    AUTO = "auto"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+PROFILE_UPDATE_THEME = Theme(
+    {
+        "profile.submitted": "bright_green",
+        "profile.supplemented": "bright_yellow",
+        "profile.warning": "bright_red",
+        "profile.response": "bright_blue",
+    }
+)
+
+_ORIGIN_STYLES = {
+    ValueOrigin.NEUTRAL: None,
+    ValueOrigin.SUBMITTED: "profile.submitted",
+    ValueOrigin.SUPPLEMENTED: "profile.supplemented",
+}
+
+
 class CLIReviewUI:
-    """Render typed review interactions with the existing terminal experience."""
+    """Render typed review interactions with accessible terminal colors."""
 
     def __init__(
         self,
         *,
         input_fn: Callable[[str], str] = input,
         output_fn: Callable[[str], None] = print,
+        color_mode: ColorMode | str | bool | None = None,
     ):
         self.input_fn = input_fn
         self.output_fn = output_fn
+        self.color_mode = _normalize_color_mode(color_mode)
+        self._colors_enabled = _detect_color_support(
+            self.color_mode,
+            custom_output=output_fn is not print,
+            stream=sys.stdout,
+        )
 
     def display(self, event: ReviewEvent) -> None:
         """Render every supported event and reject unknown objects explicitly."""
         if isinstance(event, Heading):
-            self.output_fn(_section_heading(_render_text(event.title), event.separator))
-        elif isinstance(event, (Notice, ValidationFeedback)):
-            self.output_fn(_render_text(event.message))
+            self._emit(_section_heading(_styled_text(event.title), event.separator))
+        elif isinstance(event, Notice):
+            self._emit(_styled_text(event.message))
+        elif isinstance(event, (WarningNotice, ValidationFeedback)):
+            self._emit(Text(_render_text(event.message), style="profile.warning"))
         elif isinstance(event, ContextLine):
-            self.output_fn(f"{event.label}: {_render_text(event.value)}")
+            line = Text(f"{event.label}: ")
+            line.append_text(_styled_text(event.value))
+            self._emit(line)
         elif isinstance(event, ScalarComparison):
-            self.output_fn(
-                f"\n{event.label}\n"
-                f"Current Salesforce value: {_value(event.current)}\n"
-                f"Proposed value: {_value(event.proposed)}"
-            )
+            line = Text(f"\n{event.label}\nCurrent Salesforce value: ")
+            line.append_text(_value(event.current))
+            line.append("\nProposed value: ")
+            line.append_text(_value(event.proposed))
+            self._emit(line)
         elif isinstance(event, MappingComparison):
             heading = (
                 "New Salesforce values:" if event.is_new else "Salesforce changes:"
             )
-            lines = [f"\n{event.label}", heading]
+            lines = Text(f"\n{event.label}\n{heading}")
             for row in event.rows:
+                lines.append(f"\n{row.label}: ")
                 if event.is_new:
-                    lines.append(f"{row.label}: {_value(row.proposed)}")
+                    lines.append_text(_value(row.proposed))
                 else:
-                    lines.append(
-                        f"{row.label}: {_value(row.current)} -> {_value(row.proposed)}"
-                    )
-            self.output_fn("\n".join(lines))
+                    lines.append_text(_value(row.current))
+                    lines.append(" -> ")
+                    lines.append_text(_value(row.proposed))
+            self._emit(lines)
         elif isinstance(event, ContactCard):
-            self.output_fn(
-                f"{event.heading}:\n"
-                f"Name: {_value(event.name)}\n"
-                f"Title: {_value(event.title)}\n"
-                f"Email: {_value(event.email)}\n"
-                f"Phone: {_value(event.phone)}"
-            )
+            card = Text(f"{event.heading}:\nName: ")
+            card.append_text(_value(event.name))
+            card.append("\nTitle: ")
+            card.append_text(_value(event.title))
+            card.append("\nEmail: ")
+            card.append_text(_value(event.email))
+            card.append("\nPhone: ")
+            card.append_text(_value(event.phone))
+            self._emit(card)
         elif isinstance(event, ContactComparison):
-            self.output_fn(
-                _section_heading(
-                    f"Reconciled Contact: {event.identity.value}", "-" * 72
-                )
-            )
-            self.output_fn("Field | Current Salesforce | Reconciled | Sources")
+            title = Text("Reconciled Contact: ")
+            title.append_text(_raw_value(event.identity))
+            self._emit(_section_heading(title, "-" * 72))
+            self._emit(Text("Field | Current Salesforce | Reconciled | Sources"))
             for row in event.rows:
-                self.output_fn(
-                    f"{row.label} | {_value(row.current)} | "
-                    f"{_value(row.reconciled)} | {_value(row.sources)}"
-                )
+                line = Text(f"{row.label} | ")
+                line.append_text(_value(row.current))
+                line.append(" | ")
+                line.append_text(_value(row.reconciled))
+                line.append(" | ")
+                line.append_text(_value(row.sources))
+                self._emit(line)
         elif isinstance(event, ContactFieldConflict):
-            self.output_fn(
-                _section_heading(f"Contact field conflict: {event.label}", "-" * 72)
+            self._emit(
+                _section_heading(
+                    Text(f"Contact field conflict: {event.label}"), "-" * 72
+                )
             )
             for candidate in event.candidates:
-                self.output_fn(
-                    f"{candidate.key}. {candidate.value.value}\n"
-                    f"   Sources: {candidate.sources.value}"
-                )
-            self.output_fn(f"current. {_value(event.current)}")
+                line = Text(f"{candidate.key}. ")
+                line.append_text(_raw_value(candidate.value))
+                line.append("\n   Sources: ")
+                line.append_text(_raw_value(candidate.sources))
+                self._emit(line)
+            current = Text("current. ")
+            current.append_text(_value(event.current))
+            self._emit(current)
         elif isinstance(event, ParentAccountConflict):
-            lines = [
-                _section_heading(
-                    f"Parent Account needs manual follow-up: {event.parent.value}",
-                    "-" * 72,
-                ),
-                "Active direct child values conflict, so this entire Case batch "
-                "will remain open:",
-            ]
-            for field in event.fields:
-                lines.extend(
-                    (f"\n{field.label}", f"Requested value: {_value(field.requested)}")
-                )
-                lines.extend(
-                    f"{child.account_name.value or '(unnamed)'} "
-                    f"({child.account_id.value}): {_value(child.current)}"
-                    for child in field.children
-                )
-            self.output_fn("\n".join(lines))
-        elif isinstance(event, ParentAccountNoActiveChildren):
-            lines = [
-                _section_heading(
-                    f"Parent Account needs manual follow-up: {event.parent.value}",
-                    "-" * 72,
-                ),
-                "This Parent Account has no direct child with status Certified or "
-                "Initials, so this entire Case batch will remain open.",
-            ]
-            if event.children:
-                lines.append("Direct children:")
-                lines.extend(
-                    f"{child.account_name.value or '(unnamed)'} "
-                    f"({child.account_id.value}): {_value(child.current)}"
-                    for child in event.children
-                )
-            self.output_fn("\n".join(lines))
-        elif isinstance(event, StagedRowSummary):
-            heading = (
-                "Staged row\n"
-                f"Account: {_value(event.account)}\n"
-                f"Submitter: {event.submitter_name.value} "
-                f"<{event.submitter_email.value}>\n"
-                f"Profile Updates: {_value(event.profile_updates)}"
+            title = Text(
+                "Parent Account needs manual follow-up: ", style="profile.warning"
             )
+            title.append_text(_raw_value(event.parent))
+            lines = _section_heading(title, "-" * 72)
+            lines.append(
+                "\nActive direct child values conflict, so this entire Case batch "
+                "will remain open:",
+                style="profile.warning",
+            )
+            for field in event.fields:
+                lines.append(f"\n\n{field.label}\nRequested value: ")
+                lines.append_text(_value(field.requested))
+                for child in field.children:
+                    lines.append("\n")
+                    lines.append(child.account_name.value or "(unnamed)")
+                    lines.append(f" ({child.account_id.value}): ")
+                    lines.append_text(_value(child.current))
+            self._emit(lines)
+        elif isinstance(event, ParentAccountNoActiveChildren):
+            title = Text(
+                "Parent Account needs manual follow-up: ", style="profile.warning"
+            )
+            title.append_text(_raw_value(event.parent))
+            lines = _section_heading(title, "-" * 72)
+            lines.append(
+                "\nThis Parent Account has no direct child with status Certified or "
+                "Initials, so this entire Case batch will remain open.",
+                style="profile.warning",
+            )
+            if event.children:
+                lines.append("\nDirect children:")
+                for child in event.children:
+                    lines.append("\n")
+                    lines.append(child.account_name.value or "(unnamed)")
+                    lines.append(f" ({child.account_id.value}): ")
+                    lines.append_text(_value(child.current))
+            self._emit(lines)
+        elif isinstance(event, StagedRowSummary):
+            heading = Text("Staged row\nAccount: ")
+            heading.append_text(_value(event.account))
+            heading.append("\nSubmitter: ")
+            heading.append_text(_raw_value(event.submitter_name))
+            heading.append(" <")
+            heading.append_text(_raw_value(event.submitter_email))
+            heading.append(">\nProfile Updates: ")
+            heading.append_text(_value(event.profile_updates))
             if event.contact_details_supplemented:
-                heading += (
-                    "\nNote: contact details were supplemented from available "
-                    "contact information."
+                heading.append_text(
+                    _raw_value(
+                        ValueFragment(
+                            "\nNote: contact details were supplemented from available "
+                            "contact information.",
+                            ValueOrigin.SUPPLEMENTED,
+                        )
+                    )
                 )
             if event.has_no_update_content:
-                heading += "\nNote: this combined profile update has no submitted update content."
-            self.output_fn(_section_heading(heading, "-" * 72))
+                heading.append_text(
+                    _raw_value(
+                        ValueFragment(
+                            "\nNote: this combined profile update has no submitted "
+                            "update content.",
+                            ValueOrigin.SUPPLEMENTED,
+                        )
+                    )
+                )
+            self._emit(_section_heading(heading, "-" * 72))
         elif isinstance(event, AccountHistory):
-            self.output_fn(
-                "Account History: "
-                f"{event.field.value} changed from {_value(event.old_value)} to "
-                f"{_value(event.new_value)} at {event.created_at.value}"
-            )
+            line = Text("Account History: ")
+            line.append_text(_raw_value(event.field))
+            line.append(" changed from ")
+            line.append_text(_value(event.old_value))
+            line.append(" to ")
+            line.append_text(_value(event.new_value))
+            line.append(" at ")
+            line.append_text(_raw_value(event.created_at))
+            self._emit(line)
         elif isinstance(event, ResponseEmail):
-            self.output_fn(
-                f"{_section_heading(f'Response email for {event.recipient.value}', '-' * 72)}"
-                f"\n{event.body}"
-            )
+            title = Text("Response email for ")
+            title.append_text(_raw_value(event.recipient))
+            response = _section_heading(title, "-" * 72)
+            response.append("\n")
+            response.append(event.body, style="profile.response")
+            self._emit(response)
         elif isinstance(event, ReviewQueueSnapshot):
             changes = list(iter_changes(event.manifest))
             pending = sum(
@@ -183,9 +260,11 @@ class CLIReviewUI:
                 None,
             )
             next_label = next_change.label if next_change is not None else "none"
-            self.output_fn(
-                f"Review queue: {len(event.manifest.batches)} batch(es), "
-                f"{pending} pending change(s); next: {next_label}"
+            self._emit(
+                Text(
+                    f"Review queue: {len(event.manifest.batches)} batch(es), "
+                    f"{pending} pending change(s); next: {next_label}"
+                )
             )
         else:
             raise UnsupportedReviewInteractionError(
@@ -201,22 +280,102 @@ class CLIReviewUI:
                 for alias in (choice.key, choice.label, *choice.shortcuts)
             }
             while True:
-                raw = self.input_fn(_render_text(question.prompt))
+                raw = self.input_fn(self._render(_styled_text(question.prompt)))
                 normalized = raw.strip().casefold()
                 if not normalized and question.default_key is not None:
                     normalized = question.default_key.casefold()
                 choice = aliases.get(normalized)
                 if choice is not None:
                     return ChoiceAnswer(choice)
-                self.output_fn(_render_text(question.invalid_feedback))
+                self._emit(
+                    Text(
+                        _render_text(question.invalid_feedback),
+                        style="profile.warning",
+                    )
+                )
         if isinstance(question, FreeTextQuestion):
-            return FreeTextAnswer(self.input_fn(_render_text(question.prompt)))
+            return FreeTextAnswer(
+                self.input_fn(self._render(_styled_text(question.prompt)))
+            )
         if isinstance(question, AcknowledgementQuestion):
-            self.input_fn(_render_text(question.prompt))
+            self.input_fn(self._render(_styled_text(question.prompt)))
             return AcknowledgementAnswer()
         raise UnsupportedReviewInteractionError(
             f"CLIReviewUI cannot ask {type(question).__name__}."
         )
+
+    def _emit(self, value: Text) -> None:
+        self.output_fn(self._render(value))
+
+    def _render(self, value: Text) -> str:
+        buffer = StringIO()
+        console = Console(
+            file=buffer,
+            color_system="standard" if self._colors_enabled else None,
+            force_terminal=self._colors_enabled,
+            legacy_windows=False,
+            no_color=not self._colors_enabled,
+            theme=PROFILE_UPDATE_THEME,
+        )
+        console.print(value, end="", soft_wrap=True)
+        return buffer.getvalue()
+
+
+def _normalize_color_mode(value: ColorMode | str | bool | None) -> ColorMode:
+    if value is None:
+        return ColorMode.AUTO
+    if value is True:
+        return ColorMode.ALWAYS
+    if value is False:
+        return ColorMode.NEVER
+    return ColorMode(value)
+
+
+def _detect_color_support(
+    mode: ColorMode,
+    *,
+    custom_output: bool,
+    stream: object,
+) -> bool:
+    if mode is ColorMode.ALWAYS:
+        return True
+    if mode is ColorMode.NEVER or custom_output or "NO_COLOR" in os.environ:
+        return False
+    detector = Console(file=stream, theme=PROFILE_UPDATE_THEME)
+    return detector.is_terminal and detector.color_system is not None
+
+
+def print_profile_error(
+    message: str,
+    *,
+    color_mode: ColorMode | str | bool | None = None,
+) -> None:
+    """Print one Profile Update command failure to stderr in warning red."""
+    mode = _normalize_color_mode(color_mode)
+    enabled = _detect_color_support(
+        mode,
+        custom_output=False,
+        stream=sys.stderr,
+    )
+    console = Console(
+        file=sys.stderr,
+        color_system="standard" if enabled else None,
+        force_terminal=enabled,
+        legacy_windows=False,
+        no_color=not enabled,
+        theme=PROFILE_UPDATE_THEME,
+    )
+    console.print(Text(message, style="profile.warning"), soft_wrap=True)
+
+
+def _styled_text(value: StyledText) -> Text:
+    rendered = Text()
+    for fragment in value:
+        if isinstance(fragment, ValueFragment):
+            rendered.append(fragment.value, style=_ORIGIN_STYLES[fragment.origin])
+        else:
+            rendered.append(fragment.text)
+    return rendered
 
 
 def _render_text(value: StyledText) -> str:
@@ -226,9 +385,16 @@ def _render_text(value: StyledText) -> str:
     )
 
 
-def _value(fragment: ValueFragment) -> str:
-    return fragment.value or "(blank)"
+def _value(fragment: ValueFragment) -> Text:
+    return Text(fragment.value or "(blank)", style=_ORIGIN_STYLES[fragment.origin])
 
 
-def _section_heading(title: str, separator: str) -> str:
-    return f"\n{separator}\n{title}\n{separator}"
+def _raw_value(fragment: ValueFragment) -> Text:
+    return Text(fragment.value, style=_ORIGIN_STYLES[fragment.origin])
+
+
+def _section_heading(title: Text, separator: str) -> Text:
+    result = Text(f"\n{separator}\n")
+    result.append_text(title)
+    result.append(f"\n{separator}")
+    return result

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -80,6 +80,8 @@ from .review_ui import (
     UnsupportedReviewInteractionError,
     ValidationFeedback,
     ValueFragment,
+    ValueOrigin,
+    WarningNotice,
     styled,
 )
 from .salesforce import SalesforceClient, SalesforceError
@@ -1429,7 +1431,7 @@ class InteractiveProfileUpdateProcessor:
                 Notice(
                     styled(
                         "Assigned Profile Update ",
-                        ValueFragment(submission_name),
+                        ValueFragment(submission_name, ValueOrigin.SUBMITTED),
                         " to ",
                         ValueFragment(_display(account.get("Name")) or account_id),
                         ".",
@@ -1448,7 +1450,7 @@ class InteractiveProfileUpdateProcessor:
                     FreeTextQuestion(
                         styled(
                             "Profile Update ",
-                            ValueFragment(submission_name),
+                            ValueFragment(submission_name, ValueOrigin.SUBMITTED),
                             " has no Submission Account. Enter its Certification ID to "
                             "find the Salesforce Account: ",
                         )
@@ -1510,7 +1512,7 @@ class InteractiveProfileUpdateProcessor:
             )
             prompt_fragments: list[str | ValueFragment] = [
                 "Choose the Submission Account for Profile Update ",
-                ValueFragment(submission_name),
+                ValueFragment(submission_name, ValueOrigin.SUBMITTED),
                 ":\n",
             ]
             for choice in choices:
@@ -2176,7 +2178,7 @@ class InteractiveProfileUpdateProcessor:
                     tuple(
                         ConflictCandidate(
                             str(index),
-                            ValueFragment(value),
+                            ValueFragment(value, ValueOrigin.SUBMITTED),
                             ValueFragment(self._format_contact_sources(sources)),
                         )
                         for index, (value, sources) in enumerate(
@@ -2318,7 +2320,7 @@ class InteractiveProfileUpdateProcessor:
                 ContactComparisonRow(
                     field_label,
                     ValueFragment(_display(current.get(contact_field))),
-                    ValueFragment(reconciled.get(suffix, "")),
+                    ValueFragment(reconciled.get(suffix, ""), ValueOrigin.SUBMITTED),
                     ValueFragment(self._format_contact_sources(sources)),
                 )
             )
@@ -2359,7 +2361,7 @@ class InteractiveProfileUpdateProcessor:
         has_last_name = bool((item.reconciled or {}).get("last_name"))
         if not item.contact_id and not has_last_name:
             self._display_event(
-                Notice(
+                WarningNotice(
                     styled(
                         "This Contact cannot be created automatically because the "
                         "required Last Name field is missing."
@@ -2701,7 +2703,7 @@ class InteractiveProfileUpdateProcessor:
             self._show_contact_details("Suggested Contact", candidate)
             candidate_email, candidate_key, _ = normalize_email(candidate.get("Email"))
             self._display_event(
-                Notice(
+                WarningNotice(
                     styled(
                         "Likely email typo: ",
                         ValueFragment(resolution.normalized_email),
@@ -2750,7 +2752,10 @@ class InteractiveProfileUpdateProcessor:
             Heading(
                 styled(
                     "Contact resolution for ",
-                    ValueFragment(resolution.normalized_email or "(invalid email)"),
+                    ValueFragment(
+                        resolution.normalized_email or "(invalid email)",
+                        ValueOrigin.SUBMITTED,
+                    ),
                 ),
                 ITEM_SEPARATOR,
             )
@@ -3020,11 +3025,13 @@ class InteractiveProfileUpdateProcessor:
         all_sent = True
         for email, text in emails.items():
             response_writer.append(batch.case_id, email, text)
-            self._display_event(ResponseEmail(ValueFragment(email), text))
+            self._display_event(
+                ResponseEmail(ValueFragment(email, ValueOrigin.SUBMITTED), text)
+            )
             sent = self._prompt_yes_no(
                 styled(
                     "Was the response email to ",
-                    ValueFragment(email),
+                    ValueFragment(email, ValueOrigin.SUBMITTED),
                     " sent? [yes/no]: ",
                 )
             )
@@ -3071,9 +3078,9 @@ class InteractiveProfileUpdateProcessor:
         self._display_event(
             StagedRowSummary(
                 ValueFragment(account_name or "(unavailable)"),
-                ValueFragment(submitter_name),
-                ValueFragment(submitter_email),
-                ValueFragment(source_names or "(unnamed)"),
+                ValueFragment(submitter_name, ValueOrigin.SUBMITTED),
+                ValueFragment(submitter_email, ValueOrigin.SUBMITTED),
+                ValueFragment(source_names or "(unnamed)", ValueOrigin.SUBMITTED),
                 contact_details_supplemented=(
                     row.get("has_contact_derived_values") == "true"
                 ),
@@ -3160,7 +3167,7 @@ class InteractiveProfileUpdateProcessor:
                 conflicts.append(
                     ParentAccountFieldConflict(
                         label,
-                        ValueFragment(requested),
+                        ValueFragment(requested, ValueOrigin.SUBMITTED),
                         tuple(
                             ParentAccountChildValue(
                                 ValueFragment(_display(child.get("Id"))),
@@ -3348,7 +3355,12 @@ class InteractiveProfileUpdateProcessor:
             self._display_event(
                 ContextLine(
                     "Submitter",
-                    styled(ValueFragment(name), " <", ValueFragment(email), ">"),
+                    styled(
+                        ValueFragment(name, ValueOrigin.SUBMITTED),
+                        " <",
+                        ValueFragment(email, ValueOrigin.SUBMITTED),
+                        ">",
+                    ),
                 )
             )
 
@@ -3358,7 +3370,8 @@ class InteractiveProfileUpdateProcessor:
                     styled(
                         "Profile Update ",
                         ValueFragment(
-                            _display(submission.get("Name") or submission.get("Id"))
+                            _display(submission.get("Name") or submission.get("Id")),
+                            ValueOrigin.SUBMITTED,
                         ),
                         " (status: ",
                         ValueFragment(_display(submission.get("Status__c"))),
@@ -3369,21 +3382,47 @@ class InteractiveProfileUpdateProcessor:
             comments = _display(submission.get("Comments__c"))
             notes = _display(submission.get("Other_Personnel_Notes__c"))
             if comments:
-                self._display_event(ContextLine("Comments", (ValueFragment(comments),)))
+                self._display_event(
+                    ContextLine(
+                        "Comments",
+                        (ValueFragment(comments, ValueOrigin.SUBMITTED),),
+                    )
+                )
             if notes:
                 self._display_event(
-                    ContextLine("Other Personnel notes", (ValueFragment(notes),))
+                    ContextLine(
+                        "Other Personnel notes",
+                        (ValueFragment(notes, ValueOrigin.SUBMITTED),),
+                    )
                 )
 
-        self._show_unique_row_context(batch.rows, "effective_date", "Effective date")
-        self._show_unique_row_context(batch.rows, "key_answers", "Key Update answers")
-        self._show_unique_row_context(batch.rows, "warnings", "Warnings")
+        self._show_unique_row_context(
+            batch.rows,
+            "effective_date",
+            "Effective date",
+            origin=ValueOrigin.SUBMITTED,
+        )
+        self._show_unique_row_context(
+            batch.rows,
+            "key_answers",
+            "Key Update answers",
+            origin=ValueOrigin.SUBMITTED,
+        )
+        self._show_unique_row_context(
+            batch.rows,
+            "warnings",
+            "Warnings",
+            warning=True,
+        )
 
     def _show_unique_row_context(
         self,
         rows: list[dict[str, str]],
         field_name: str,
         label: str,
+        *,
+        origin: ValueOrigin = ValueOrigin.NEUTRAL,
+        warning: bool = False,
     ) -> None:
         values = dict.fromkeys(
             row.get(field_name, "").strip()
@@ -3391,7 +3430,11 @@ class InteractiveProfileUpdateProcessor:
             if row.get(field_name, "").strip()
         )
         for value in values:
-            self._display_event(ContextLine(label, (ValueFragment(value),)))
+            fragment = ValueFragment(value, origin)
+            if warning:
+                self._display_event(WarningNotice(styled(f"{label}: ", fragment)))
+            else:
+                self._display_event(ContextLine(label, (fragment,)))
 
     def _show_account_history(
         self,
@@ -3536,7 +3579,7 @@ class InteractiveProfileUpdateProcessor:
             )
         )
         self._display_event(
-            Notice(
+            WarningNotice(
                 styled(
                     "Salesforce blocked this Contact create as a possible duplicate."
                 )
@@ -3945,7 +3988,7 @@ class InteractiveProfileUpdateProcessor:
             ScalarComparison(
                 proposal.label,
                 ValueFragment(current),
-                ValueFragment(proposed),
+                ValueFragment(proposed, ValueOrigin.SUBMITTED),
             )
         )
 
@@ -3961,7 +4004,7 @@ class InteractiveProfileUpdateProcessor:
                 MappingComparisonRow(
                     label,
                     ValueFragment(_display(current.get(field_name))),
-                    ValueFragment(_display(proposed_value)),
+                    ValueFragment(_display(proposed_value), ValueOrigin.SUBMITTED),
                 )
             )
         self._display_event(MappingComparison(proposal.label, tuple(rows), is_new))

--- a/src/aisc_salesforce/review_ui.py
+++ b/src/aisc_salesforce/review_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol
 
 from .review_queue import ReviewQueueManifest
@@ -10,6 +11,14 @@ from .review_queue import ReviewQueueManifest
 
 class UnsupportedReviewInteractionError(RuntimeError):
     """A review UI received an interaction shape it does not support."""
+
+
+class ValueOrigin(StrEnum):
+    """Semantic source of a displayed value, independent of any renderer."""
+
+    NEUTRAL = "neutral"
+    SUBMITTED = "submitted"
+    SUPPLEMENTED = "supplemented"
 
 
 @dataclass(frozen=True)
@@ -24,6 +33,7 @@ class ValueFragment:
     """An interpolated domain value that a UI may style differently."""
 
     value: str
+    origin: ValueOrigin = ValueOrigin.NEUTRAL
 
 
 type StyledFragment = TextFragment | ValueFragment
@@ -50,6 +60,13 @@ class Heading:
 @dataclass(frozen=True)
 class Notice:
     """Informational reviewer-facing content."""
+
+    message: StyledText
+
+
+@dataclass(frozen=True)
+class WarningNotice:
+    """Actionable warning content that a UI may emphasize semantically."""
 
     message: StyledText
 
@@ -217,6 +234,7 @@ class ReviewQueueSnapshot:
 type ReviewEvent = (
     Heading
     | Notice
+    | WarningNotice
     | ValidationFeedback
     | ContextLine
     | ScalarComparison

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from io import StringIO
 from types import SimpleNamespace
 
 import pytest
@@ -511,6 +512,30 @@ def test_process_profile_update_nested_operation_preserves_parent_output_dir(
     assert calls == [tmp_path]
 
 
+@pytest.mark.parametrize("operation", ["stage", "prepare", "review"])
+@pytest.mark.parametrize("position", ["before", "after"])
+def test_process_profile_update_no_color_works_around_nested_operations(
+    monkeypatch, operation, position
+):
+    calls = []
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 0
+
+    monkeypatch.setattr(app, f"_run_{operation}_profile_update_session", record)
+    session = [] if operation == "stage" else ["2026-08-04T15-30-00Z"]
+    argv = ["process-profile-updates"]
+    if position == "before":
+        argv.append("--no-color")
+    argv.extend([operation, *session])
+    if position == "after":
+        argv.append("--no-color")
+
+    assert app.main(argv) == 0
+    assert calls[0][1]["color_mode"] == app.ColorMode.NEVER
+
+
 def test_process_profile_updates_reports_authentication_and_safe_stop(
     monkeypatch, tmp_path
 ):
@@ -589,6 +614,21 @@ def test_process_profile_updates_cli_reports_processing_failure(monkeypatch, cap
         "Process profile updates failed: manual verification failed"
         in capsys.readouterr().err
     )
+
+
+def test_process_profile_update_failure_is_red_on_a_supported_terminal(monkeypatch):
+    class TerminalBuffer(StringIO):
+        def isatty(self):
+            return True
+
+    stream = TerminalBuffer()
+    monkeypatch.setattr("sys.stderr", stream)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+
+    app.print_profile_error("Process profile updates failed: example")
+
+    assert "\x1b[91mProcess profile updates failed: example\x1b[0m" in stream.getvalue()
 
 
 def test_rename_cli_previews_by_default_and_apply_is_explicit(monkeypatch):

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -3716,6 +3716,7 @@ def test_email_formatter_creates_one_paragraph_per_submitter():
     assert emails["first@example.com"].count("Thank you for updating") == 1
     assert "Company Name: Acme Steel" in emails["first@example.com"]
     assert "Billing City: Chicago" in emails["second@example.com"]
+    assert all("\x1b[" not in body for body in emails.values())
 
 
 def test_unsent_response_closes_sources_but_keeps_case_pending(tmp_path):

--- a/tests/test_review_ui.py
+++ b/tests/test_review_ui.py
@@ -1,4 +1,6 @@
+import re
 from dataclasses import FrozenInstanceError
+from io import StringIO
 
 import pytest
 
@@ -13,17 +15,23 @@ from aisc_salesforce.review_ui import (
     AcknowledgementAnswer,
     ChoiceAnswer,
     ChoiceQuestion,
+    Heading,
     MappingComparison,
     MappingComparisonRow,
     ParentAccountChildValue,
     ParentAccountConflict,
     ParentAccountFieldConflict,
     ParentAccountNoActiveChildren,
+    ResponseEmail,
     ReviewChoice,
     ReviewQueueSnapshot,
     ScalarComparison,
+    StagedRowSummary,
     UnsupportedReviewInteractionError,
+    ValidationFeedback,
     ValueFragment,
+    ValueOrigin,
+    WarningNotice,
     styled,
 )
 
@@ -52,6 +60,153 @@ def test_review_dataclasses_are_frozen_and_keep_values_structured():
     assert event.proposed.value == "Acme Steel"
     with pytest.raises(FrozenInstanceError):
         event.label = "Other"  # type: ignore[misc]
+
+
+def test_value_fragment_origin_is_backward_compatible_and_renderer_neutral():
+    assert ValueFragment("old caller").origin is ValueOrigin.NEUTRAL
+    assert (
+        ValueFragment("submitted", ValueOrigin.SUBMITTED).origin
+        is ValueOrigin.SUBMITTED
+    )
+
+
+def test_cli_forced_color_uses_the_semantic_palette_and_literal_text():
+    output = []
+    ui = CLIReviewUI(output_fn=output.append, color_mode="always")
+
+    ui.display(
+        ScalarComparison(
+            "Company [Name]",
+            ValueFragment("Current [Salesforce]"),
+            ValueFragment("Submitted [value]", ValueOrigin.SUBMITTED),
+        )
+    )
+    ui.display(
+        StagedRowSummary(
+            ValueFragment("Acme"),
+            ValueFragment("Alex", ValueOrigin.SUBMITTED),
+            ValueFragment("alex@example.com", ValueOrigin.SUBMITTED),
+            ValueFragment("PU-1", ValueOrigin.SUBMITTED),
+            contact_details_supplemented=True,
+        )
+    )
+    ui.display(WarningNotice(styled("Warning [literal]")))
+    ui.display(ValidationFeedback(styled("Try [again]")))
+    ui.display(ResponseEmail(ValueFragment("alex@example.com"), "Hello [Alex]"))
+
+    rendered = "\n".join(output)
+    assert "\x1b[92mSubmitted [value]\x1b[0m" in rendered
+    assert "\x1b[93mNote: contact details were supplemented" in rendered
+    assert "\x1b[91mWarning [literal]\x1b[0m" in rendered
+    assert "\x1b[91mTry [again]\x1b[0m" in rendered
+    assert "\x1b[94mHello [Alex]\x1b[0m" in rendered
+    assert "Current [Salesforce]" in rendered
+
+
+def test_cli_keeps_neutral_events_uncolored_even_when_color_is_forced():
+    output = []
+    ui = CLIReviewUI(output_fn=output.append, color_mode="always")
+
+    ui.display(Heading(styled("Account Updates"), "=" * 4))
+    ui.display(ScalarComparison("Name", ValueFragment("Old"), ValueFragment("New")))
+    ui.display(ReviewQueueSnapshot(build_review_queue([])))
+
+    assert all("\x1b[" not in value for value in output)
+
+
+@pytest.mark.parametrize("color_mode", [None, "never", False])
+def test_cli_custom_output_is_plain_unless_color_is_forced(color_mode):
+    output = []
+    ui = CLIReviewUI(output_fn=output.append, color_mode=color_mode)
+
+    ui.display(
+        ScalarComparison(
+            "Name",
+            ValueFragment("Old"),
+            ValueFragment("New", ValueOrigin.SUBMITTED),
+        )
+    )
+
+    assert "\x1b[" not in output[0]
+
+
+def test_cli_no_color_environment_disables_ansi_on_a_supported_terminal(
+    monkeypatch,
+):
+    class TerminalBuffer(StringIO):
+        def isatty(self):
+            return True
+
+    stream = TerminalBuffer()
+    monkeypatch.setattr("sys.stdout", stream)
+    monkeypatch.setenv("NO_COLOR", "1")
+    ui = CLIReviewUI()
+
+    ui.display(
+        ScalarComparison(
+            "Name",
+            ValueFragment("Old"),
+            ValueFragment("New", ValueOrigin.SUBMITTED),
+        )
+    )
+
+    assert "\x1b[" not in stream.getvalue()
+
+
+def test_cli_auto_color_uses_ansi_on_a_supported_terminal(monkeypatch):
+    class TerminalBuffer(StringIO):
+        def isatty(self):
+            return True
+
+    stream = TerminalBuffer()
+    monkeypatch.setattr("sys.stdout", stream)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    ui = CLIReviewUI()
+
+    ui.display(
+        ScalarComparison(
+            "Name",
+            ValueFragment("Old"),
+            ValueFragment("New", ValueOrigin.SUBMITTED),
+        )
+    )
+
+    assert "\x1b[92mNew\x1b[0m" in stream.getvalue()
+
+
+@pytest.mark.parametrize("terminal", [False, True])
+def test_cli_auto_color_falls_back_for_redirection_and_dumb_terminals(
+    monkeypatch, terminal
+):
+    class TerminalBuffer(StringIO):
+        def isatty(self):
+            return terminal
+
+    stream = TerminalBuffer()
+    monkeypatch.setattr("sys.stdout", stream)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    if terminal:
+        monkeypatch.setenv("TERM", "dumb")
+    ui = CLIReviewUI()
+
+    ui.display(WarningNotice(styled("Needs attention")))
+
+    assert "\x1b[" not in stream.getvalue()
+
+
+def test_forced_color_and_plain_rendering_have_identical_readable_text():
+    event = ScalarComparison(
+        "Company Name",
+        ValueFragment("Acme"),
+        ValueFragment("Acme [Steel]", ValueOrigin.SUBMITTED),
+    )
+    colored = []
+    plain = []
+    CLIReviewUI(output_fn=colored.append, color_mode="always").display(event)
+    CLIReviewUI(output_fn=plain.append, color_mode="never").display(event)
+
+    assert re.sub(r"\x1b\[[0-9;]*m", "", colored[0]) == plain[0]
 
 
 def test_cli_renders_scalar_and_mapping_comparisons_compatibly():

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { editable = "." }
 dependencies = [
     { name = "loguru" },
     { name = "requests" },
+    { name = "rich" },
     { name = "tzdata" },
 ]
 
@@ -27,6 +28,7 @@ dev = [
 requires-dist = [
     { name = "loguru", specifier = ">=0.7" },
     { name = "requests", specifier = ">=2.32" },
+    { name = "rich", specifier = ">=14.0" },
     { name = "tzdata", specifier = ">=2025.2" },
 ]
 
@@ -269,6 +271,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +332,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -640,6 +663,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add semantic terminal colors to profile update review output.
- Support `--no-color`, `NO_COLOR`, terminal detection, and plain-text generated artifacts.
- Add tests and documentation for the color behavior.

Closes #44