### PR TITLE
chore: review docstrings and generator typing

### DIFF
--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -278,10 +278,12 @@ class _ParentRouting:
 
     @property
     def is_parent(self) -> bool:
+        """Return whether a parent Account routes changes to active direct children."""
         return bool(self.direct_children)
 
     @property
     def blocked(self) -> bool:
+        """Return whether parent routing has no active targets or field conflicts."""
         return self.is_parent and (not self.target_accounts or bool(self.conflicts))
 
 
@@ -399,6 +401,7 @@ class _QueuePublishingClient:
             return attribute
 
         def mutation(*args: Any, **kwargs: Any) -> Any:
+            """Publish queue snapshots before and after one Salesforce mutation."""
             self._publish()
             try:
                 return attribute(*args, **kwargs)
@@ -1165,6 +1168,7 @@ class _AuditWriter:
             self.output.close()
 
     def append(self, result: ActionResult) -> None:
+        """Write an audit event, then flush and sync it to disk."""
         if self.output is None:
             raise RuntimeError("Audit writer is not open.")
         proposal = result.proposal
@@ -1221,6 +1225,11 @@ class _ResponseWriter:
         self.path.touch()
 
     def append(self, case_id: str, email: str, text: str) -> bool:
+        """Append a response email once and return whether it was written.
+
+        Returns:
+            True when the response block was not already present.
+        """
         block = f"Case {case_id}\nTo: {email}\n\n{text}\n\n"
         if block in self.path.read_text(encoding="utf-8"):
             return False

--- a/src/aisc_salesforce/review_queue.py
+++ b/src/aisc_salesforce/review_queue.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Generator
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -810,7 +811,9 @@ class ReviewQueueStore:
         return self.manifest
 
 
-def iter_changes(manifest: ReviewQueueManifest):
+def iter_changes(  # noqa: UP043 - the full generator contract is intentional.
+    manifest: ReviewQueueManifest,
+) -> Generator[ProposedChange, None, None]:  # noqa: UP043
     """Yield changes once in manifest order, despite cross-row references."""
     seen: set[str] = set()
     for batch in manifest.batches:

--- a/tests/test_process_profile_updates.py
+++ b/tests/test_process_profile_updates.py
@@ -47,6 +47,22 @@ from aisc_salesforce.stage_profile_updates import CSV_COLUMNS, StagingResult
 NOW = datetime(2026, 7, 17, 18, 0, tzinfo=UTC)
 
 
+def test_review_helpers_have_docstrings():
+    routing = profile_update_processing._ParentRouting
+    assert routing.is_parent.__doc__
+    assert routing.blocked.__doc__
+    assert profile_update_processing._AuditWriter.append.__doc__
+    assert profile_update_processing._ResponseWriter.append.__doc__
+
+    class Client:
+        def create_record(self):
+            return None
+
+    client = profile_update_processing._QueuePublishingClient(Client(), lambda: None)
+    mutation = client.__getattr__("create_record")
+    assert mutation.__doc__
+
+
 def staged_row(**changes):
     row = {column: "" for column in CSV_COLUMNS}
     row.update(

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -1,10 +1,13 @@
 import json
+from collections.abc import Generator
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime
+from typing import get_type_hints
 
 import pytest
 
 from aisc_salesforce.review_queue import (
+    ProposedChange,
     QueueStatus,
     ReviewQueueStore,
     build_review_queue,
@@ -17,6 +20,12 @@ from aisc_salesforce.review_queue import (
 from aisc_salesforce.stage_profile_updates import CSV_COLUMNS
 
 NOW = datetime(2026, 7, 17, 18, 0, tzinfo=UTC)
+
+
+def test_iter_changes_has_explicit_generator_return_type():
+    assert get_type_hints(iter_changes)["return"] == Generator[  # noqa: UP043
+        ProposedChange, None, None
+    ]
 
 
 def queue_row(**changes):


### PR DESCRIPTION
## Summary
- add missing docstrings for profile update routing, queue publishing, audit, and response helpers
- make `iter_changes` return type explicit and cover the contracts with tests

Closes #52

Tests: `uv run pytest tests/test_process_profile_updates.py tests/test_review_queue.py` (111 passed)