### PR TITLE
Prioritize RAS for multi-account family accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,12 @@ is established Salesforce schema, not a mapping error.
 `required_profile_rules.py` is a reusable, pure rule engine for choosing a
 participant Profile from Account-role assignments. It does not read from or
 write to Salesforce; future orchestration can pass it already-known Account
-IDs, roles, and certification statuses.
+IDs, roles, certification statuses, and the IDs of Accounts in multi-account
+Families. Only `Certified` and `Initials` assignments qualify. When a
+qualifying assignment belongs to a multi-account Family, it selects the
+Participant RAS Profile before the usual single-role, New York, and
+multiple-role rules. Accounts outside that supplied ID set keep the usual
+rules.
 
 Contact searches prefer the Account's **family accounts**: the target Account,
 its parent Account, and its **sibling accounts** that have the same parent. A

--- a/docs/api.md
+++ b/docs/api.md
@@ -107,7 +107,11 @@ matching and subject-length validation have one shared implementation.
 
 This pure rule module accepts already-known Account-role assignments and never
 reads from or writes to Salesforce. Its frozen decision preserves the ordered,
-deduplicated assignments that caused the selected Profile.
+deduplicated assignments that caused the selected Profile. Callers can
+optionally pass the Account IDs that belong to multi-account Families. A
+qualifying assignment on one of those IDs selects Participant RAS before the
+usual role-based rules; `Certified` and `Initials` are the only qualifying
+statuses.
 
 ## Legacy Case subject correction
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -81,6 +81,11 @@ identify the exact data involved.
   itself. Family membership helps the project prefer a relevant Contact match;
   it does not automatically change every Account in the family.
 
+  For required participant Profile selection, a **multi-account Family** is an
+  Account that has a parent, a child, or a sibling in the Account hierarchy. A
+  standalone root Account is not a multi-account Family. A qualifying role on
+  a multi-account Family Account requires the Participant RAS Profile.
+
 ## I
 
 **iMIS contact consolidation**
@@ -154,4 +159,3 @@ identify the exact data involved.
 
 : One row in the staged Profile Updates CSV. It may represent one submission or
   several compatible submissions grouped by Account and submitter email.
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -606,7 +606,13 @@ selecting a participant Profile from Account-role assignments. It accepts an
 `AccountRole`, Salesforce Account ID, and certification status for each
 assignment, then returns a Profile decision and its ordered, deduplicated
 causes. It performs no Salesforce reads or writes. A later orchestration layer
-is responsible for obtaining assignments and using the result.
+is responsible for obtaining assignments and using the result. Only
+`Certified` and `Initials` assignments are eligible. That layer can also pass
+the IDs of Accounts in multi-account Families (Accounts with a parent, child,
+or sibling). A qualifying assignment on one of those IDs has first priority and
+selects Participant RAS. A standalone root Account does not qualify for this
+override. When no qualifying assignment is in the supplied ID set, the usual
+single-role, New York, and multiple-role rules apply unchanged.
 
 Each JSON entry represents one distinct comparison key shared by any submitter
 and role occurrences. It contains:

--- a/src/aisc_salesforce/required_profile_rules.py
+++ b/src/aisc_salesforce/required_profile_rules.py
@@ -2,12 +2,13 @@
 
 This module deliberately does not read from or write to Salesforce.  Callers
 provide already-known assignments and can later use the returned profile when
-orchestrating Salesforce work.
+orchestrating Salesforce work. A qualifying assignment on a multi-account
+Family Account has priority and selects the RAS profile.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 
 from .account_roles import QUALIFYING_CERTIFICATION_STATUSES, AccountRole
