### PR TITLE
Add required profile rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,11 @@ queue. The Quality/QC role intentionally uses the
 `Cert_Marketing_Contact__c` Account lookup field; its marketing-oriented name
 is established Salesforce schema, not a mapping error.
 
+`required_profile_rules.py` is a reusable, pure rule engine for choosing a
+participant Profile from Account-role assignments. It does not read from or
+write to Salesforce; future orchestration can pass it already-known Account
+IDs, roles, and certification statuses.
+
 Contact searches prefer the Account's **family accounts**: the target Account,
 its parent Account, and its **sibling accounts** that have the same parent. A
 root Account with no parent has only itself in its family. Exact normalized and

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,21 @@ The frozen data classes model an Account name plus ordered Profile Update/date
 pairs. Both recurring automation and staging use these helpers, so identifier
 matching and subject-length validation have one shared implementation.
 
+## Required participant Profile rules
+
+::: aisc_salesforce.required_profile_rules
+    options:
+      show_root_heading: true
+      members:
+        - NOT_ELIGIBLE_SKIP_REASON
+        - AccountRoleAssignment
+        - RequiredProfileDecision
+        - determine_required_profile
+
+This pure rule module accepts already-known Account-role assignments and never
+reads from or writes to Salesforce. Its frozen decision preserves the ordered,
+deduplicated assignments that caused the selected Profile.
+
 ## Legacy Case subject correction
 
 ::: aisc_salesforce.rename_profile_update_cases

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -599,6 +599,15 @@ New York has no submitted title field. Completely blank roles have completely
 blank role columns. The prefixed resolution columns are readable projections
 kept for compatibility; `contact_resolutions` is the authoritative contract.
 
+### Required participant Profile rules
+
+`aisc_salesforce.required_profile_rules` is a pure Python rule engine for
+selecting a participant Profile from Account-role assignments. It accepts an
+`AccountRole`, Salesforce Account ID, and certification status for each
+assignment, then returns a Profile decision and its ordered, deduplicated
+causes. It performs no Salesforce reads or writes. A later orchestration layer
+is responsible for obtaining assignments and using the result.
+
 Each JSON entry represents one distinct comparison key shared by any submitter
 and role occurrences. It contains:
 

