### PR TITLE
Add participant-drop intake workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ the command tries them before asking for a company name. If more than one
 Account matches, it requires an explicit selection. Enter `cancel` at any
 prompt to exit without writing to Salesforce. Once an Account is resolved, the
 command posts `Withdrawal in progress: <scenario>.` to that Account's Chatter
-feed. Invoice lookup uses the live-metadata field `Invoice.InvoiceNumber` (not
-`Invoice.Name`) and its `BillingAccountId`.
+feed. Invoice lookup does not use Salesforce's built-in `Invoice` object.
+Instead, it matches the invoice number against `Cert_Invoice__c.Name` and uses
+that record's `Cert_Account__c` Account lookup.
 
 Create a read-only application-stage count:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ command reports blockers—such as a missing email, profile configuration
 problem, username collision, or multiple active linked Users—instead of
 attempting a repair. `--json` provides a stable machine-readable plan.
 
+Start an interactive participant-drop intake:
+
+```bash
+uv run aisc_salesforce participant-drop
+```
+
+Choose Unpaid Invoice, Withdrawal Request, CRG drop, or another participant
+drop. The related reference and Certification ID are optional; when supplied,
+the command tries them before asking for a company name. If more than one
+Account matches, it requires an explicit selection. Enter `cancel` at any
+prompt to exit without writing to Salesforce. Once an Account is resolved, the
+command posts `Withdrawal in progress: <scenario>.` to that Account's Chatter
+feed. Invoice lookup uses the live-metadata field `Invoice.InvoiceNumber` (not
+`Invoice.Name`) and its `BillingAccountId`.
+
 Create a read-only application-stage count:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,11 +42,11 @@ uv run aisc_salesforce participant-drop
 
 Select the scenario (Unpaid Invoice, Withdrawal Request, CRG drop, or another
 participant drop). Reference values are optional. An invoice reference is
-matched exactly against `Invoice.InvoiceNumber`, a Withdrawal Request reference
+matched exactly against `Cert_Invoice__c.Name`, a Withdrawal Request reference
 against `Withdrawal_Request__c.Name`, and a CRG reference against
-`Cert_Audit__c.Name`. Those records supply their Account lookup. This corrects
-the older `Invoice.Name` assumption: live Salesforce metadata uses
-`Invoice.InvoiceNumber` and `BillingAccountId`.
+`Cert_Audit__c.Name`. Those records supply their Account lookup. The workflow
+does not use Salesforce's built-in `Invoice` object; it uses the custom
+`Cert_Invoice__c` object and its `Cert_Account__c` Account lookup.
 
 When a reference does not resolve an Account, the command tries a normalized
 Certification ID and then normalized partial company-name matches. A single

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,29 @@ cp .env.example .env
 The CLI loads `.env` without replacing environment variables that are already
 set.
 
+## Participant-drop intake
+
+Start a participant withdrawal intake from the terminal:
+
+```bash
+uv run aisc_salesforce participant-drop
+```
+
+Select the scenario (Unpaid Invoice, Withdrawal Request, CRG drop, or another
+participant drop). Reference values are optional. An invoice reference is
+matched exactly against `Invoice.InvoiceNumber`, a Withdrawal Request reference
+against `Withdrawal_Request__c.Name`, and a CRG reference against
+`Cert_Audit__c.Name`. Those records supply their Account lookup. This corrects
+the older `Invoice.Name` assumption: live Salesforce metadata uses
+`Invoice.InvoiceNumber` and `BillingAccountId`.
+
+When a reference does not resolve an Account, the command tries a normalized
+Certification ID and then normalized partial company-name matches. A single
+match proceeds automatically; multiple matches always require an explicit
+choice. Type `cancel` at any prompt to stop. Cancellation makes no Salesforce
+write. A completed intake posts exactly `Withdrawal in progress: <scenario>.`
+to the selected Account's Chatter feed.
+
 ## Participant user-provisioning Profile check
 
 Run the read-only configuration check before using participant provisioning:

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -14,9 +14,11 @@ from .application_snapshot import (
     ApplicationSnapshotService,
     write_application_snapshot,
 )