@@ -45,11 +46,18 @@ _SINGLE_ROLE_PROFILES = {
 
 def determine_required_profile(
     assignments: Iterable[AccountRoleAssignment],
+    multi_account_family_account_ids: Collection[str] | None = None,
 ) -> RequiredProfileDecision:
     """Select the required participant Profile from qualifying assignments.
 
-    Duplicate role/Account pairs retain only their first occurrence.  A New
-    York assignment or more than one distinct role requires the RAS profile.
+    Duplicate role/Account pairs retain only their first occurrence. A
+    qualifying assignment on an Account in ``multi_account_family_account_ids``
+    requires the RAS profile before all other profile rules. Otherwise, a New
+    York assignment or more than one distinct role requires RAS.
+
+    ``multi_account_family_account_ids`` is optional so callers that do not
+    have family-hierarchy information retain the existing behavior. Its IDs
+    must represent Accounts that have a parent, child, or sibling.
     """
     causes = _qualifying_unique_assignments(assignments)
     if not causes:
@@ -59,16 +67,30 @@ def determine_required_profile(
             causal_assignments=(),
         )
 
-    roles = {assignment.role for assignment in causes}
-    if AccountRole.NEW_YORK in roles or len(roles) > 1:
+    if multi_account_family_account_ids is not None and any(
+        assignment.account_id in multi_account_family_account_ids
+        for assignment in causes
+    ):
         profile = ParticipantProfile.RAS
     else:
-        profile = _SINGLE_ROLE_PROFILES[next(iter(roles))]
+        profile = _profile_from_roles(causes)
     return RequiredProfileDecision(
         profile=profile,
         skip_reason=None,
         causal_assignments=causes,
     )
+
+
+def _profile_from_roles(
+    causes: tuple[AccountRoleAssignment, ...],
+) -> ParticipantProfile:
+    """Return the usual Profile from qualifying assignments without family data."""
+    roles = {assignment.role for assignment in causes}
+    if AccountRole.NEW_YORK in roles or len(roles) > 1:
+        profile = ParticipantProfile.RAS
+    else:
+        profile = _SINGLE_ROLE_PROFILES[next(iter(roles))]
+    return profile
 
 
 def _qualifying_unique_assignments(

--- a/tests/test_required_profile_rules.py
+++ b/tests/test_required_profile_rules.py
@@ -48,6 +48,55 @@ def test_new_york_role_requires_ras_profile():
     assert decision == RequiredProfileDecision(ParticipantProfile.RAS, None, (source,))
 
 
+@pytest.mark.parametrize("role", list(AccountRole))
+def test_multi_account_family_assignment_overrides_role_profile_with_ras(role):
+    source = assignment(role, "001-family-member")
+
+    decision = determine_required_profile(
+        [source], multi_account_family_account_ids={"001-family-member"}
+    )
+
+    assert decision == RequiredProfileDecision(ParticipantProfile.RAS, None, (source,))
+
+
+def test_non_qualifying_multi_account_family_assignment_is_not_eligible():
+    source = assignment(
+        AccountRole.PRINCIPAL,
+        "001-family-member",
+        certification_status="Expired",
+    )
+
+    decision = determine_required_profile(
+        [source], multi_account_family_account_ids={"001-family-member"}
+    )
+
+    assert decision == RequiredProfileDecision(None, NOT_ELIGIBLE_SKIP_REASON, ())
+
+
+@pytest.mark.parametrize(
+    ("sources", "expected_profile"),
+    [
+        ([assignment(AccountRole.PRINCIPAL)], ParticipantProfile.PRINCIPAL),
+        ([assignment(AccountRole.NEW_YORK)], ParticipantProfile.RAS),
+        (
+            [
+                assignment(AccountRole.ACCOUNTING, "001-first"),
+                assignment(AccountRole.QUALITY_QC, "001-second"),
+            ],
+            ParticipantProfile.RAS,
+        ),
+    ],
+)
+def test_assignments_outside_multi_account_family_keep_existing_rules(
+    sources, expected_profile
+):
+    decision = determine_required_profile(
+        sources, multi_account_family_account_ids={"001-unrelated-family-member"}
+    )
+
+    assert decision == RequiredProfileDecision(expected_profile, None, tuple(sources))
+
+
 @pytest.mark.parametrize(
     "sources",
     [


### PR DESCRIPTION
## Summary
- prioritize the Participant RAS Profile for qualifying assignments on multi-account Family Accounts
- preserve existing single-role, New York, and multiple-role behavior outside the supplied family Account IDs
- document the rule and add coverage for qualifying and non-qualifying statuses

## Validation
- pytest -q tests/test_required_profile_rules.py (23 passed)