### PR TITLE
Extract shared Account-role definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ filled from that Contact where possible. Repeating the same contact information
 in several roles does not create a warning, but conflicting emails for the same
 submitted name are treated as ambiguous.
 
+The shared Account-role definitions in `account_roles.py` own these submitted
+field and Account lookup mappings for staging, processing, and the review
+queue. The Quality/QC role intentionally uses the
+`Cert_Marketing_Contact__c` Account lookup field; its marketing-oriented name
+is established Salesforce schema, not a mapping error.
+
 Contact searches prefer the Account's **family accounts**: the target Account,
 its parent Account, and its **sibling accounts** that have the same parent. A
 root Account with no parent has only itself in its family. Exact normalized and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -514,6 +514,15 @@ When at least one revised address component is present, the output contains all
 five components. Missing submitted components are filled from the Account
 billing address where possible.
 
+### Shared Account-role mappings
+
+`src/aisc_salesforce/account_roles.py` owns the submitted Salesforce fields and
+Account lookup mappings shared by staging, interactive processing, and the
+review queue. The Quality/QC role deliberately uses the
+`Cert_Marketing_Contact__c` Account lookup field. The field's marketing name is
+part of the existing Salesforce schema and does not mean the role should use a
+different lookup.
+
 ### Submitted contact normalization
 
 Staging canonicalizes only values submitted for the submitter and the five

