### PR TITLE
Add per-field Contact review

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,16 +535,16 @@ files fail validation.
 Each real field change accepts a shortcut or its complete decision phrase:
 
 - `A` or `apply automatically` writes the displayed value to Salesforce.
-- `M` or `make manually` pauses for the reviewer to make the change, then refetches
-  Salesforce and continues only if the value matches.
+- `M` or `make manually` defers the field to the manual follow-up section, then
+  refetches Salesforce to verify the result.
 - `N` or `will not be made` records the rejection without changing Salesforce.
 
 Shortcuts and phrases are case-insensitive. Audit entries always store the
 complete phrase.
 
 All staged-row checkpoints are completed before Salesforce changes begin. The
-review then prints three explicit sections in order: `Contact Updates`,
-`Account Updates`, and `Role Links`.
+review then prints four explicit sections in order: `Contact Updates`, `Manual
+Contact Follow-up`, `Account Updates`, and `Role Links`.
 
 The Contact section reloads every source Profile Update from Salesforce and
 collects only nonblank Contact values that were explicitly submitted for the
@@ -574,21 +574,25 @@ is resolved before the first Contact write.
 
 After reconciliation, the heading identifies the person and email rather than
 leading with a role. One Contact-level table shows each current value,
-reconciled value, and source. The final comparison uses readable field lines
-instead of printing a Python dictionary. For example:
+reconciled value, and source. Each changed First Name, Last Name, Title, Email,
+and Phone field then receives its own `A`, `M`, or `N` decision. Already-current
+fields are audited no-ops and do not prompt.
 
 ```text
-Salesforce changes:
-Title: Old Title -> Owner
-Phone: 312.555.0101 -> 312.555.0199
+Contact Title: Alex Smith <alex@example.com>
+Current Salesforce value: Old Title
+Proposed value: Owner
 ```
 
-One `A`, `M`, or `N` decision applies to the complete Contact. An automatic
-decision makes at most one Contact `update_record` call, or creates a shared
-new Contact once. A manual decision verifies all proposed fields together. A
-rejected Contact is unchanged. Source-to-Contact mappings are preserved after
-creation and email changes, so the final role section can reuse the same
-resolved Contact safely.
+Approved fields are grouped into at most one automatic Contact update or create;
+rejected and manual fields are omitted from that payload. A new Contact requires
+an approved Last Name for automatic creation. After all automatic Contact work
+finishes, `Manual Contact Follow-up` processes manual fields one at a time. If a
+fresh Salesforce value differs from the submission, the reviewer sees both
+values and may accept Salesforce's value; Enter defaults to `yes`. Declining
+fails verification, leaves the Case and submissions open, and permits a later
+retry. Source-to-Contact mappings are preserved so role links and response text
+use a final refreshed Contact.
 
 Non-role Account changes run after every Contact is complete. The `Role Links`
 section runs last and may update only Account lookup fields; it never creates
@@ -644,12 +648,11 @@ is the first unblocked pending change and becomes `null` when none remains.
 The JSON Lines audit is flushed after every decision and Salesforce result.
 Contact events include classification, comparison key, candidates, selected
 Contact, reason, confidence, and warnings. Each conflict choice is an explicit
-event containing its candidate values and sources. Each reconciled Contact has
-one aggregate create/update event containing the final field dictionary and
-all source submission IDs. This structured dictionary remains in the JSON audit
-for machine-readable traceability, but it is not printed as the reviewer-facing
-comparison. Operator identity selections, duplicate recovery, ignored entries,
-Case Contact assignment, and role assignments remain separate events.
+event containing its candidate values and sources. Each Contact field has its
+own result with the submitted `proposed_value` and authoritative `final_value`.
+Those values differ when the reviewer accepts a manual Salesforce override.
+Operator identity selections, duplicate recovery, ignored entries, Case Contact
+assignment, and role assignments remain separate events.
 The response file contains one generated paragraph per submitter email.
 Account-information changes keep the `ITEM: NEW INFORMATION` and
 `Replaces OLD INFORMATION` format. Each submitted Contact role is consolidated

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -501,7 +501,7 @@ Contact roles. It does this before role resolution, CSV projection, and
 - Submitter names, role first and last names, and role titles are trimmed and
   changed to Proper Case. Punctuation is preserved.
 - Case-insensitive whole-token exceptions preserve these spellings: `CEO`,
-  `CFO`, `COO`, `CTO`, `VP`, `HR`, `QA`, `QC`, `QMS`, `IT`, `ISO`, `AWS`,
+  `CFO`, `COO`, `CTO`, `VP`, `HR`, `QA`, `QC`, `QMS`, `AISC`, `IT`, `ISO`, `AWS`,
   `API`, `AI`, `PhD`, `MBA`, `iOS`, `macOS`, `McDonald`, `MacKenzie`, and
   `O'Connor`.
 - A recognizable ten-digit North American phone, optionally prefixed by `1` or
@@ -853,7 +853,7 @@ checkpoint. For a real change, choose an explicit decision:
 | Shortcut | Complete phrase | Result |
 |---|---|---|
 | `A` | `apply automatically` | Update Salesforce with the proposed value |
-| `M` | `make manually` | Pause, refetch, and verify the reviewer’s Salesforce change |
+| `M` | `make manually` | Defer the field, then refetch and verify it during manual follow-up |
 | `N` | `will not be made` | Record the rejection without a Salesforce data change |
 
 Decision shortcuts and complete phrases are case-insensitive. The JSON Lines
@@ -866,8 +866,9 @@ All row checkpoints are shown before the first Salesforce write. Processing
 then prints and completes these ordered phases:
 
 1. `Contact Updates`
-2. `Account Updates`
-3. `Role Links`
+2. `Manual Contact Follow-up`
+3. `Account Updates`
+4. `Role Links`
 
 ### Contact Updates
 
@@ -906,29 +907,49 @@ identity and field-conflict choices finish before any Contact is written.
 
 A final heading identifies each Contact by person and email, independent of
 role. Its table shows `Field`, `Current Salesforce`, `Reconciled`, and
-`Sources`. The decision summary displays readable lines instead of a Python
-dictionary:
+`Sources`. The processor then presents First Name, Last Name, Title, Email, and
+Phone as independent decisions. An already-current submitted field is an
+audited no-op and does not prompt. A changed field displays a readable scalar
+comparison:
 
 ```text
-Salesforce changes:
-Title: Old Title -> Owner
-Phone: 312.555.0101 -> 312.555.0199
+Contact Title: Alex Smith <alex@example.com>
+Current Salesforce value: Old Title
+Proposed value: Owner
 ```
 
-A new Contact similarly appears under `New Salesforce values`, with one
-labeled field per line. The reviewer then makes one `A`, `M`, or `N` decision
-for the complete Contact:
+A reviewer can therefore approve, defer, or reject different fields on the same
+Contact:
 
-- `A` updates all changed fields in one `update_record` call, or creates a
-  shared new Contact once.
-- `M` pauses for a manual change and verifies all reconciled fields together.
-- `N` leaves the Contact unchanged.
+- `A` adds that field to one grouped automatic Contact payload.
+- `M` omits that field from the automatic payload and defers it to manual
+  follow-up.
+- `N` omits that field from writes and records the rejection.
 
-Thus each resolved Contact has at most one automated Contact create or update
-call in a run. A Contact already matching every reconciled value is an audited
-no-op without a decision prompt. If a new submitter Contact is created, its ID
-is assigned to `Case.ContactId`; matching an existing submitter alone does not
-change that Case lookup.
+All decisions are collected before the first Contact write. Approved fields are
+then combined, so each resolved Contact has at most one automatic create or
+update call in a run. Rejected and manual fields are absent from that payload.
+A new Contact requires an approved Last Name for automatic creation. If Last
+Name is manual, the reviewer uses the manual-creation path and the processor
+verifies the other approved values; if safe creation is impossible, processing
+fails without creating a partial Contact. If every new-Contact field is
+rejected, no Contact or role link is created. When a new submitter Contact is
+created, its ID is assigned to `Case.ContactId`; matching an existing submitter
+alone does not change that Case lookup.
+
+After every automatic Contact has finished, a visibly separated `Manual Contact
+Follow-up` heading reminds the reviewer that external Salesforce edits begin.
+Manual fields are processed one at a time. After each acknowledgement, the
+processor refetches that field. A matching value is verified immediately. When
+Salesforce contains a different value, the processor displays both the
+submitted proposal and fresh Salesforce value, then asks whether the Salesforce
+value should be accepted. Enter defaults to `yes`; acceptance makes the fresh
+Salesforce value authoritative. Declining records a failed verification, keeps
+the Case and source submissions open, and leaves the batch retryable. An
+interruption or Salesforce read failure has the same safe open-batch behavior.
+Every completed Contact is refreshed again before role-link decisions and
+response generation, so downstream names, titles, emails, and phones reflect
+the actual final Salesforce record.
 
 ### Account Updates and Role Links
 