--- a/src/aisc_salesforce/required_profile_rules.py
+++ b/src/aisc_salesforce/required_profile_rules.py
@@ -1,0 +1,87 @@
+"""Pure rules for selecting a participant Profile from Account-role assignments.
+
+This module deliberately does not read from or write to Salesforce.  Callers
+provide already-known assignments and can later use the returned profile when
+orchestrating Salesforce work.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .account_roles import QUALIFYING_CERTIFICATION_STATUSES, AccountRole
+from .user_sync_config import ParticipantProfile
+
+NOT_ELIGIBLE_SKIP_REASON = "Not eligible: no qualifying Account-role assignments."
+"""Reason returned when no assignment has a qualifying certification status."""
+
+
+@dataclass(frozen=True)
+class AccountRoleAssignment:
+    """One Account role, its Salesforce Account ID, and certification status."""
+
+    role: AccountRole
+    account_id: str
+    certification_status: str
+
+
+@dataclass(frozen=True)
+class RequiredProfileDecision:
+    """The selected profile, eligibility explanation, and ordered rule causes."""
+
+    profile: ParticipantProfile | None
+    skip_reason: str | None
+    causal_assignments: tuple[AccountRoleAssignment, ...]
+
+
+_SINGLE_ROLE_PROFILES = {
+    AccountRole.CERTIFICATION: ParticipantProfile.PARTICIPANT,
+    AccountRole.PRINCIPAL: ParticipantProfile.PRINCIPAL,
+    AccountRole.ACCOUNTING: ParticipantProfile.AP,
+    AccountRole.QUALITY_QC: ParticipantProfile.QC,
+}
+
+
+def determine_required_profile(
+    assignments: Iterable[AccountRoleAssignment],
+) -> RequiredProfileDecision:
+    """Select the required participant Profile from qualifying assignments.
+
+    Duplicate role/Account pairs retain only their first occurrence.  A New
+    York assignment or more than one distinct role requires the RAS profile.
+    """
+    causes = _qualifying_unique_assignments(assignments)
+    if not causes:
+        return RequiredProfileDecision(
+            profile=None,
+            skip_reason=NOT_ELIGIBLE_SKIP_REASON,
+            causal_assignments=(),
+        )
+
+    roles = {assignment.role for assignment in causes}
+    if AccountRole.NEW_YORK in roles or len(roles) > 1:
+        profile = ParticipantProfile.RAS
+    else:
+        profile = _SINGLE_ROLE_PROFILES[next(iter(roles))]
+    return RequiredProfileDecision(
+        profile=profile,
+        skip_reason=None,
+        causal_assignments=causes,
+    )
+
+
+def _qualifying_unique_assignments(
+    assignments: Iterable[AccountRoleAssignment],
+) -> tuple[AccountRoleAssignment, ...]:
+    """Return qualifying role/Account causes in first-seen order."""
+    causes: list[AccountRoleAssignment] = []
+    seen: set[tuple[AccountRole, str]] = set()
+    for assignment in assignments:
+        if assignment.certification_status not in QUALIFYING_CERTIFICATION_STATUSES:
+            continue
+        key = (assignment.role, assignment.account_id)
+        if key not in seen:
+            seen.add(key)
+            causes.append(assignment)
+    return tuple(causes)

--- a/tests/test_required_profile_rules.py
+++ b/tests/test_required_profile_rules.py
@@ -1,0 +1,125 @@
+"""Tests for the pure required-profile rule engine."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from aisc_salesforce.account_roles import AccountRole
+from aisc_salesforce.required_profile_rules import (
+    NOT_ELIGIBLE_SKIP_REASON,
+    AccountRoleAssignment,
+    RequiredProfileDecision,
+    determine_required_profile,
+)
+from aisc_salesforce.user_sync_config import ParticipantProfile
+
+
+def assignment(
+    role: AccountRole,
+    account_id: str = "001-first",
+    certification_status: str = "Certified",
+) -> AccountRoleAssignment:
+    """Create a concise assignment for a rule test."""
+    return AccountRoleAssignment(role, account_id, certification_status)
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_profile"),
+    [
+        (AccountRole.CERTIFICATION, ParticipantProfile.PARTICIPANT),
+        (AccountRole.PRINCIPAL, ParticipantProfile.PRINCIPAL),
+        (AccountRole.ACCOUNTING, ParticipantProfile.AP),
+        (AccountRole.QUALITY_QC, ParticipantProfile.QC),
+    ],
+)
+def test_single_qualifying_role_selects_its_profile(role, expected_profile):
+    source = assignment(role)
+
+    decision = determine_required_profile([source])
+
+    assert decision == RequiredProfileDecision(expected_profile, None, (source,))
+
+
+def test_new_york_role_requires_ras_profile():
+    source = assignment(AccountRole.NEW_YORK)
+
+    decision = determine_required_profile([source])
+
+    assert decision == RequiredProfileDecision(ParticipantProfile.RAS, None, (source,))
+
+
+@pytest.mark.parametrize(
+    "sources",
+    [
+        [assignment(AccountRole.CERTIFICATION), assignment(AccountRole.PRINCIPAL)],
+        [
+            assignment(AccountRole.ACCOUNTING, "001-first"),
+            assignment(AccountRole.QUALITY_QC, "001-second"),
+        ],
+        [assignment(AccountRole.CERTIFICATION), assignment(AccountRole.NEW_YORK)],
+    ],
+)
+def test_multiple_distinct_qualifying_roles_require_ras_profile(sources):
+    decision = determine_required_profile(sources)
+
+    assert decision == RequiredProfileDecision(
+        ParticipantProfile.RAS, None, tuple(sources)
+    )
+
+
+def test_repeated_role_on_different_accounts_stays_as_separate_causes():
+    sources = [
+        assignment(AccountRole.PRINCIPAL, "001-first"),
+        assignment(AccountRole.PRINCIPAL, "001-second"),
+    ]
+
+    decision = determine_required_profile(sources)
+
+    assert decision == RequiredProfileDecision(
+        ParticipantProfile.PRINCIPAL, None, tuple(sources)
+    )
+
+
+def test_ignored_statuses_do_not_cause_eligibility_or_a_profile():
+    sources = [
+        assignment(AccountRole.CERTIFICATION, certification_status="Expired"),
+        assignment(AccountRole.PRINCIPAL, certification_status="Pending"),
+    ]
+
+    decision = determine_required_profile(sources)
+
+    assert decision == RequiredProfileDecision(None, NOT_ELIGIBLE_SKIP_REASON, ())
+
+
+def test_initials_is_a_qualifying_certification_status():
+    source = assignment(AccountRole.ACCOUNTING, certification_status="Initials")
+
+    assert determine_required_profile([source]).profile is ParticipantProfile.AP
+
+
+def test_no_assignments_is_not_eligible():
+    assert determine_required_profile([]) == RequiredProfileDecision(
+        None, NOT_ELIGIBLE_SKIP_REASON, ()
+    )
+
+
+def test_duplicate_role_account_causes_are_deduplicated_in_first_seen_order():
+    first = assignment(AccountRole.CERTIFICATION, "001-first", "Certified")
+    duplicate = assignment(AccountRole.CERTIFICATION, "001-first", "Initials")
+    other = assignment(AccountRole.CERTIFICATION, "001-second")
+
+    decision = determine_required_profile([first, duplicate, other])
+
+    assert decision == RequiredProfileDecision(
+        ParticipantProfile.PARTICIPANT, None, (first, other)
+    )
+
+
+def test_rule_input_and_decision_are_frozen():
+    source = assignment(AccountRole.CERTIFICATION)
+    decision = determine_required_profile([source])
+
+    with pytest.raises(FrozenInstanceError):
+        source.account_id = "001-other"
+    with pytest.raises(FrozenInstanceError):
+        decision.profile = ParticipantProfile.RAS


### PR DESCRIPTION
## Summary
- add a pure rule engine for selecting required participant Profiles from Account-role assignments
- filter non-qualifying certification statuses and preserve ordered, deduplicated causes
- document the public API and add comprehensive tests

Tests: 462 passed

Closes #58