+from .cli_participant_drop import CLIParticipantDropInteraction
 from .cli_review_ui import CLIReviewUI, ColorMode, print_profile_error
 from .dictionary import DictionaryError, load_export_plan
 from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
+from .participant_drop import ParticipantDropService
 from .picklist_audit import (
     PicklistAuditError,
     PicklistAuditResult,
@@ -168,6 +170,10 @@ def main(
     reconcile_user_parser.add_argument(
         "--json", action="store_true", help="Print the stable JSON plan contract."
     )
+    subparsers.add_parser(
+        "participant-drop",
+        help="Interactively record that a participant withdrawal is in progress.",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -284,6 +290,12 @@ def main(
         except (SalesforceError, UserSyncConfigError) as error:
             print(f"User reconciliation failed: {error}", file=sys.stderr)
             return 1
+    if args.command == "participant-drop":
+        try:
+            return _run_participant_drop(input_fn=input_fn, output_fn=output_fn)
+        except (SalesforceError, ValueError) as error:
+            print(f"Participant drop failed: {error}", file=sys.stderr)
+            return 1
     return 1
 
 
@@ -354,6 +366,22 @@ def _run_reconcile_user(
     return (
         1 if any(item.code == "profile_configuration" for item in plan.blockers) else 0
     )
+
+
+def _run_participant_drop(
+    *,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Authenticate and run the interactive participant withdrawal intake."""
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    ParticipantDropService(SalesforceClient(auth)).run(
+        CLIParticipantDropInteraction(input_fn=input_fn, output_fn=output_fn)
+    )
+    return 0
 
 
 def _print_picklist_audit(

--- a/src/aisc_salesforce/cli_participant_drop.py
+++ b/src/aisc_salesforce/cli_participant_drop.py
@@ -1,0 +1,77 @@
+"""Terminal adapter for the participant-drop workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .participant_drop import AccountCandidate, ParticipantDropScenario
+
+
+class CLIParticipantDropInteraction:
+    """Ask terminal users for the values required by participant-drop intake."""
+
+    def __init__(
+        self,
+        *,
+        input_fn: Callable[[str], str] = input,
+        output_fn: Callable[[str], None] = print,
+    ):
+        self.input_fn = input_fn
+        self.output_fn = output_fn
+
+    def choose_scenario(self) -> ParticipantDropScenario | None:
+        choices = tuple(ParticipantDropScenario)
+        self.output_fn("Participant-drop scenario:")
+        for index, scenario in enumerate(choices, start=1):
+            self.output_fn(f"  {index}. {scenario.value}")
+        while True:
+            value = self.input_fn("Choose a scenario (or 'cancel'): ").strip()
+            if _is_cancel(value):
+                return None
+            if value.isdigit() and 1 <= int(value) <= len(choices):
+                return choices[int(value) - 1]
+            self.output_fn("Enter one of the listed numbers, or 'cancel'.")
+
+    def request_reference(self, scenario: ParticipantDropScenario) -> str | None:
+        labels = {
+            ParticipantDropScenario.UNPAID_INVOICE: "Invoice number",
+            ParticipantDropScenario.WITHDRAWAL_REQUEST: "Withdrawal Request name",
+            ParticipantDropScenario.CRG_DROP: "CRG audit name",
+            ParticipantDropScenario.OTHER: "Related reference",
+        }
+        value = self.input_fn(
+            f"{labels[scenario]} (optional; press Enter to skip, or 'cancel'): "
+        ).strip()
+        return None if _is_cancel(value) else value
+
+    def request_certification_id(self) -> str | None:
+        value = self.input_fn(
+            "Certification ID (optional; press Enter to skip, or 'cancel'): "
+        ).strip()
+        return None if _is_cancel(value) else value
+
+    def request_company_name(self) -> str | None:
+        value = self.input_fn("Company name (or 'cancel'): ").strip()
+        return None if _is_cancel(value) else value
+
+    def select_account(
+        self, candidates: tuple[AccountCandidate, ...]
+    ) -> AccountCandidate | None:
+        self.output_fn("Multiple Accounts matched:")
+        for index, candidate in enumerate(candidates, start=1):
+            certification_id = candidate.certification_id or "no Certification ID"
+            self.output_fn(f"  {index}. {candidate.name} ({certification_id})")
+        while True:
+            value = self.input_fn("Choose an Account (or 'cancel'): ").strip()
+            if _is_cancel(value):
+                return None
+            if value.isdigit() and 1 <= int(value) <= len(candidates):
+                return candidates[int(value) - 1]
+            self.output_fn("Enter one of the listed numbers, or 'cancel'.")
+
+    def show(self, message: str) -> None:
+        self.output_fn(message)
+
+
+def _is_cancel(value: str) -> bool:
+    return value.casefold() in {"cancel", "c", "q", "quit"}

--- a/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
+++ b/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
@@ -71,6 +71,11 @@ Account,acct_support_functions,Support_Office_Functions__c,many,,FALSE
 Account,acct_support_location,Support_Office_Location__c,many,,FALSE
 Account,acct_sustainability,Sustainability_Program__c,boolean,,FALSE
 Account,acct_url,Website,string,should be restricted to a url,FALSE
+Invoice,invoice_number,InvoiceNumber,string,The invoice number used for participant-drop lookup,TRUE
+Invoice,invoice_billing_account,BillingAccountId,Lookup (Account),Account used for participant-drop lookup,TRUE
+Withdrawal_Request__c,withdrawal_request_id,Id,Id,Withdrawal request record ID,TRUE
+Withdrawal_Request__c,withdrawal_request_name,Name,string,Withdrawal request reference used for participant-drop lookup,TRUE
+Withdrawal_Request__c,withdrawal_request_account,Account__c,Lookup (Account),Account used for participant-drop lookup,TRUE
 Case,case_acctid,AccountId,,,TRUE
 Case,case_additional_audit,Additional_Audit__c,,,FALSE
 Case,case_adhere_to_aisc_cosp_2_1,Adhere_to_AISC_CoSP_2_1__c,,,FALSE

--- a/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
+++ b/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
@@ -71,8 +71,8 @@ Account,acct_support_functions,Support_Office_Functions__c,many,,FALSE
 Account,acct_support_location,Support_Office_Location__c,many,,FALSE
 Account,acct_sustainability,Sustainability_Program__c,boolean,,FALSE
 Account,acct_url,Website,string,should be restricted to a url,FALSE
-Invoice,invoice_number,InvoiceNumber,string,The invoice number used for participant-drop lookup,TRUE
-Invoice,invoice_billing_account,BillingAccountId,Lookup (Account),Account used for participant-drop lookup,TRUE
+Cert_Invoice__c,cert_invoice_name,Name,string,The invoice number used for participant-drop lookup,TRUE
+Cert_Invoice__c,cert_invoice_account,Cert_Account__c,Lookup (Account),Account used for participant-drop lookup,TRUE
 Withdrawal_Request__c,withdrawal_request_id,Id,Id,Withdrawal request record ID,TRUE
 Withdrawal_Request__c,withdrawal_request_name,Name,string,Withdrawal request reference used for participant-drop lookup,TRUE
 Withdrawal_Request__c,withdrawal_request_account,Account__c,Lookup (Account),Account used for participant-drop lookup,TRUE

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -53,7 +53,7 @@ class ParticipantDropInteraction(Protocol):
 
 
 _REFERENCE_LOOKUPS = {
-    ParticipantDropScenario.UNPAID_INVOICE: ("Invoice", "InvoiceNumber", "BillingAccountId"),
+    ParticipantDropScenario.UNPAID_INVOICE: ("Cert_Invoice__c", "Name", "Cert_Account__c"),
     ParticipantDropScenario.WITHDRAWAL_REQUEST: (
         "Withdrawal_Request__c",
         "Name",

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -1,0 +1,212 @@
+"""Reusable participant-withdrawal intake and Account resolution workflow."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class ParticipantDropScenario(StrEnum):
+    """The reason a participant withdrawal is being started."""
+
+    UNPAID_INVOICE = "Unpaid Invoice"
+    WITHDRAWAL_REQUEST = "Withdrawal Request"
+    CRG_DROP = "CRG drop"
+    OTHER = "Other participant drop"
+
+
+@dataclass(frozen=True)
+class AccountCandidate:
+    """The small amount of Account information needed for human selection."""
+
+    id: str
+    name: str
+    certification_id: str | None
+
+
+@dataclass(frozen=True)
+class ParticipantDropResult:
+    """The outcome of one intake run."""
+
+    account: AccountCandidate | None
+    cancelled: bool = False
+
+
+class ParticipantDropInteraction(Protocol):
+    """UI boundary for the workflow; terminals are only one possible adapter."""
+
+    def choose_scenario(self) -> ParticipantDropScenario | None: ...
+
+    def request_reference(self, scenario: ParticipantDropScenario) -> str | None: ...
+
+    def request_certification_id(self) -> str | None: ...
+
+    def request_company_name(self) -> str | None: ...
+
+    def select_account(
+        self, candidates: tuple[AccountCandidate, ...]
+    ) -> AccountCandidate | None: ...
+
+    def show(self, message: str) -> None: ...
+
+
+_REFERENCE_LOOKUPS = {
+    ParticipantDropScenario.UNPAID_INVOICE: ("Invoice", "InvoiceNumber", "BillingAccountId"),
+    ParticipantDropScenario.WITHDRAWAL_REQUEST: (
+        "Withdrawal_Request__c",
+        "Name",
+        "Account__c",
+    ),
+    ParticipantDropScenario.CRG_DROP: ("Cert_Audit__c", "Name", "Cert_Account__c"),
+}
+_NORMALIZED_SEARCH = re.compile(r"[^a-z0-9]+")
+
+
+class ParticipantDropService:
+    """Find one Account and record the start of its withdrawal in Chatter."""
+
+    def __init__(self, client: object):
+        self.client = client
+
+    def run(self, interaction: ParticipantDropInteraction) -> ParticipantDropResult:
+        """Run intake, posting only after one Account has been resolved."""
+        scenario = interaction.choose_scenario()
+        if scenario is None:
+            return self._cancel(interaction)
+
+        reference = interaction.request_reference(scenario)
+        if reference is None:
+            return self._cancel(interaction)
+        account = self._find_by_reference(scenario, reference)
+        if account is None and reference.strip():
+            interaction.show("No Account matched that reference; using fallback search.")
+
+        if account is None:
+            certification_id = interaction.request_certification_id()
+            if certification_id is None:
+                return self._cancel(interaction)
+            account = self._find_by_certification_id(certification_id)
+            if account is None and certification_id.strip():
+                interaction.show(
+                    "No Account matched that Certification ID; using company-name search."
+                )
+
+        while account is None:
+            company_name = interaction.request_company_name()
+            if company_name is None:
+                return self._cancel(interaction)
+            candidates = self._find_by_company_name(company_name)
+            if not candidates:
+                interaction.show("No Accounts matched that company name; try again or cancel.")
+                continue
+            if len(candidates) == 1:
+                account = candidates[0]
+                continue
+            selected = interaction.select_account(candidates)
+            if selected is None:
+                return self._cancel(interaction)
+            if selected not in candidates:
+                raise ValueError("Selected Account was not one of the presented candidates.")
+            account = selected
+
+        message = f"Withdrawal in progress: {scenario.value}."
+        self.client.post_feed_message(account.id, message)
+        interaction.show(f"Withdrawal intake recorded for {account.name}.")
+        return ParticipantDropResult(account)
+
+    def _find_by_reference(
+        self, scenario: ParticipantDropScenario, reference: str
+    ) -> AccountCandidate | None:
+        if not reference.strip() or scenario not in _REFERENCE_LOOKUPS:
+            return None
+        object_name, key_field, account_field = _REFERENCE_LOOKUPS[scenario]
+        records = self.client.query_records(
+            object_name,
+            [key_field, account_field],
+            where=f"{key_field} = '{_soql_literal(reference.strip())}'",
+        )
+        account_ids = {
+            record.get(account_field)
+            for record in records
+            if isinstance(record.get(account_field), str) and record[account_field]
+        }
+        if len(account_ids) != 1:
+            return None
+        return self._find_account_by_id(account_ids.pop())
+
+    def _find_account_by_id(self, account_id: str) -> AccountCandidate | None:
+        records = self.client.query_records(
+            "Account",
+            ["Id", "Name", "Certification_ID__c"],
+            where=f"Id = '{_soql_literal(account_id)}'",
+        )
+        candidates = _account_candidates(records)
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _find_by_certification_id(self, certification_id: str) -> AccountCandidate | None:
+        normalized = _normalize_search(certification_id)
+        if not normalized:
+            return None
+        records = self.client.query_records(
+            "Account",
+            ["Id", "Name", "Certification_ID__c"],
+            where="Certification_ID__c != NULL",
+        )
+        candidates = [
+            candidate
+            for candidate in _account_candidates(records)
+            if _normalize_search(candidate.certification_id) == normalized
+        ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _find_by_company_name(self, company_name: str) -> tuple[AccountCandidate, ...]:
+        normalized = _normalize_search(company_name)
+        if not normalized:
+            return ()
+        records = self.client.query_records(
+            "Account",
+            ["Id", "Name", "Certification_ID__c"],
+            where="Name != NULL",
+        )
+        return tuple(
+            candidate
+            for candidate in _account_candidates(records)
+            if normalized in _normalize_search(candidate.name)
+        )
+
+    @staticmethod
+    def _cancel(interaction: ParticipantDropInteraction) -> ParticipantDropResult:
+        interaction.show("Participant drop cancelled; no Salesforce changes were made.")
+        return ParticipantDropResult(None, cancelled=True)
+
+
+def _account_candidates(records: list[dict[str, object]]) -> tuple[AccountCandidate, ...]:
+    """Turn valid Account query rows into unique candidates in Salesforce order."""
+    candidates: list[AccountCandidate] = []
+    known_ids: set[str] = set()
+    for record in records:
+        account_id = record.get("Id")
+        name = record.get("Name")
+        certification_id = record.get("Certification_ID__c")
+        if not isinstance(account_id, str) or not isinstance(name, str) or account_id in known_ids:
+            continue
+        candidates.append(
+            AccountCandidate(
+                account_id,
+                name,
+                certification_id if isinstance(certification_id, str) else None,
+            )
+        )
+        known_ids.add(account_id)
+    return tuple(candidates)
+
+
+def _normalize_search(value: str | None) -> str:
+    return _NORMALIZED_SEARCH.sub("", (value or "").casefold())
+
+
+def _soql_literal(value: str) -> str:
+    """Escape user text placed inside one quoted SOQL literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,40 @@ def test_user_sync_config_cli_runs_the_read_only_check(monkeypatch, capsys):
     assert capsys.readouterr().err == ""
 
 
+def test_participant_drop_cli_runs_interactive_workflow(monkeypatch):
+    output = []
+    received = {}
+
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(
+        app.os, "environ", {"SF_CLIENT_ID": "id", "SF_CLIENT_SECRET": "secret"}
+    )
+    monkeypatch.setattr(app, "get_credentials", lambda values: values)
+    monkeypatch.setattr(app, "get_oauth_url", lambda values: "token-url")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: "auth"
+    )
+    monkeypatch.setattr(app, "SalesforceClient", lambda auth: "client")
+
+    class Service:
+        def __init__(self, client):
+            assert client == "client"
+
+        def run(self, interaction):
+            received["scenario"] = interaction.choose_scenario()
+            received["reference"] = interaction.request_reference(received["scenario"])
+            return SimpleNamespace(cancelled=False)
+
+    monkeypatch.setattr(app, "ParticipantDropService", Service)
+
+    answers = iter(["1", "INV-42"])
+    assert app.main(
+        ["participant-drop"], input_fn=lambda prompt: next(answers), output_fn=output.append
+    ) == 0
+    assert received["scenario"].value == "Unpaid Invoice"
+    assert received["reference"] == "INV-42"
+
+
 def test_user_sync_config_command_authenticates_and_validates(monkeypatch, capsys):
     environment = {
         "SF_CLIENT_ID": "id",

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -113,4 +113,7 @@ def test_schema_dictionary_includes_participant_drop_withdrawal_fields():
         "Name",
         "Account__c",
     ]
-    assert "InvoiceNumber" in [field.api_name for field in plan["Invoice"]]
+    assert [field.api_name for field in plan["Cert_Invoice__c"]] == [
+        "Name",
+        "Cert_Account__c",
+    ]

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,4 +1,5 @@
 import csv
+from pathlib import Path
 
 import pytest
 
@@ -97,3 +98,19 @@ def test_load_export_plan_rejects_missing_columns(tmp_path):
     write_dictionary(path, [], headers=["Salesforce_Table"])
     with pytest.raises(DictionaryError, match="missing required columns"):
         load_export_plan(path)
+
+
+def test_schema_dictionary_includes_participant_drop_withdrawal_fields():
+    dictionary_path = (
+        Path(__file__).parents[1]
+        / "src/aisc_salesforce/data/salesforce_schema_dictionary.csv"
+    )
+
+    plan = load_export_plan(dictionary_path)
+
+    assert [field.api_name for field in plan["Withdrawal_Request__c"]] == [
+        "Id",
+        "Name",
+        "Account__c",
+    ]
+    assert "InvoiceNumber" in [field.api_name for field in plan["Invoice"]]

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -1,0 +1,140 @@
+from aisc_salesforce.participant_drop import (
+    AccountCandidate,
+    ParticipantDropScenario,
+    ParticipantDropService,
+)
+
+
+class Client:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.queries = []
+        self.messages = []
+
+    def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where))
+        return next(self.responses)
+
+    def post_feed_message(self, account_id, message):
+        self.messages.append((account_id, message))
+
+
+class Interaction:
+    def __init__(self, scenario, reference="", certification_ids=(), company_names=(), choice=None):
+        self.scenario = scenario
+        self.reference = reference
+        self.certification_ids = iter(certification_ids)
+        self.company_names = iter(company_names)
+        self.choice = choice
+        self.messages = []
+
+    def choose_scenario(self):
+        return self.scenario
+
+    def request_reference(self, scenario):
+        return self.reference
+
+    def request_certification_id(self):
+        return next(self.certification_ids, None)
+
+    def request_company_name(self):
+        return next(self.company_names, None)
+
+    def select_account(self, candidates):
+        return self.choice
+
+    def show(self, message):
+        self.messages.append(message)
+
+
+def test_unpaid_invoice_uses_invoice_number_and_posts_exact_message():
+    client = Client(
+        [
+            [{"BillingAccountId": "001invoice"}],
+            [{"Id": "001invoice", "Name": "Invoice Steel", "Certification_ID__c": "C-1"}],
+        ]
+    )
+    interaction = Interaction(ParticipantDropScenario.UNPAID_INVOICE, "INV-42")
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.account == AccountCandidate("001invoice", "Invoice Steel", "C-1")
+    assert client.queries[0] == (
+        "Invoice", ["InvoiceNumber", "BillingAccountId"], "InvoiceNumber = 'INV-42'"
+    )
+    assert client.messages == [
+        ("001invoice", "Withdrawal in progress: Unpaid Invoice.")
+    ]
+
+
+def test_withdrawal_request_uses_name_and_crg_drop_uses_audit_name():
+    for scenario, object_name, field, account_id in (
+        (ParticipantDropScenario.WITHDRAWAL_REQUEST, "Withdrawal_Request__c", "Account__c", "001withdrawal"),
+        (ParticipantDropScenario.CRG_DROP, "Cert_Audit__c", "Cert_Account__c", "001crg"),
+    ):
+        client = Client(
+            [[{field: account_id}], [{"Id": account_id, "Name": "Steel", "Certification_ID__c": None}]]
+        )
+        result = ParticipantDropService(client).run(Interaction(scenario, "REF-1"))
+
+        assert result.account.id == account_id
+        assert client.queries[0] == (object_name, ["Name", field], "Name = 'REF-1'")
+
+
+def test_falls_back_to_normalized_certification_id_then_company_name():
+    client = Client(
+        [
+            [
+                {"Id": "001b", "Name": "AISC Steel, Inc.", "Certification_ID__c": "abc 123"},
+                {"Id": "001c", "Name": "Unrelated", "Certification_ID__c": "other"},
+            ],
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        certification_ids=["ABC-123"],
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.account.id == "001b"
+    assert client.messages == [("001b", "Withdrawal in progress: Other participant drop.")]
+
+
+def test_company_no_match_retries_and_multiple_candidates_require_selection():
+    first = AccountCandidate("001a", "Acme Steel", "A-1")
+    selected = AccountCandidate("001b", "Acme Steel West", "A-2")
+    client = Client(
+        [
+            [],
+            [],
+            [
+                {"Id": first.id, "Name": first.name, "Certification_ID__c": first.certification_id},
+                {"Id": selected.id, "Name": selected.name, "Certification_ID__c": selected.certification_id},
+            ],
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        certification_ids=["missing"],
+        company_names=["No company", "Acme"],
+        choice=selected,
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.account == selected
+    assert "No Accounts matched that company name; try again or cancel." in interaction.messages
+    assert client.messages == [("001b", "Withdrawal in progress: Other participant drop.")]
+
+
+def test_cancel_never_posts_to_salesforce():
+    client = Client([[]])
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER, certification_ids=["missing"], company_names=[None]
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -47,10 +47,10 @@ class Interaction:
         self.messages.append(message)
 
 
-def test_unpaid_invoice_uses_invoice_number_and_posts_exact_message():
+def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
     client = Client(
         [
-            [{"BillingAccountId": "001invoice"}],
+            [{"Cert_Account__c": "001invoice"}],
             [{"Id": "001invoice", "Name": "Invoice Steel", "Certification_ID__c": "C-1"}],
         ]
     )
@@ -60,7 +60,7 @@ def test_unpaid_invoice_uses_invoice_number_and_posts_exact_message():
 
     assert result.account == AccountCandidate("001invoice", "Invoice Steel", "C-1")
     assert client.queries[0] == (
-        "Invoice", ["InvoiceNumber", "BillingAccountId"], "InvoiceNumber = 'INV-42'"
+        "Cert_Invoice__c", ["Name", "Cert_Account__c"], "Name = 'INV-42'"
     )
     assert client.messages == [
         ("001invoice", "Withdrawal in progress: Unpaid Invoice.")


### PR DESCRIPTION
## Summary
- add interactive participant-drop intake with reference, certification, and company-name account resolution
- use custom Cert_Invoice__c.Name and Cert_Account__c for invoice lookups
- document the workflow and cover it with tests

## Validation
- uv run pytest (487 passed)

No connected issue was provided.