@@ -1034,19 +1055,24 @@ records are closed and the Case stays `Pending`.
 Contact audit objects include classification, comparison key, candidates,
 selected Contact, reason, confidence, and warnings. Every field-conflict
 selection is an explicit event that records the candidate values and their
-sources. A single aggregate Contact create/update event records the final field
-dictionary and every source submission ID for that Contact. The dictionary is
-kept in JSON for machine-readable auditing; the interactive comparison uses the
-readable field lines shown above. Operator identity selections, duplicate
-recovery, ignored entries, Case Contact assignment, and later Account-role
-assignments are separate, immediately flushed events.
+sources. The final Contact outcome is stored per Salesforce field, even though
+approved fields share one automatic write. Each field result records its full
+decision phrase, submitted `proposed_value`, and authoritative `final_value`.
+For ordinary applied, rejected, and no-op results this remains backward
+compatible with the proposal or original value; for an accepted manual
+override, `final_value` preserves the fresh Salesforce value separately from
+the submission. Contact queue entries transition independently while queue
+schema version `1` and its stable field IDs remain unchanged. Operator identity
+selections, duplicate recovery, ignored entries, Case Contact assignment, and
+later Account-role assignments are separate, immediately flushed events.
 
-On interruption, an unrelated Salesforce failure, or a manual value that does not verify,
-the audit is flushed, unfinalized source Profile Updates stay open, the Case is
-kept Pending, and the command exits nonzero. Retry with `review SESSION_ID` to
-reload the saved artifacts and refresh only the captured records. Values
-applied before the interruption are fetched again and recorded as no-ops, so
-they are not applied or emailed twice.
+On interruption, an unrelated Salesforce failure, a failed manual read, or a
+differing manual value that the reviewer declines, the audit is flushed,
+unfinalized source Profile Updates stay open, the Case is kept Pending, and the
+command exits nonzero. Retry with `review SESSION_ID` to reload the saved
+artifacts and refresh only the captured records. Values applied before the
+interruption are fetched again and recorded as no-ops, so they are not applied
+or emailed twice.
 
 `Q` or `Quit` is different from an error or keyboard interruption. It writes a
 `stopped early` audit event, keeps the current Case Pending, leaves that Case's

--- a/src/aisc_salesforce/contact_normalization.py
+++ b/src/aisc_salesforce/contact_normalization.py
@@ -18,6 +18,7 @@ CONTACT_CASE_EXCEPTIONS = (
     "QA",
     "QC",
     "QMS",
+    "AISC",
     "IT",
     "ISO",
     "AWS",

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -201,6 +201,9 @@ class ActionStatus(StrEnum):
     DEFERRED_MANUAL = "deferred manual follow-up"
 
 
+_FINAL_VALUE_UNSET = object()
+
+
 @dataclass(frozen=True)
 class ChangeProposal:
     """One proposed field or record change shown to the reviewer."""
@@ -238,6 +241,7 @@ class ActionResult:
     error: str = ""
     error_code: str = ""
     salesforce_message: str = ""
+    final_value: Any = _FINAL_VALUE_UNSET
 
 
 @dataclass
@@ -354,8 +358,9 @@ class _ContactWorkItem:
     current_contact: dict[str, Any] | None = None
     reconciled: dict[str, str] | None = None
     write_values: dict[str, str] | None = None
-    decision: ReviewDecision | None = None
-    result: ActionResult | None = None
+    decisions: dict[str, ReviewDecision] | None = None
+    results: dict[str, ActionResult] | None = None
+    submitter_assigned: bool = False
 
     @property
     def sources(self) -> list[ContactSource]:
@@ -1175,6 +1180,20 @@ class _AuditWriter:
             "label": proposal.label,
             "original_value": proposal.original_value,
             "proposed_value": proposal.proposed_value,
+            "final_value": (
+                result.final_value
+                if result.final_value is not _FINAL_VALUE_UNSET
+                else (
+                    proposal.proposed_value
+                    if result.status
+                    in {
+                        ActionStatus.APPLIED,
+                        ActionStatus.VERIFIED_MANUAL,
+                        ActionStatus.NOOP,
+                    }
+                    else proposal.original_value
+                )
+            ),
             "context": proposal.context,
             "warnings": proposal.warnings,
             "classification": proposal.classification,
@@ -1739,12 +1758,20 @@ class InteractiveProfileUpdateProcessor:
         for item in contact_items:
             self._reconcile_contact_fields(batch, item)
         for item in contact_items:
-            self._prepare_contact_decision(batch, item)
+            self._prepare_contact_decisions(batch, item)
 
         results: list[ActionResult] = []
         for item in contact_items:
-            contact_results = self._execute_contact_work(batch, item)
-            results.extend(contact_results)
+            results.extend(self._execute_automatic_contact_work(batch, item))
+
+        self._display_event(
+            Heading(styled("Manual Contact Follow-up"), STAGE_SEPARATOR)
+        )
+        for item in contact_items:
+            results.extend(self._execute_manual_contact_work(batch, item))
+        self._refresh_completed_contacts(contact_items)
+        for item in contact_items:
+            results.extend((item.results or {}).values())
 
         self._display_event(Heading(styled("Account Updates"), STAGE_SEPARATOR))
         account_results: list[ActionResult] = []
@@ -2326,38 +2353,17 @@ class InteractiveProfileUpdateProcessor:
             )
         self._display_event(ContactComparison(ValueFragment(identity), tuple(rows)))
 
-    def _prepare_contact_decision(
+    def _prepare_contact_decisions(
         self,
         batch: CaseBatch,
         item: _ContactWorkItem,
     ) -> None:
-        """Show one final Contact proposal and collect one A/M/N decision."""
+        """Show one Contact table, then decide each submitted field separately."""
         if item.ignored:
             return
         self._show_reconciled_contact(item)
-        payload = dict(item.write_values or {})
-        if not item.contact_id:
-            payload = {"AccountId": batch.account_id, **payload}
-        proposal = self._contact_proposal(
-            batch,
-            item,
-            field_name="Contact",
-            label=f"Contact: {self._contact_review_identity(item)}",
-            original_value=item.current_contact or {},
-            proposed_value=payload,
-        )
-        if item.contact_id and not item.write_values:
-            item.result = ActionResult(
-                proposal,
-                None,
-                ActionStatus.NOOP,
-                action="reconciled Contact already current",
-            )
-            self._append_audit(item.result)
-            self._display_event(
-                Notice(styled("Contact is already current; no change needed."))
-            )
-            return
+        item.decisions = {}
+        item.results = {}
         has_last_name = bool((item.reconciled or {}).get("last_name"))
         if not item.contact_id and not has_last_name:
             self._display_event(
@@ -2368,171 +2374,289 @@ class InteractiveProfileUpdateProcessor:
                     )
                 )
             )
