### PR TITLE
chore: replace email opening format call

### DIFF
--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -4645,7 +4645,12 @@ def format_response_emails(
                 "your account",
             ),
         )
-        lines = [ACCOUNT_EMAIL_OPENING.format(account_name=account_name)]
+        lines = [
+            f"Thank you for updating your information with AISC. The changes are "
+            f"summarized below. An updated Participant Portal login will be sent by a "
+            f"separate email, if needed. Unless otherwise noted, previous contacts will "
+            f"remain in the {account_name} contact list."
+        ]
         seen: set[tuple[str, str, str, str]] = set()
         for proposal in proposals:
             identity = (

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -4239,7 +4239,13 @@ def test_email_formatter_creates_one_paragraph_per_submitter():
     emails = format_response_emails(results)
 
     assert list(emails) == ["first@example.com", "second@example.com"]
-    assert emails["first@example.com"].count("Thank you for updating") == 1
+    assert (
+        "Thank you for updating your information with AISC. The changes are "
+        "summarized below. An updated Participant Portal login will be sent by a "
+        "separate email, if needed. Unless otherwise noted, previous contacts will "
+        "remain in the Acme Steel contact list."
+        in emails["first@example.com"]
+    )
     assert "Company Name: Acme Steel" in emails["first@example.com"]
     assert "Billing City: Chicago" in emails["second@example.com"]
     assert all("\x1b[" not in body for body in emails.values())


### PR DESCRIPTION
## Summary
- replace the response email opening .format() call with an equivalent f-string
- verify the full opening sentence includes the account name

## Testing
- uv run ruff check src/aisc_salesforce/process_profile_updates.py tests/test_process_profile_updates.py
- uv run pytest

Closes #51