--- a/src/aisc_salesforce/account_roles.py
+++ b/src/aisc_salesforce/account_roles.py
@@ -1,0 +1,115 @@
+"""Shared Account-role mappings for Profile Update workflows.
+
+This module is the sole owner of Salesforce field names for submitted Account
+roles.  Quality/QC intentionally maps to ``Cert_Marketing_Contact__c``;
+despite its name, that is the Account lookup field used for this role.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class AccountRole(StrEnum):
+    """Account roles, with values matching staged CSV column prefixes."""
+
+    CERTIFICATION = "certification"
+    PRINCIPAL = "principal"
+    ACCOUNTING = "accounting"
+    QUALITY_QC = "quality"
+    NEW_YORK = "new_york"
+
+
+@dataclass(frozen=True)
+class RoleDefinition:
+    """Map one submitted role to its fields and current Account lookup."""
+
+    role: AccountRole
+    label: str
+    first_name_field: str
+    last_name_field: str
+    title_field: str | None
+    email_field: str
+    phone_field: str
+    account_lookup: str
+
+    @property
+    def prefix(self) -> str:
+        """Return the role's established staged-CSV column prefix."""
+        return str(self.role)
+
+    @property
+    def submitted_fields(self) -> tuple[tuple[str, str], ...]:
+        """Return CSV suffix and Salesforce submission-field pairs."""
+        fields = [
+            ("first_name", self.first_name_field),
+            ("last_name", self.last_name_field),
+        ]
+        if self.title_field is not None:
+            fields.append(("title", self.title_field))
+        fields.extend(
+            [
+                ("email", self.email_field),
+                ("phone", self.phone_field),
+            ]
+        )
+        return tuple(fields)
+
+
+ACCOUNT_ROLE_DEFINITIONS = (
+    RoleDefinition(
+        AccountRole.CERTIFICATION,
+        "Certification",
+        "Cert_First_Name__c",
+        "Cert_Last_Name__c",
+        "Cert_Title__c",
+        "Cert_Email__c",
+        "Cert_Phone__c",
+        "Cert_Certification_Contact__c",
+    ),
+    RoleDefinition(
+        AccountRole.PRINCIPAL,
+        "Principal",
+        "Principal_First_Name__c",
+        "Principal_Last_Name__c",
+        "Principal_Title__c",
+        "Principal_Email__c",
+        "Principal_Phone__c",
+        "Cert_Principal_Contact__c",
+    ),
+    RoleDefinition(
+        AccountRole.ACCOUNTING,
+        "Accounting",
+        "AP_First_Name__c",
+        "AP_Last_Name__c",
+        "AP_Title__c",
+        "AP_Email__c",
+        "AP_Phone__c",
+        "Cert_Accounting_Contact__c",
+    ),
+    RoleDefinition(
+        AccountRole.QUALITY_QC,
+        "Quality",
+        "Quality_First_Name__c",
+        "Quality_Last_Name__c",
+        "QC_Title__c",
+        "Quality_Email__c",
+        "Quality_Phone__c",
+        "Cert_Marketing_Contact__c",
+    ),
+    RoleDefinition(
+        AccountRole.NEW_YORK,
+        "New York",
+        "NY_First_Name__c",
+        "NY_Last_Name__c",
+        None,
+        "NY_Email__c",
+        "NY_Phone__c",
+        "Cert_Safety_Contact__c",
+    ),
+)
+"""Ordered, immutable definitions for every supported Account role."""
+
+QUALIFYING_CERTIFICATION_STATUSES = frozenset({"Certified", "Initials"})
+"""Certification statuses that qualify an Account for Profile Update work."""

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -17,6 +17,11 @@ from typing import Any, TextIO
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+from .account_roles import (
+    ACCOUNT_ROLE_DEFINITIONS,
+    QUALIFYING_CERTIFICATION_STATUSES,
+    RoleDefinition,
+)
 from .contact_normalization import normalize_contact_value
 from .contact_resolution import (
     ContactResolution,
@@ -87,11 +92,8 @@ from .review_ui import (
 from .salesforce import SalesforceClient, SalesforceError
 from .salesforce_enums import CaseStatus, ProfileChangeStatus
 from .stage_profile_updates import (
-    ACTIVE_CERTIFICATION_STATUSES,
     CSV_COLUMNS,
-    ROLE_DEFINITIONS,
     ProfileUpdateStagingService,
-    RoleDefinition,
     StagingResult,
     write_staged_profile_updates,
 )
@@ -1891,7 +1893,7 @@ class InteractiveProfileUpdateProcessor:
         account_fields = [
             "Id",
             "ParentId",
-            *(role.account_lookup for role in ROLE_DEFINITIONS),
+            *(role.account_lookup for role in ACCOUNT_ROLE_DEFINITIONS),
         ]
         account = self.client.get_record("Account", batch.account_id, account_fields)
         family_ids = self._fresh_family_account_ids(batch)
@@ -1929,7 +1931,7 @@ class InteractiveProfileUpdateProcessor:
                         source = ContactSource("submitter", submission_id=submission_id)
                         occurrences.append((source, details, row, ""))
 
-                for role in ROLE_DEFINITIONS:
+                for role in ACCOUNT_ROLE_DEFINITIONS:
                     details = {
                         suffix: normalize_contact_value(
                             suffix, record.get(source_field)
@@ -3168,7 +3170,7 @@ class InteractiveProfileUpdateProcessor:
         results: list[ActionResult] = []
         responses: list[_RoleResponse] = []
         items_by_key = {item.key: item for item in items}
-        for role in ROLE_DEFINITIONS:
+        for role in ACCOUNT_ROLE_DEFINITIONS:
             submitted = _submitted_role_values(submissions, row, role)
             if not any(submitted.values()):
                 continue
@@ -3410,7 +3412,7 @@ class InteractiveProfileUpdateProcessor:
             child
             for child in direct_children
             if _display(child.get("Cert_Certification_Status__c"))
-            in ACTIVE_CERTIFICATION_STATUSES
+            in QUALIFYING_CERTIFICATION_STATUSES
         )
         conflicts: list[ParentAccountFieldConflict] = []
         if active_children:
@@ -3495,7 +3497,7 @@ class InteractiveProfileUpdateProcessor:
                 requested = _latest_nonblank(submissions, source_field)
                 if requested:
                     requests.append((account_field, label, requested))
-            for role in ROLE_DEFINITIONS:
+            for role in ACCOUNT_ROLE_DEFINITIONS:
                 submitted = _submitted_role_values(submissions, row, role)
                 has_fresh_role_value = any(
                     _latest_nonblank(submissions, source_field)
@@ -3780,7 +3782,7 @@ class InteractiveProfileUpdateProcessor:
         contacts_by_id: dict[str, dict[str, Any]] = {}
         for account in target_accounts:
             account_id = _required_record_text(account, "Id", "Affected Account ID")
-            for role in ROLE_DEFINITIONS:
+            for role in ACCOUNT_ROLE_DEFINITIONS:
                 contact_id = _display(account.get(role.account_lookup))
                 contact = None
                 if contact_id:

--- a/src/aisc_salesforce/profile_updates.py
+++ b/src/aisc_salesforce/profile_updates.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from .account_roles import ACCOUNT_ROLE_DEFINITIONS
 from .profile_update_subjects import (
     ProfileUpdateReference,
     append_profile_update,
@@ -60,30 +61,11 @@ SUMMARY_FIELDS = [
     ("Will_new_equipment_be_purchased__c", "New Equipment Will Be Purchased"),
     ("Will_old_equipment_be_removed__c", "Old Equipment Will Be Removed"),
     ("Will_software_change__c", "Software Will Change"),
-    ("AP_First_Name__c", "Accounting Contact First Name"),
-    ("AP_Last_Name__c", "Accounting Contact Last Name"),
-    ("AP_Title__c", "Accounting Contact Title"),
-    ("AP_Email__c", "Accounting Contact Email"),
-    ("AP_Phone__c", "Accounting Contact Phone"),
-    ("Cert_First_Name__c", "Certification Contact First Name"),
-    ("Cert_Last_Name__c", "Certification Contact Last Name"),
-    ("Cert_Title__c", "Certification Contact Title"),
-    ("Cert_Email__c", "Certification Contact Email"),
-    ("Cert_Phone__c", "Certification Contact Phone"),
-    ("Principal_First_Name__c", "Principal Contact First Name"),
-    ("Principal_Last_Name__c", "Principal Contact Last Name"),
-    ("Principal_Title__c", "Principal Contact Title"),
-    ("Principal_Email__c", "Principal Contact Email"),
-    ("Principal_Phone__c", "Principal Contact Phone"),
-    ("Quality_First_Name__c", "Quality Contact First Name"),
-    ("Quality_Last_Name__c", "Quality Contact Last Name"),
-    ("QC_Title__c", "Quality Contact Title"),
-    ("Quality_Email__c", "Quality Contact Email"),
-    ("Quality_Phone__c", "Quality Contact Phone"),
-    ("NY_First_Name__c", "New York Contact First Name"),
-    ("NY_Last_Name__c", "New York Contact Last Name"),
-    ("NY_Email__c", "New York Contact Email"),
-    ("NY_Phone__c", "New York Contact Phone"),
+    *(
+        (field_name, f"{role.label} Contact {suffix.replace('_', ' ').title()}")
+        for role in ACCOUNT_ROLE_DEFINITIONS
+        for suffix, field_name in role.submitted_fields
+    ),
     ("Other_Personnel_Notes__c", "Other Personnel Notes"),
     ("Comments__c", "Comments"),
 ]

--- a/src/aisc_salesforce/queried_fields.py
+++ b/src/aisc_salesforce/queried_fields.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from .account_roles import ACCOUNT_ROLE_DEFINITIONS
+
 # Application snapshot
 APPLICATION_CASE_FIELDS = (
     "Id",
@@ -67,30 +69,11 @@ SUBMISSION_FIELDS = (
     "Will_new_equipment_be_purchased__c",
     "Will_old_equipment_be_removed__c",
     "Will_software_change__c",
-    "AP_First_Name__c",
-    "AP_Last_Name__c",
-    "AP_Title__c",
-    "AP_Email__c",
-    "AP_Phone__c",
-    "Cert_First_Name__c",
-    "Cert_Last_Name__c",
-    "Cert_Title__c",
-    "Cert_Email__c",
-    "Cert_Phone__c",
-    "Principal_First_Name__c",
-    "Principal_Last_Name__c",
-    "Principal_Title__c",
-    "Principal_Email__c",
-    "Principal_Phone__c",
-    "Quality_First_Name__c",
-    "Quality_Last_Name__c",
-    "QC_Title__c",
-    "Quality_Email__c",
-    "Quality_Phone__c",
-    "NY_First_Name__c",
-    "NY_Last_Name__c",
-    "NY_Email__c",
-    "NY_Phone__c",
+    *(
+        field_name
+        for role in ACCOUNT_ROLE_DEFINITIONS
+        for _, field_name in role.submitted_fields
+    ),
     "Other_Personnel_Notes__c",
     "Comments__c",
 )
@@ -122,11 +105,7 @@ ACCOUNT_FIELDS = (
     "BillingCountry",
     "ParentId",
     "Cert_Certification_Status__c",
-    "Cert_Certification_Contact__c",
-    "Cert_Principal_Contact__c",
-    "Cert_Accounting_Contact__c",
-    "Cert_Marketing_Contact__c",
-    "Cert_Safety_Contact__c",
+    *(role.account_lookup for role in ACCOUNT_ROLE_DEFINITIONS),
 )
 
 CONTACT_FIELDS = (
@@ -160,11 +139,7 @@ ACCOUNT_REVIEW_FIELDS = (
     "BillingState",
     "BillingPostalCode",
     "BillingCountry",
-    "Cert_Certification_Contact__c",
-    "Cert_Principal_Contact__c",
-    "Cert_Accounting_Contact__c",
-    "Cert_Marketing_Contact__c",
-    "Cert_Safety_Contact__c",
+    *(role.account_lookup for role in ACCOUNT_ROLE_DEFINITIONS),
 )
 
 CONTACT_REVIEW_FIELDS = CONTACT_FIELDS

--- a/src/aisc_salesforce/review_queue.py
+++ b/src/aisc_salesforce/review_queue.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid5
 
+from .account_roles import ACCOUNT_ROLE_DEFINITIONS
 from .filesystem import sync_directory
-from .stage_profile_updates import ROLE_DEFINITIONS
 
 SCHEMA_VERSION = 1
 REVIEW_QUEUE_FILENAME = "review_queue.json"
@@ -1120,7 +1120,7 @@ def _build_contact_changes(
 def _role_link_changes(raw: dict[str, str], row: StagedRow) -> list[ProposedChange]:
     changes = []
     for affected in _affected_accounts(raw):
-        for role in ROLE_DEFINITIONS:
+        for role in ACCOUNT_ROLE_DEFINITIONS:
             if not any(
                 raw.get(f"{role.prefix}_{suffix}", "").strip()
                 for suffix, _ in role.submitted_fields

--- a/src/aisc_salesforce/stage_profile_updates.py
+++ b/src/aisc_salesforce/stage_profile_updates.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from .account_roles import (
+    ACCOUNT_ROLE_DEFINITIONS,
+    QUALIFYING_CERTIFICATION_STATUSES,
+    RoleDefinition,
+)
 from .contact_normalization import normalize_contact_value
 from .contact_resolution import (
     ContactResolution,
@@ -65,93 +70,6 @@ KEY_UPDATE_FIELDS = [
     "Revised_Company_Owner__c",
     *(api_name for _, api_name, _ in ADDRESS_FIELDS),
     *(api_name for api_name, _ in KEY_ANSWER_FIELDS),
-]
-
-ACTIVE_CERTIFICATION_STATUSES = frozenset({"Certified", "Initials"})
-
-
-@dataclass(frozen=True)
-class RoleDefinition:
-    """Map one submitted role to its fields and current Account lookup."""
-
-    prefix: str
-    label: str
-    first_name_field: str
-    last_name_field: str
-    title_field: str | None
-    email_field: str
-    phone_field: str
-    account_lookup: str
-
-    @property
-    def submitted_fields(self) -> list[tuple[str, str]]:
-        """Return pairs of CSV suffixes and Salesforce submission fields."""
-        fields = [
-            ("first_name", self.first_name_field),
-            ("last_name", self.last_name_field),
-        ]
-        if self.title_field is not None:
-            fields.append(("title", self.title_field))
-        fields.extend(
-            [
-                ("email", self.email_field),
-                ("phone", self.phone_field),
-            ]
-        )
-        return fields
-
-
-ROLE_DEFINITIONS = [
-    RoleDefinition(
-        "certification",
-        "Certification",
-        "Cert_First_Name__c",
-        "Cert_Last_Name__c",
-        "Cert_Title__c",
-        "Cert_Email__c",
-        "Cert_Phone__c",
-        "Cert_Certification_Contact__c",
-    ),
-    RoleDefinition(
-        "principal",
-        "Principal",
-        "Principal_First_Name__c",
-        "Principal_Last_Name__c",
-        "Principal_Title__c",
-        "Principal_Email__c",
-        "Principal_Phone__c",
-        "Cert_Principal_Contact__c",
-    ),
-    RoleDefinition(
-        "accounting",
-        "Accounting",
-        "AP_First_Name__c",
-        "AP_Last_Name__c",
-        "AP_Title__c",
-        "AP_Email__c",
-        "AP_Phone__c",
-        "Cert_Accounting_Contact__c",
-    ),
-    RoleDefinition(
-        "quality",
-        "Quality",
-        "Quality_First_Name__c",
-        "Quality_Last_Name__c",
-        "QC_Title__c",
-        "Quality_Email__c",
-        "Quality_Phone__c",
-        "Cert_Marketing_Contact__c",
-    ),
-    RoleDefinition(
-        "new_york",
-        "New York",
-        "NY_First_Name__c",
-        "NY_Last_Name__c",
-        None,
-        "NY_Email__c",
-        "NY_Phone__c",
-        "Cert_Safety_Contact__c",
-    ),
 ]
 
 SHARED_COLUMNS = [
@@ -215,7 +133,7 @@ def _role_columns(role: RoleDefinition) -> list[str]:
 CSV_COLUMNS = [
     *SHARED_COLUMNS,
     *KEY_COLUMNS,
-    *(column for role in ROLE_DEFINITIONS for column in _role_columns(role)),
+    *(column for role in ACCOUNT_ROLE_DEFINITIONS for column in _role_columns(role)),
 ]
 
 
@@ -342,7 +260,7 @@ class ProfileUpdateStagingService:
         lookup_ids = _unique_text_values(
             account.get(role.account_lookup)
             for account in accounts
-            for role in ROLE_DEFINITIONS
+            for role in ACCOUNT_ROLE_DEFINITIONS
         )
         clauses = []
         if account_ids:
@@ -396,7 +314,7 @@ class ProfileUpdateStagingService:
                 child
                 for child in direct_children
                 if _clean_text(child.get("Cert_Certification_Status__c"))
-                in ACTIVE_CERTIFICATION_STATUSES
+                in QUALIFYING_CERTIFICATION_STATUSES
             ]
             if direct_children
             else ([account] if account is not None else [])
@@ -812,7 +730,7 @@ def _has_submitted_update_content(records: list[dict[str, Any]]) -> bool:
         *KEY_UPDATE_FIELDS,
         *(
             api_name
-            for role in ROLE_DEFINITIONS
+            for role in ACCOUNT_ROLE_DEFINITIONS
             for _, api_name in role.submitted_fields
         ),
         "Comments__c",
@@ -827,7 +745,7 @@ def _has_submitted_update_content(records: list[dict[str, Any]]) -> bool:
 
 def _merge_roles(records: list[dict[str, Any]]) -> list[MergedRole]:
     roles: list[MergedRole] = []
-    for definition in ROLE_DEFINITIONS:
+    for definition in ACCOUNT_ROLE_DEFINITIONS:
         values: dict[str, str] = {}
         source_submission_id = ""
         for record in records:

--- a/tests/test_account_roles.py
+++ b/tests/test_account_roles.py
@@ -1,0 +1,137 @@
+"""Regression coverage for shared Account-role business rules."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from aisc_salesforce import (
+    account_roles,
+    process_profile_updates,
+    review_queue,
+    stage_profile_updates,
+)
+from aisc_salesforce.account_roles import (
+    ACCOUNT_ROLE_DEFINITIONS,
+    QUALIFYING_CERTIFICATION_STATUSES,
+    AccountRole,
+    RoleDefinition,
+)
+
+
+def test_account_roles_preserve_staged_column_prefixes():
+    assert list(AccountRole) == [
+        AccountRole.CERTIFICATION,
+        AccountRole.PRINCIPAL,
+        AccountRole.ACCOUNTING,
+        AccountRole.QUALITY_QC,
+        AccountRole.NEW_YORK,
+    ]
+    assert [role.value for role in AccountRole] == [
+        "certification",
+        "principal",
+        "accounting",
+        "quality",
+        "new_york",
+    ]
+
+
+def test_shared_role_definitions_preserve_all_salesforce_mappings():
+    assert isinstance(ACCOUNT_ROLE_DEFINITIONS, tuple)
+    assert len(ACCOUNT_ROLE_DEFINITIONS) == 5
+    assert all(
+        isinstance(definition, RoleDefinition)
+        for definition in ACCOUNT_ROLE_DEFINITIONS
+    )
+    assert [
+        (
+            definition.role,
+            definition.label,
+            definition.submitted_fields,
+            definition.account_lookup,
+        )
+        for definition in ACCOUNT_ROLE_DEFINITIONS
+    ] == [
+        (
+            AccountRole.CERTIFICATION,
+            "Certification",
+            (
+                ("first_name", "Cert_First_Name__c"),
+                ("last_name", "Cert_Last_Name__c"),
+                ("title", "Cert_Title__c"),
+                ("email", "Cert_Email__c"),
+                ("phone", "Cert_Phone__c"),
+            ),
+            "Cert_Certification_Contact__c",
+        ),
+        (
+            AccountRole.PRINCIPAL,
+            "Principal",
+            (
+                ("first_name", "Principal_First_Name__c"),
+                ("last_name", "Principal_Last_Name__c"),
+                ("title", "Principal_Title__c"),
+                ("email", "Principal_Email__c"),
+                ("phone", "Principal_Phone__c"),
+            ),
+            "Cert_Principal_Contact__c",
+        ),
+        (
+            AccountRole.ACCOUNTING,
+            "Accounting",
+            (
+                ("first_name", "AP_First_Name__c"),
+                ("last_name", "AP_Last_Name__c"),
+                ("title", "AP_Title__c"),
+                ("email", "AP_Email__c"),
+                ("phone", "AP_Phone__c"),
+            ),
+            "Cert_Accounting_Contact__c",
+        ),
+        (
+            AccountRole.QUALITY_QC,
+            "Quality",
+            (
+                ("first_name", "Quality_First_Name__c"),
+                ("last_name", "Quality_Last_Name__c"),
+                ("title", "QC_Title__c"),
+                ("email", "Quality_Email__c"),
+                ("phone", "Quality_Phone__c"),
+            ),
+            "Cert_Marketing_Contact__c",
+        ),
+        (
+            AccountRole.NEW_YORK,
+            "New York",
+            (
+                ("first_name", "NY_First_Name__c"),
+                ("last_name", "NY_Last_Name__c"),
+                ("email", "NY_Email__c"),
+                ("phone", "NY_Phone__c"),
+            ),
+            "Cert_Safety_Contact__c",
+        ),
+    ]
+
+
+def test_shared_definitions_are_immutable():
+    assert isinstance(QUALIFYING_CERTIFICATION_STATUSES, frozenset)
+    assert QUALIFYING_CERTIFICATION_STATUSES == frozenset({"Certified", "Initials"})
+    with pytest.raises(FrozenInstanceError):
+        ACCOUNT_ROLE_DEFINITIONS[0].label = "Changed"
+    with pytest.raises(AttributeError):
+        ACCOUNT_ROLE_DEFINITIONS.append(ACCOUNT_ROLE_DEFINITIONS[0])
+
+
+def test_staging_processing_and_review_queue_use_shared_definitions():
+    assert stage_profile_updates.ACCOUNT_ROLE_DEFINITIONS is ACCOUNT_ROLE_DEFINITIONS
+    assert process_profile_updates.ACCOUNT_ROLE_DEFINITIONS is ACCOUNT_ROLE_DEFINITIONS
+    assert review_queue.ACCOUNT_ROLE_DEFINITIONS is ACCOUNT_ROLE_DEFINITIONS
+    assert (
+        stage_profile_updates.QUALIFYING_CERTIFICATION_STATUSES
+        is QUALIFYING_CERTIFICATION_STATUSES
+    )
+    assert (
+        process_profile_updates.QUALIFYING_CERTIFICATION_STATUSES
+        is QUALIFYING_CERTIFICATION_STATUSES
+    )
+    assert account_roles.RoleDefinition is stage_profile_updates.RoleDefinition


### PR DESCRIPTION
## Summary
- centralize immutable Account-role mappings and qualifying certification statuses
- update staging, processing, review, query, and summary consumers to use the shared definitions
- document and test the intentional Quality/QC marketing lookup mapping

## Validation
- `uv run pytest`
- `uv run ruff check src tests`

Closes #56