-        self._show_proposal(proposal)
-        item.decision = self._review_decision(
-            proposal,
-            automatic_allowed=bool(item.contact_id)
-            or (has_last_name and bool(item.resolution.comparison_key)),
-            action="review reconciled Contact",
+
+        current = item.current_contact or {}
+        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+            if suffix not in (item.reconciled or {}):
+                continue
+            proposal = self._contact_field_proposal(
+                batch, item, suffix, contact_field, field_label
+            )
+            if _values_equal(current.get(contact_field), proposal.proposed_value):
+                result = ActionResult(
+                    proposal,
+                    None,
+                    ActionStatus.NOOP,
+                    action="Contact field already current",
+                    final_value=current.get(contact_field),
+                )
+                item.results[contact_field] = result
+                self._append_audit(result)
+                self._display_event(
+                    Notice(
+                        styled(
+                            ValueFragment(field_label),
+                            ": already current; no change needed.",
+                        )
+                    )
+                )
+                continue
+
+            self._show_proposal(proposal)
+            decision = self._review_decision(
+                proposal,
+                automatic_allowed=bool(item.contact_id) or has_last_name,
+                action=f"review Contact {field_label}",
+            )
+            item.decisions[contact_field] = decision
+            if decision is ReviewDecision.WILL_NOT_BE_MADE:
+                result = ActionResult(
+                    proposal,
+                    decision,
+                    ActionStatus.REJECTED,
+                    action="no Contact field write",
+                    final_value=current.get(contact_field),
+                )
+                item.results[contact_field] = result
+                self._append_audit(result)
+
+    def _contact_field_proposal(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+        suffix: str,
+        contact_field: str,
+        field_label: str,
+    ) -> ChangeProposal:
+        """Build the audit and queue identity for one Contact field."""
+        return self._contact_proposal(
+            batch,
+            item,
+            field_name=contact_field,
+            label=f"Contact {field_label}: {self._contact_review_identity(item)}",
+            original_value=(item.original_contact or {}).get(contact_field),
+            proposed_value=(item.reconciled or {}).get(suffix, ""),
         )
 
-    def _execute_contact_work(
+    def _execute_automatic_contact_work(
         self,
         batch: CaseBatch,
         item: _ContactWorkItem,
     ) -> list[ActionResult]:
-        """Apply or verify one aggregate Contact decision."""
+        """Apply every approved field in at most one automatic Contact write."""
         if item.ignored:
             return []
-        if item.result is not None:
-            return [item.result]
-        proposal = self._contact_proposal(
-            batch,
-            item,
-            field_name="Contact",
-            label=f"Contact: {self._contact_review_identity(item)}",
-            original_value=item.current_contact or {},
-            proposed_value=(
-                dict(item.write_values or {})
-                if item.contact_id
-                else {"AccountId": batch.account_id, **dict(item.write_values or {})}
-            ),
-        )
-        decision = item.decision
-        if decision is ReviewDecision.WILL_NOT_BE_MADE:
-            result = ActionResult(
-                proposal,
-                decision,
-                ActionStatus.REJECTED,
-                action="no Contact write",
+        decisions = item.decisions or {}
+        approved = {
+            field_name: value
+            for field_name, value in (item.write_values or {}).items()
+            if decisions.get(field_name) is ReviewDecision.APPLY_AUTOMATICALLY
+        }
+        if not approved:
+            return []
+
+        if not item.contact_id and (
+            decisions.get("LastName") is not ReviewDecision.APPLY_AUTOMATICALLY
+        ):
+            if any(
+                decision is ReviewDecision.MAKE_MANUALLY
+                for decision in decisions.values()
+            ):
+                return []
+            error = "A new Contact requires an approved Last Name."
+            self._fail_contact_fields(
+                batch, item, approved, error, action="create Contact"
             )
-            self._append_audit(result)
-            item.result = result
-            return [result]
-        if decision is ReviewDecision.MAKE_MANUALLY:
-            result = self._verify_manual_contact(batch, item, proposal)
-        elif item.contact_id:
+            raise ProcessingError(error)
+
+        action = (
+            "update Contact from approved fields"
+            if item.contact_id
+            else "create Contact from approved fields"
+        )
+        result_status = ActionStatus.APPLIED
+        recovery_error: SalesforceError | None = None
+        original_target = item.contact_id
+        if item.contact_id:
             try:
-                self._update_record(
-                    "Contact", item.contact_id, dict(item.write_values or {})
-                )
+                self._update_record("Contact", item.contact_id, approved)
             except SalesforceError as error:
-                result = ActionResult(
-                    proposal,
-                    decision,
-                    ActionStatus.FAILED,
-                    action="update Contact from reconciled proposals",
-                    error=str(error),
+                self._fail_contact_fields(
+                    batch,
+                    item,
+                    approved,
+                    str(error),
+                    action=action,
                     error_code=error.error_code or "",
                     salesforce_message=error.salesforce_message or "",
                 )
-                self._append_audit(result)
                 raise ProcessingError(str(error)) from error
-            result = ActionResult(
-                proposal,
-                decision,
-                ActionStatus.APPLIED,
-                action="update Contact from reconciled proposals",
-            )
-            self._append_audit(result)
         else:
+            payload = {"AccountId": batch.account_id, **approved}
+            aggregate = self._contact_proposal(
+                batch,
+                item,
+                field_name="Contact",
+                label=f"Contact: {self._contact_review_identity(item)}",
+                original_value={},
+                proposed_value=payload,
+            )
             try:
-                contact_id = self._create_record(
-                    "Contact", dict(proposal.proposed_value)
-                )
+                item.contact_id = self._create_record("Contact", payload)
             except SalesforceError as error:
                 if _is_duplicate_contact_error(error):
-                    result = self._recover_duplicate_contact(
+                    recovery = self._recover_duplicate_contact(
                         batch,
                         item.row,
-                        proposal,
+                        aggregate,
                         item.resolution,
                         error,
+                        append_audit=False,
                     )
-                    contact_id = result.proposal.target_record_id
+                    if recovery.status is ActionStatus.REJECTED:
+                        item.ignored = True
+                        for field_name in approved:
+                            suffix, field_label = self._contact_field_metadata(field_name)
+                            proposal = self._contact_field_proposal(
+                                batch, item, suffix, field_name, field_label
+                            )
+                            result = ActionResult(
+                                proposal,
+                                ReviewDecision.WILL_NOT_BE_MADE,
+                                ActionStatus.REJECTED,
+                                action=recovery.action,
+                                error=recovery.error,
+                                error_code=recovery.error_code,
+                                salesforce_message=recovery.salesforce_message,
+                                final_value=proposal.original_value,
+                            )
+                            item.results[field_name] = result
+                            self._append_audit(result)
+                        return []
+                    item.contact_id = recovery.proposal.target_record_id
+                    item.current_contact = dict(
+                        item.resolution.selected_contact or {}
+                    )
+                    action = recovery.action
+                    result_status = ActionStatus.VERIFIED_MANUAL
+                    recovery_error = error
                 else:
-                    result = ActionResult(
-                        proposal,
-                        decision,
-                        ActionStatus.FAILED,
-                        action="create Contact",
-                        error=str(error),
+                    self._fail_contact_fields(
+                        batch,
+                        item,
+                        approved,
+                        str(error),
+                        action=action,
                         error_code=error.error_code or "",
                         salesforce_message=error.salesforce_message or "",
                     )
-                    self._append_audit(result)
                     raise ProcessingError(str(error)) from error
-            else:
-                created_proposal = ChangeProposal(
-                    **{
-                        **proposal.__dict__,
-                        "target_record_id": contact_id,
-                        "selected_contact": contact_snapshot(
-                            {"Id": contact_id, **dict(proposal.proposed_value)}
-                        ),
-                    }
-                )
-                result = ActionResult(
-                    created_proposal,
-                    decision,
-                    ActionStatus.APPLIED,
-                    action="create Contact",
-                )
-                self._append_audit(result)
-            if result.status in {
-                ActionStatus.APPLIED,
-                ActionStatus.VERIFIED_MANUAL,
-            }:
-                item.contact_id = contact_id
 
-        item.result = result
-        results = [result]
-        if result.status in {
-            ActionStatus.APPLIED,
-            ActionStatus.VERIFIED_MANUAL,
-        }:
-            item.current_contact = self.client.get_record(
-                "Contact", item.contact_id, CONTACT_REVIEW_FIELDS
+        if result_status is ActionStatus.APPLIED:
+            item.current_contact = {
+                **(item.current_contact or {}),
+                "Id": item.contact_id,
+                **approved,
+            }
+        item.resolution.selected_contact = item.current_contact
+        for field_name, proposed_value in approved.items():
+            suffix, field_label = self._contact_field_metadata(field_name)
+            proposal = self._contact_field_proposal(
+                batch, item, suffix, field_name, field_label
             )
-            item.resolution.selected_contact = item.current_contact
-            if (
-                not proposal.target_record_id or proposal.target_record_id == "(new)"
-            ) and any(source.kind == "submitter" for source in item.sources):
-                results.append(
-                    self._assign_created_submitter_to_case(
-                        batch,
-                        item.row,
-                        item.resolution,
-                        item.contact_id,
-                    )
-                )
-        return results
+            proposal = replace(proposal, target_record_id=item.contact_id)
+            final_value = (
+                proposed_value
+                if result_status is ActionStatus.APPLIED
+                else (item.current_contact or {}).get(field_name)
+            )
+            result = ActionResult(
+                proposal,
+                ReviewDecision.APPLY_AUTOMATICALLY,
+                result_status,
+                action=action,
+                error=str(recovery_error) if recovery_error is not None else "",
+                error_code=(
+                    recovery_error.error_code or ""
+                    if recovery_error is not None
+                    else ""
+                ),
+                salesforce_message=(
+                    recovery_error.salesforce_message or ""
+                    if recovery_error is not None
+                    else ""
+                ),
+                final_value=final_value,
+            )
+            item.results[field_name] = result
+            self._append_audit(result)
 
-    def _verify_manual_contact(
+        if not original_target:
+            return self._assign_created_submitter_if_needed(batch, item)
+        return []
+
+    def _fail_contact_fields(
         self,
         batch: CaseBatch,
         item: _ContactWorkItem,
-        proposal: ChangeProposal,
-    ) -> ActionResult:
-        """Verify all reconciled Contact fields together."""
-        try:
-            if item.contact_id:
-                self._acknowledge(
-                    AcknowledgementQuestion(
-                        styled(
-                            "Make the complete Contact change in Salesforce, then "
-                            "press Enter to verify it: "
-                        )
-                    )
-                )
-                contact_id = item.contact_id
-            else:
+        values: dict[str, str],
+        error: str,
+        *,
+        action: str,
+        error_code: str = "",
+        salesforce_message: str = "",
+    ) -> None:
+        """Audit the same grouped-write failure against each approved field."""
+        for field_name in values:
+            suffix, field_label = self._contact_field_metadata(field_name)
+            proposal = self._contact_field_proposal(
+                batch, item, suffix, field_name, field_label
+            )
+            result = ActionResult(
+                proposal,
+                ReviewDecision.APPLY_AUTOMATICALLY,
+                ActionStatus.FAILED,
+                action=action,
+                error=error,
+                error_code=error_code,
+                salesforce_message=salesforce_message,
+                final_value=proposal.original_value,
+            )
+            item.results[field_name] = result
+            self._append_audit(result)
+
+    def _execute_manual_contact_work(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+    ) -> list[ActionResult]:
+        """Process manual fields only after every automatic Contact write."""
+        if item.ignored:
+            return []
+        decisions = item.decisions or {}
+        manual_fields = [
+            field_name
+            for field_name, decision in decisions.items()
+            if decision is ReviewDecision.MAKE_MANUALLY
+        ]
+        if not manual_fields:
+            return []
+
+        created_manually = not item.contact_id
+        if created_manually:
+            first_field = manual_fields[0]
+            suffix, field_label = self._contact_field_metadata(first_field)
+            proposal = self._contact_field_proposal(
+                batch, item, suffix, first_field, field_label
+            )
+            try:
                 while True:
                     contact_id = self._ask_free_text(
                         FreeTextQuestion(
                             styled(
-                                "Create the Contact in Salesforce, then enter its "
-                                "Contact ID: "
+                                "Create the Contact in Salesforce using every "
+                                "approved and manual field, then enter its Contact "
+                                "ID: "
                             )
                         )
                     ).strip()
@@ -2543,79 +2667,206 @@ class InteractiveProfileUpdateProcessor:
                             styled("A Contact ID is required for manual verification.")
                         )
                     )
-            fresh = self.client.get_record("Contact", contact_id, CONTACT_REVIEW_FIELDS)
-        except (KeyboardInterrupt, EOFError) as error:
-            result = ActionResult(
-                proposal,
-                ReviewDecision.MAKE_MANUALLY,
-                ActionStatus.INTERRUPTED,
-                action="verify reconciled Contact manually",
-                error="Reviewer interrupted processing.",
+                fresh = self.client.get_record(
+                    "Contact", contact_id, CONTACT_REVIEW_FIELDS
+                )
+            except (KeyboardInterrupt, EOFError) as error:
+                self._manual_contact_failure(
+                    item,
+                    proposal,
+                    ActionStatus.INTERRUPTED,
+                    "Reviewer interrupted processing.",
+                )
+                raise ProcessingInterrupted(
+                    "Profile Update review was interrupted."
+                ) from error
+            except SalesforceError as error:
+                self._manual_contact_failure(
+                    item, proposal, ActionStatus.FAILED, str(error)
+                )
+                raise ProcessingError(str(error)) from error
+            if not _values_equal(fresh.get("AccountId"), batch.account_id):
+                error = "The manually created Contact belongs to a different Account."
+                self._manual_contact_failure(
+                    item, proposal, ActionStatus.FAILED, error
+                )
+                raise ProcessingError(error)
+            item.contact_id = contact_id
+            item.current_contact = fresh
+            item.resolution.selected_contact = fresh
+
+            for field_name, decision in decisions.items():
+                if decision is not ReviewDecision.APPLY_AUTOMATICALLY:
+                    continue
+                suffix, field_label = self._contact_field_metadata(field_name)
+                approved_proposal = replace(
+                    self._contact_field_proposal(
+                        batch, item, suffix, field_name, field_label
+                    ),
+                    target_record_id=contact_id,
+                )
+                final_value = fresh.get(field_name)
+                if not _values_equal(final_value, approved_proposal.proposed_value):
+                    error = (
+                        "The manually created Contact does not match an approved "
+                        f"{field_label} value."
+                    )
+                    result = ActionResult(
+                        approved_proposal,
+                        decision,
+                        ActionStatus.FAILED,
+                        action="verify approved field after manual Contact creation",
+                        error=error,
+                        final_value=final_value,
+                    )
+                    item.results[field_name] = result
+                    self._append_audit(result)
+                    raise ProcessingError(error)
+                result = ActionResult(
+                    approved_proposal,
+                    decision,
+                    ActionStatus.VERIFIED_MANUAL,
+                    action="verify approved field after manual Contact creation",
+                    final_value=final_value,
+                )
+                item.results[field_name] = result
+                self._append_audit(result)
+
+        for field_name in manual_fields:
+            self._verify_manual_contact_field(batch, item, field_name)
+
+        if created_manually:
+            return self._assign_created_submitter_if_needed(batch, item)
+        return []
+
+    def _verify_manual_contact_field(
+        self,
+        batch: CaseBatch,
+        item: _ContactWorkItem,
+        field_name: str,
+    ) -> None:
+        suffix, field_label = self._contact_field_metadata(field_name)
+        proposal = self._contact_field_proposal(
+            batch, item, suffix, field_name, field_label
+        )
+        proposal = replace(proposal, target_record_id=item.contact_id)
+        try:
+            self._acknowledge(
+                AcknowledgementQuestion(
+                    styled(
+                        "Make the Contact ",
+                        ValueFragment(field_label),
+                        " change in Salesforce, then press Enter to verify it: ",
+                    )
+                )
             )
-            self._append_audit(result)
+            fresh = self.client.get_record("Contact", item.contact_id, ["Id", field_name])
+            final_value = fresh.get(field_name)
+            if not _values_equal(final_value, proposal.proposed_value):
+                self._display_event(
+                    ScalarComparison(
+                        f"Manual Contact {field_label} verification",
+                        ValueFragment(_display(final_value)),
+                        ValueFragment(
+                            _display(proposal.proposed_value), ValueOrigin.SUBMITTED
+                        ),
+                    )
+                )
+                accepted = self._prompt_yes_no(
+                    styled(
+                        "Accept the current Salesforce ",
+                        ValueFragment(field_label),
+                        " value? [yes/no] (default yes): ",
+                    ),
+                    default_yes=True,
+                )
+                if not accepted:
+                    error = "The differing Salesforce Contact value was not accepted."
+                    self._manual_contact_failure(
+                        item,
+                        proposal,
+                        ActionStatus.FAILED,
+                        error,
+                        final_value=final_value,
+                    )
+                    raise ProcessingError(error)
+        except (KeyboardInterrupt, EOFError) as error:
+            self._manual_contact_failure(
+                item,
+                proposal,
+                ActionStatus.INTERRUPTED,
+                "Reviewer interrupted processing.",
+            )
             raise ProcessingInterrupted(
                 "Profile Update review was interrupted."
             ) from error
-        except ProcessingError as error:
-            result = ActionResult(
-                proposal,
-                ReviewDecision.MAKE_MANUALLY,
-                ActionStatus.FAILED,
-                action="verify reconciled Contact manually",
-                error=str(error),
-            )
-            self._append_audit(result)
-            raise
         except SalesforceError as error:
-            result = ActionResult(
-                proposal,
-                ReviewDecision.MAKE_MANUALLY,
-                ActionStatus.FAILED,
-                action="verify reconciled Contact manually",
-                error=str(error),
+            self._manual_contact_failure(
+                item, proposal, ActionStatus.FAILED, str(error)
             )
-            self._append_audit(result)
             raise ProcessingError(str(error)) from error
-        expected = item.write_values or {}
-        if not item.contact_id:
-            expected = {
-                field_name: value
-                for field_name, value in proposal.proposed_value.items()
-                if field_name != "AccountId"
-            }
-        if (
-            not item.contact_id
-            and not _values_equal(fresh.get("AccountId"), batch.account_id)
-        ) or any(
-            not _values_equal(fresh.get(field_name), value)
-            for field_name, value in expected.items()
-        ):
-            error = "Salesforce Contact does not match all reconciled proposed fields."
-            result = ActionResult(
-                proposal,
-                ReviewDecision.MAKE_MANUALLY,
-                ActionStatus.FAILED,
-                action="verify reconciled Contact manually",
-                error=error,
-            )
-            self._append_audit(result)
-            raise ProcessingError(error)
-        item.contact_id = contact_id
-        verified_proposal = ChangeProposal(
-            **{
-                **proposal.__dict__,
-                "target_record_id": contact_id,
-                "selected_contact": contact_snapshot(fresh),
-            }
-        )
+
         result = ActionResult(
-            verified_proposal,
+            proposal,
             ReviewDecision.MAKE_MANUALLY,
             ActionStatus.VERIFIED_MANUAL,
-            action="verify reconciled Contact manually",
+            action="verify Contact field manually",
+            final_value=final_value,
         )
+        item.results[field_name] = result
         self._append_audit(result)
-        return result
+        item.current_contact = {**(item.current_contact or {}), field_name: final_value}
+
+    def _manual_contact_failure(
+        self,
+        item: _ContactWorkItem,
+        proposal: ChangeProposal,
+        status: ActionStatus,
+        error: str,
+        *,
+        final_value: Any = _FINAL_VALUE_UNSET,
+    ) -> None:
+        result = ActionResult(
+            proposal,
+            ReviewDecision.MAKE_MANUALLY,
+            status,
+            action="verify Contact field manually",
+            error=error,
+            final_value=final_value,
+        )
+        item.results[proposal.field_name] = result
+        self._append_audit(result)
+
+    @staticmethod
+    def _contact_field_metadata(field_name: str) -> tuple[str, str]:
+        for suffix, contact_field, field_label in CONTACT_SUFFIX_FIELDS:
+            if contact_field == field_name:
+                return suffix, field_label
+        raise ValueError(f"Unknown Contact field {field_name!r}.")
+
+    def _assign_created_submitter_if_needed(
+        self, batch: CaseBatch, item: _ContactWorkItem
+    ) -> list[ActionResult]:
+        if item.submitter_assigned or not any(
+            source.kind == "submitter" for source in item.sources
+        ):
+            return []
+        item.submitter_assigned = True
+        return [
+            self._assign_created_submitter_to_case(
+                batch, item.row, item.resolution, item.contact_id
+            )
+        ]
+
+    def _refresh_completed_contacts(self, items: list[_ContactWorkItem]) -> None:
+        """Refresh final Contact state before role links and response text."""
+        for item in items:
+            if item.ignored or not item.contact_id:
+                continue
+            item.current_contact = self.client.get_record(
+                "Contact", item.contact_id, CONTACT_REVIEW_FIELDS
+            )
+            item.resolution.selected_contact = item.current_contact
 
     def _contact_proposal(
         self,
@@ -2628,7 +2879,7 @@ class InteractiveProfileUpdateProcessor:
         proposed_value: Any,
         warnings: str = "",
     ) -> ChangeProposal:
-        """Build an aggregate Contact proposal with every source ID."""
+        """Build a Contact proposal with every contributing source ID."""
         base = self._proposal(
             batch,
             item.row,
@@ -2968,10 +3219,11 @@ class InteractiveProfileUpdateProcessor:
             )
             results.append(result)
             previous_contact = original_contact
-            contact_changed = item.result is not None and item.result.status in {
-                ActionStatus.APPLIED,
-                ActionStatus.VERIFIED_MANUAL,
-            }
+            contact_changed = any(
+                result.status
+                in {ActionStatus.APPLIED, ActionStatus.VERIFIED_MANUAL}
+                for result in (item.results or {}).values()
+            )
             changed = contact_changed or result.status in {
                 ActionStatus.APPLIED,
                 ActionStatus.VERIFIED_MANUAL,
@@ -3565,19 +3817,22 @@ class InteractiveProfileUpdateProcessor:
         proposal: ChangeProposal,
         resolution: ContactResolution,
         error: SalesforceError,
+        *,
+        append_audit: bool = True,
     ) -> ActionResult:
         """Recover a Contact create that Salesforce's duplicate rule blocked."""
-        self._append_audit(
-            ActionResult(
-                proposal,
-                ReviewDecision.APPLY_AUTOMATICALLY,
-                ActionStatus.FAILED,
-                action="Salesforce duplicate rule blocked Contact create",
-                error=str(error),
-                error_code=error.error_code or "",
-                salesforce_message=error.salesforce_message or "",
+        if append_audit:
+            self._append_audit(
+                ActionResult(
+                    proposal,
+                    ReviewDecision.APPLY_AUTOMATICALLY,
+                    ActionStatus.FAILED,
+                    action="Salesforce duplicate rule blocked Contact create",
+                    error=str(error),
+                    error_code=error.error_code or "",
+                    salesforce_message=error.salesforce_message or "",
+                )
             )
-        )
         self._display_event(
             WarningNotice(
                 styled(
@@ -3630,7 +3885,8 @@ class InteractiveProfileUpdateProcessor:
                     error_code=error.error_code or "",
                     salesforce_message=error.salesforce_message or "",
                 )
-                self._append_audit(ignored)
+                if append_audit:
+                    self._append_audit(ignored)
                 return ignored
 
             if choice == "alternate_email":
@@ -3694,7 +3950,8 @@ class InteractiveProfileUpdateProcessor:
                 ActionStatus.VERIFIED_MANUAL,
                 action=action,
             )
-            self._append_audit(result)
+            if append_audit:
+                self._append_audit(result)
             return result
 
     def _select_contact_by_email(self, email: str) -> dict[str, Any] | None:
@@ -4078,7 +4335,9 @@ class InteractiveProfileUpdateProcessor:
                 f"Unknown review decision answer {answer!r}."
             ) from error
 
-    def _prompt_yes_no(self, prompt: StyledText) -> bool:
+    def _prompt_yes_no(
+        self, prompt: StyledText, *, default_yes: bool = False
+    ) -> bool:
         answer = self._ask_choice(
             ChoiceQuestion(
                 prompt,
@@ -4087,6 +4346,7 @@ class InteractiveProfileUpdateProcessor:
                     ReviewChoice("no", "no"),
                 ),
                 styled("Enter yes or no."),
+                default_key="yes" if default_yes else None,
             )
         )
         return answer == "yes"
@@ -4304,22 +4564,31 @@ class InteractiveProfileUpdateProcessor:
         if self._queue_store is None:
             return False
         changes = list(iter_changes(self._queue_store.manifest))
-        exact_id = stable_queue_id(
-            "proposed_change",
-            object_name=proposal.target_object,
-            source_submission_ids=proposal.source_submission_ids,
-            target_context=proposal.target_record_id,
-            field=proposal.field_name,
-        )
-        item_ids = [change.id for change in changes if change.id == exact_id]
-        if proposal.target_object == "Contact" and proposal.field_name == "Contact":
+        target_contexts = [proposal.target_record_id]
+        if proposal.target_object == "Contact" and proposal.comparison_key:
+            target_contexts.append(f"email:{proposal.comparison_key}")
+        exact_ids = {
+            stable_queue_id(
+                "proposed_change",
+                object_name=proposal.target_object,
+                source_submission_ids=proposal.source_submission_ids,
+                target_context=target_context,
+                field=proposal.field_name,
+            )
+            for target_context in target_contexts
+        }
+        item_ids = [change.id for change in changes if change.id in exact_ids]
+        if proposal.target_object == "Contact" and not item_ids:
             source_ids = set(proposal.source_submission_ids)
-            item_ids.extend(
+            field_candidates = {
                 change.id
                 for change in changes
                 if change.phase is QueuePhase.CONTACT
+                and change.field == proposal.field_name
                 and set(change.source_submission_ids) == source_ids
-            )
+            }
+            if len(field_candidates) == 1:
+                item_ids.extend(field_candidates)
         item_ids = list(dict.fromkeys(item_ids))
         for item_id in item_ids:
             self._queue_store.transition(item_id, status, outcome=outcome)

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -1916,6 +1916,9 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         [
             "1",
             "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
             "will not be made",
             "yes",
         ]
@@ -1941,7 +1944,7 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
     assert contact_query[2] == "Email = 'old@example.com'"
     assert "AccountId" not in contact_query[2]
     assert any("Contact choice" in prompt for prompt in feeder.prompts)
-    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 2
+    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 5
     assert (
         "Contact",
         "contact-1",
@@ -1961,8 +1964,8 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
     assert any(
-        item["field"] == "Contact"
-        and item["action"] == "update Contact from reconciled proposals"
+        item["field"] == "FirstName"
+        and item["action"] == "update Contact from approved fields"
         and item["result"] == "applied"
         for item in entries
     )
@@ -1977,8 +1980,8 @@ def test_exact_email_match_is_global_and_each_mismatch_precedes_role_decision(
     assert (
         "Phone | 312-555-0100 | 312.555.0199 | submission-1 / Certification"
     ) in displayed
-    assert "First Name: Alex -> Alexa" in displayed
-    assert "Phone: 312-555-0100 -> 312.555.0199" in displayed
+    assert "Contact First Name: Alexa Jones <old@example.com>" in displayed
+    assert "Contact Phone: Alexa Jones <old@example.com>" in displayed
     assert "Current Salesforce value: {" not in displayed
     assert "Proposed value: {" not in displayed
     assert (
@@ -2018,6 +2021,65 @@ def test_incomplete_contact_is_not_automatically_created(tmp_path):
     assert "required Last Name" in "\n".join(output)
 
 
+def test_incomplete_new_contact_can_use_manual_creation_path(tmp_path):
+    client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_First_Name__c"
+    ] = "Only"
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Decision ["):
+            decisions = iter(("make manually", "apply automatically"))
+            answer.decisions = getattr(answer, "decisions", decisions)
+            return next(answer.decisions)
+        if prompt.startswith("Create the Contact in Salesforce"):
+            manual = {
+                "Id": "manual-contact",
+                "AccountId": "account-1",
+                "FirstName": "Only",
+                "LastName": "Entered Manually",
+                "Title": "",
+                "Email": "",
+                "Phone": "",
+            }
+            client.records[("Contact", "manual-contact")] = manual
+            client.contacts.append(manual)
+            return "manual-contact"
+        if prompt.startswith("Make the Contact First Name change"):
+            return ""
+        if prompt.startswith("Was the response email"):
+            return "yes"
+        raise AssertionError(prompt)
+
+    result = InteractiveProfileUpdateProcessor(
+        client, input_fn=answer, output_fn=lambda message: None, now=NOW
+    ).review(
+        [
+            staged_row(
+                certification_first_name="Only",
+                certification_resolution_action="create_contact",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == []
+    assert (
+        "Account",
+        "account-1",
+        {"Cert_Certification_Contact__c": "manual-contact"},
+    ) in client.updated
+    verified = next(
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+        if '"field": "FirstName"' in line
+        and '"result": "verified manually"' in line
+    )
+    assert verified["final_value"] == "Only"
+
+
 def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
     client = FakeClient()
     client.records[("Company_Profile_Change__c", "submission-1")].update(
@@ -2029,6 +2091,8 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
     )
     feeder = Feeder(
         [
+            "apply automatically",
+            "apply automatically",
             "apply automatically",
             "apply automatically",
             "yes",
@@ -2056,7 +2120,7 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
 
     contact_query = next(query for query in client.queries if query[0] == "Contact")
     assert contact_query[2] == "Email = 'new.person@example.com'"
-    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 2
+    assert sum(prompt.startswith("Decision [") for prompt in feeder.prompts) == 4
     assert client.created == [
         (
             "Contact",
@@ -2079,10 +2143,9 @@ def test_valid_contact_creation_precedes_field_and_role_decisions(tmp_path):
     assert (
         "Email | (blank) | new.person@example.com | submission-1 / Certification"
     ) in displayed
-    assert "New Salesforce values:" in displayed
-    assert "First Name: New" in displayed
-    assert "Last Name: Person" in displayed
-    assert "Email: new.person@example.com" in displayed
+    assert "Contact First Name: New Person <new.person@example.com>" in displayed
+    assert "Contact Last Name: New Person <new.person@example.com>" in displayed
+    assert "Contact Email: New Person <new.person@example.com>" in displayed
     assert "Proposed value: {" not in displayed
 
 
@@ -2096,7 +2159,9 @@ def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
             "Cert_Phone__c": "312-555-0101",
         }
     )
-    feeder = Feeder(["apply automatically", "apply automatically", "yes"])
+    feeder = Feeder(
+        ["apply automatically"] * 5 + ["yes"]
+    )
     processor = InteractiveProfileUpdateProcessor(
         client,
         input_fn=feeder,
@@ -2149,7 +2214,9 @@ def test_new_contract_reuses_submitter_role_contact_and_assigns_case(tmp_path):
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
     contact_create = next(
-        entry for entry in entries if entry["action"] == "create Contact"
+        entry
+        for entry in entries
+        if entry["action"] == "create Contact from approved fields"
     )
     case_assignment = next(
         entry
@@ -2279,6 +2346,7 @@ def test_contact_phase_combines_roles_into_one_write_before_account_and_role_lin
             "apply automatically",
             "apply automatically",
             "apply automatically",
+            "apply automatically",
             "yes",
         ]
     )
@@ -2337,16 +2405,18 @@ def test_contact_phase_combines_roles_into_one_write_before_account_and_role_lin
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    aggregate = next(
-        entry
+    contact_fields = {
+        entry["field"]: entry
         for entry in entries
-        if entry["action"] == "update Contact from reconciled proposals"
-    )
-    assert aggregate["proposed_value"] == {
-        "Phone": "312.555.0199",
-        "Title": "Director",
+        if entry["action"] == "update Contact from approved fields"
     }
-    assert aggregate["source_submission_ids"] == ["submission-1"]
+    assert {
+        field: entry["proposed_value"] for field, entry in contact_fields.items()
+    } == {"Phone": "312.555.0199", "Title": "Director"}
+    assert all(
+        entry["source_submission_ids"] == ["submission-1"]
+        for entry in contact_fields.values()
+    )
 
 
 def test_conflicting_contact_values_are_resolved_before_any_contact_write(tmp_path):
@@ -2652,6 +2722,7 @@ def test_contact_updates_use_tim_and_stacy_emails_before_assigning_roles(tmp_pat
                 "apply automatically",
                 "apply automatically",
                 "apply automatically",
+                "apply automatically",
                 "yes",
             ]
         ),
@@ -2718,6 +2789,8 @@ def test_shared_new_contact_is_created_once_and_reused_for_both_roles(tmp_path):
         client,
         input_fn=Feeder(
             [
+                "apply automatically",
+                "apply automatically",
                 "apply automatically",
                 "apply automatically",
                 "apply automatically",
@@ -2793,6 +2866,10 @@ def test_distinct_emails_in_one_role_stay_separate_until_role_assignment(
             "apply automatically",
             "apply automatically",
             "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
+            "apply automatically",
             "yes",
         ]
     )
@@ -2848,8 +2925,13 @@ def test_distinct_emails_in_one_role_stay_separate_until_role_assignment(
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    creates = [entry for entry in entries if entry["action"] == "create Contact"]
-    assert [entry["proposed_value"]["Email"] for entry in creates] == [
+    creates = [
+        entry
+        for entry in entries
+        if entry["action"] == "create Contact from approved fields"
+        and entry["field"] == "Email"
+    ]
+    assert [entry["proposed_value"] for entry in creates] == [
         "first@example.com",
         "second@example.com",
     ]
@@ -2880,7 +2962,9 @@ def test_every_fresh_submitter_submission_contributes_to_reconciliation(tmp_path
     client.records[("Company_Profile_Change__c", "submission-2")] = second
     processor = InteractiveProfileUpdateProcessor(
         client,
-        input_fn=Feeder(["2", "apply automatically"]),
+        input_fn=Feeder(
+            ["2", "apply automatically", "apply automatically", "apply automatically"]
+        ),
         output_fn=lambda message: None,
         now=NOW,
     )
@@ -2952,19 +3036,457 @@ def test_rejected_reconciled_contact_has_no_contact_write(tmp_path):
         now=NOW,
     )
 
-    result = processor.review([staged_row(contact_resolutions="[]")], tmp_path)
+    result = processor.review(
+        [
+            staged_row(
+                contact_resolutions=staged_resolution(
+                    email="alex@example.com",
+                    sources=[
+                        ContactSource("role", "certification", "submission-1")
+                    ],
+                    submitted={"title": "Director"},
+                    classification=ContactResolutionClassification.USE_EXISTING,
+                    selected=contact,
+                )
+            )
+        ],
+        tmp_path,
+    )
 
     assert not any(item[0] == "Contact" for item in client.updated)
     entries = [
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    rejected = next(entry for entry in entries if entry["action"] == "no Contact write")
+    rejected = next(
+        entry for entry in entries if entry["action"] == "no Contact field write"
+    )
     assert rejected["decision"] == "will not be made"
-    assert rejected["proposed_value"] == {"Title": "Director"}
+    assert rejected["proposed_value"] == "Director"
 
 
-def test_manual_contact_decision_verifies_all_fields_together(tmp_path):
+def test_contact_fields_have_independent_decisions_and_one_grouped_write(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "alex@example.com",
+        "Phone": "312.555.0100",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "Alexa",
+            "Cert_Last_Name__c": "Smith",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "alex@example.com",
+            "Cert_Phone__c": "312-555-0199",
+        }
+    )
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Decision ["):
+            decisions = iter(("apply automatically", "will not be made", "make manually"))
+            answer.decisions = getattr(answer, "decisions", decisions)
+            return next(answer.decisions)
+        if prompt.startswith("Make the Contact Phone change"):
+            client.records[("Contact", "contact-1")]["Phone"] = "312.555.0199"
+            return ""
+        if prompt.startswith("Was the response email"):
+            return "yes"
+        raise AssertionError(prompt)
+
+    output = []
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=answer,
+        output_fn=output.append,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                contact_resolutions=staged_resolution(
+                    email="alex@example.com",
+                    sources=[
+                        ContactSource("role", "certification", "submission-1")
+                    ],
+                    submitted={
+                        "first_name": "Alexa",
+                        "title": "Director",
+                        "phone": "312.555.0199",
+                    },
+                    classification=ContactResolutionClassification.USE_EXISTING,
+                    selected=contact,
+                )
+            )
+        ],
+        tmp_path,
+    )
+
+    assert [item for item in client.updated if item[0] == "Contact"] == [
+        ("Contact", "contact-1", {"FirstName": "Alexa"})
+    ]
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line)["target_object"] == "Contact"
+        and json.loads(line)["field"] in {"FirstName", "Title", "Phone"}
+    ]
+    by_field = {entry["field"]: entry for entry in entries}
+    assert by_field["FirstName"]["decision"] == "apply automatically"
+    assert by_field["FirstName"]["final_value"] == "Alexa"
+    assert by_field["Title"]["result"] == "rejected"
+    assert by_field["Title"]["final_value"] == "Manager"
+    assert by_field["Phone"]["decision"] == "make manually"
+    assert by_field["Phone"]["final_value"] == "312.555.0199"
+    displayed = "\n".join(output)
+    assert "\n========================================================================\nManual Contact Follow-up" in displayed
+    queue = json.loads(result.queue_path.read_text(encoding="utf-8"))
+    outcomes = {
+        change["field"]: change["outcome"]
+        for batch in queue["batches"]
+        for queued_row in batch["rows"]
+        for change in queued_row["changes"]
+        if change["field"] in {"FirstName", "Title", "Phone"}
+    }
+    assert outcomes == {
+        "FirstName": "applied",
+        "Title": "rejected",
+        "Phone": "verified manually",
+    }
+
+
+def test_new_contact_omits_rejected_fields_from_grouped_create(tmp_path):
+    client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Title__c": "Director",
+            "Cert_Email__c": "new.person@example.com",
+        }
+    )
+    processor = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(
+            [
+                "apply automatically",
+                "apply automatically",
+                "will not be made",
+                "apply automatically",
+                "apply automatically",
+                "yes",
+            ]
+        ),
+        output_fn=lambda message: None,
+        now=NOW,
+    )
+
+    result = processor.review(
+        [
+            staged_row(
+                certification_first_name="New",
+                certification_last_name="Person",
+                certification_title="Director",
+                certification_email="new.person@example.com",
+                certification_resolution_action="create_contact",
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == [
+        (
+            "Contact",
+            {
+                "AccountId": "account-1",
+                "FirstName": "New",
+                "LastName": "Person",
+                "Email": "new.person@example.com",
+            },
+        )
+    ]
+    entries = [
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert {
+        entry["field"]: entry["result"]
+        for entry in entries
+        if entry["target_object"] == "Contact"
+        and entry["field"] in {"FirstName", "LastName", "Title", "Email"}
+    } == {
+        "FirstName": "applied",
+        "LastName": "applied",
+        "Title": "rejected",
+        "Email": "applied",
+    }
+
+
+def test_differing_manual_contact_value_defaults_to_accepting_salesforce(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_Title__c"
+    ] = "Director"
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Decision ["):
+            return "make manually"
+        if prompt.startswith("Make the Contact Title change"):
+            client.records[("Contact", "contact-1")]["Title"] = "Senior Director"
+            return ""
+        if prompt.startswith("Accept the current Salesforce Title"):
+            return ""
+        if prompt.startswith("Was the response email"):
+            return "yes"
+        raise AssertionError(prompt)
+
+    output = []
+    result = InteractiveProfileUpdateProcessor(
+        client, input_fn=answer, output_fn=output.append, now=NOW
+    ).review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    verified = next(
+        json.loads(line)
+        for line in result.audit_path.read_text(encoding="utf-8").splitlines()
+        if '"field": "Title"' in line and '"decision": "make manually"' in line
+    )
+    assert verified["proposed_value"] == "Director"
+    assert verified["final_value"] == "Senior Director"
+    displayed = "\n".join(output)
+    assert "Current Salesforce value: Senior Director" in displayed
+    assert "Proposed value: Director" in displayed
+    assert "Senior Director" in result.response_path.read_text(encoding="utf-8")
+
+
+def test_declined_manual_contact_override_fails_and_keeps_batch_retryable(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_Title__c"
+    ] = "Director"
+
+    def answer(prompt):
+        if prompt.startswith("Continue with this staged row"):
+            return ""
+        if prompt.startswith("Decision ["):
+            return "make manually"
+        if prompt.startswith("Make the Contact Title change"):
+            client.records[("Contact", "contact-1")]["Title"] = "Senior Director"
+            return ""
+        if prompt.startswith("Accept the current Salesforce Title"):
+            return "no"
+        raise AssertionError(prompt)
+
+    with pytest.raises(ProcessingError, match="not accepted"):
+        InteractiveProfileUpdateProcessor(
+            client, input_fn=answer, output_fn=lambda message: None, now=NOW
+        ).review(
+            [
+                staged_row(
+                    contact_resolutions=staged_resolution(
+                        sources=[
+                            ContactSource(
+                                "role", "certification", "submission-1"
+                            )
+                        ],
+                        submitted={"title": "Director"},
+                        classification=ContactResolutionClassification.USE_EXISTING,
+                        selected=contact,
+                    )
+                )
+            ],
+            tmp_path,
+        )
+
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+    queue = json.loads((tmp_path / "review_queue.json").read_text(encoding="utf-8"))
+    title = next(
+        change
+        for batch in queue["batches"]
+        for queued_row in batch["rows"]
+        for change in queued_row["changes"]
+        if change["field"] == "Title"
+    )
+    assert title["status"] == "failed"
+
+
+@pytest.mark.parametrize("interruption", [KeyboardInterrupt(), EOFError()])
+def test_manual_contact_confirmation_interruption_is_audited(
+    tmp_path, interruption
+):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_Title__c"
+    ] = "Director"
+    feeder = Feeder(["make manually", interruption])
+
+    with pytest.raises(ProcessingInterrupted):
+        InteractiveProfileUpdateProcessor(
+            client, input_fn=feeder, output_fn=lambda message: None, now=NOW
+        ).review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "review_audit.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    interrupted = next(
+        entry
+        for entry in entries
+        if entry["field"] == "Title" and entry["result"] == "interrupted"
+    )
+    assert interrupted["decision"] == "make manually"
+    assert not any(item[0] == "Company_Profile_Change__c" for item in client.updated)
+
+
+def test_manual_contact_salesforce_read_failure_is_audited(tmp_path):
+    contact = {
+        "Id": "contact-1",
+        "AccountId": "account-1",
+        "FirstName": "Alex",
+        "LastName": "Smith",
+        "Title": "Manager",
+        "Email": "alex@example.com",
+        "Phone": "",
+    }
+    client = FakeClient(
+        account=account_record(Cert_Certification_Contact__c="contact-1"),
+        contacts=[contact],
+    )
+    client.records[("Company_Profile_Change__c", "submission-1")][
+        "Cert_Title__c"
+    ] = "Director"
+    original_get = client.get_record
+
+    def fail_manual_read(object_name, record_id, fields):
+        if object_name == "Contact" and list(fields) == ["Id", "Title"]:
+            raise SalesforceError("manual Contact read failed")
+        return original_get(object_name, record_id, fields)
+
+    client.get_record = fail_manual_read
+
+    with pytest.raises(ProcessingError, match="manual Contact read failed"):
+        InteractiveProfileUpdateProcessor(
+            client,
+            input_fn=Feeder(["make manually", ""]),
+            output_fn=lambda message: None,
+            now=NOW,
+        ).review([staged_row(contact_resolutions="[]")], tmp_path)
+
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "review_audit.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    failed = next(
+        entry
+        for entry in entries
+        if entry["field"] == "Title" and entry["result"] == "failed"
+    )
+    assert failed["decision"] == "make manually"
+    assert failed["error"] == "manual Contact read failed"
+
+
+def test_all_rejected_new_contact_is_not_created_or_assigned(tmp_path):
+    client = FakeClient()
+    client.records[("Company_Profile_Change__c", "submission-1")].update(
+        {
+            "Cert_First_Name__c": "New",
+            "Cert_Last_Name__c": "Person",
+            "Cert_Email__c": "new.person@example.com",
+        }
+    )
+    contact_resolutions = staged_resolution(
+        email="new.person@example.com",
+        sources=[ContactSource("role", "certification", "submission-1")],
+        submitted={
+            "first_name": "New",
+            "last_name": "Person",
+            "email": "new.person@example.com",
+        },
+    )
+
+    result = InteractiveProfileUpdateProcessor(
+        client,
+        input_fn=Feeder(["will not be made"] * 3 + ["yes"]),
+        output_fn=lambda message: None,
+        now=NOW,
+    ).review(
+        [
+            staged_row(
+                certification_resolution_action="create_contact",
+                contact_resolutions=contact_resolutions,
+            )
+        ],
+        tmp_path,
+    )
+
+    assert client.created == []
+    assert not any(
+        object_name == "Account" and "Cert_Certification_Contact__c" in values
+        for object_name, _, values in client.updated
+    )
+    queue = json.loads(result.queue_path.read_text(encoding="utf-8"))
+    contact_changes = [
+        change
+        for batch in queue["batches"]
+        for queued_row in batch["rows"]
+        for change in queued_row["changes"]
+        if change["salesforce"]["object_name"] == "Contact"
+    ]
+    assert {change["outcome"] for change in contact_changes} == {"rejected"}
+
+
+def test_manual_contact_decisions_verify_fields_individually(tmp_path):
     contact = {
         "Id": "contact-1",
         "AccountId": "account-1",
@@ -2993,10 +3515,11 @@ def test_manual_contact_decision_verifies_all_fields_together(tmp_path):
             return ""
         if prompt.startswith("Decision ["):
             return "make manually"
-        if prompt.startswith("Make the complete Contact change"):
-            client.records[("Contact", "contact-1")].update(
-                {"Title": "Director", "Phone": "312.555.0199"}
-            )
+        if prompt.startswith("Make the Contact Title change"):
+            client.records[("Contact", "contact-1")]["Title"] = "Director"
+            return ""
+        if prompt.startswith("Make the Contact Phone change"):
+            client.records[("Contact", "contact-1")]["Phone"] = "312.555.0199"
             return ""
         if prompt.startswith("Was the response email"):
             return "yes"
@@ -3016,13 +3539,14 @@ def test_manual_contact_decision_verifies_all_fields_together(tmp_path):
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    verified = next(
+    verified = [
         entry
         for entry in entries
-        if entry["action"] == "verify reconciled Contact manually"
-    )
-    assert verified["result"] == "verified manually"
-    assert verified["proposed_value"] == {
+        if entry["action"] == "verify Contact field manually"
+    ]
+    assert {entry["field"] for entry in verified} == {"Title", "Phone"}
+    assert all(entry["result"] == "verified manually" for entry in verified)
+    assert {entry["field"]: entry["proposed_value"] for entry in verified} == {
         "Phone": "312.555.0199",
         "Title": "Director",
     }
@@ -3071,7 +3595,7 @@ def test_contact_failure_is_audited_and_same_input_retries_then_becomes_noop(
         .splitlines()
     ]
     assert any(
-        entry["action"] == "update Contact from reconciled proposals"
+        entry["action"] == "update Contact from approved fields"
         and entry["result"] == "failed"
         for entry in failed_entries
     )
@@ -3107,7 +3631,7 @@ def test_contact_failure_is_audited_and_same_input_retries_then_becomes_noop(
         for line in noop_result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
     assert any(
-        entry["action"] == "reconciled Contact already current"
+        entry["action"] == "Contact field already current"
         for entry in noop_entries
     )
 
@@ -3124,7 +3648,7 @@ def test_compatibility_review_normalizes_fresh_role_values(tmp_path):
     )
     processor = InteractiveProfileUpdateProcessor(
         client,
-        input_fn=Feeder(["apply automatically", "apply automatically", "yes"]),
+        input_fn=Feeder(["apply automatically"] * 6 + ["yes"]),
         output_fn=lambda message: None,
         now=NOW,
     )
@@ -3184,6 +3708,8 @@ def test_duplicate_create_can_recover_with_an_alternate_email_contact(tmp_path):
     feeder = Feeder(
         [
             "apply automatically",
+            "apply automatically",
+            "apply automatically",
             "3",
             "other@example.com",
             "apply automatically",
@@ -3228,16 +3754,16 @@ def test_duplicate_create_can_recover_with_an_alternate_email_contact(tmp_path):
         json.loads(line)
         for line in result.audit_path.read_text(encoding="utf-8").splitlines()
     ]
-    assert any(
-        entry["action"] == "Salesforce duplicate rule blocked Contact create"
-        for entry in entries
-    )
+    assert not any(entry["field"] == "Contact" for entry in entries)
     recovered = next(
         entry
         for entry in entries
         if entry["action"] == "use alternate-email Contact after duplicate failure"
+        and entry["field"] == "Email"
     )
     assert recovered["selected_contact"]["Id"] == "alternate-contact"
+    assert recovered["proposed_value"] == "new.person@example.com"
+    assert recovered["final_value"] == "other@example.com"
 
 
 def test_duplicate_exact_email_matches_are_audited_and_keep_case_retryable(tmp_path):


### PR DESCRIPTION
Summary:
- Add independent apply, manual, or reject decisions for each changed Contact field.
- Defer manual fields to a follow-up phase with Salesforce verification and safe retry behavior.
- Refresh final Contact values before role links and response generation, with updated documentation and tests.

Closes #46