### PR TITLE
Add participant drop action menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,21 +80,27 @@ command reports blockers—such as a missing email, profile configuration
 problem, username collision, or multiple active linked Users—instead of
 attempting a repair. `--json` provides a stable machine-readable plan.
 
-Start an interactive participant-drop intake:
+Open the interactive participant-drop menu:
 
 ```bash
 uv run aisc_salesforce participant-drop
 ```
 
-Choose Unpaid Invoice, Withdrawal Request, CRG drop, or another participant
-drop. The related reference and Certification ID are optional; when supplied,
-the command tries them before asking for a company name. If more than one
-Account matches, it requires an explicit selection. Enter `cancel` at any
-prompt to exit without writing to Salesforce. Once an Account is resolved, the
-command posts `Withdrawal in progress: <scenario>.` to that Account's Chatter
-feed. Invoice lookup does not use Salesforce's built-in `Invoice` object.
-Instead, it matches the invoice number against `Cert_Invoice__c.Name` and uses
-that record's `Cert_Account__c` Account lookup.
+First choose **Start a new withdrawal** or **Complete an existing withdrawal**.
+Completing an existing withdrawal is not implemented yet, so that choice
+displays a message and exits successfully. Starting continues to the existing
+scenario choices: Unpaid Invoice, Withdrawal Request, CRG drop, or another
+participant drop. The command does not load Salesforce configuration or
+connect to Salesforce until you choose Start.
+
+The related reference and Certification ID are optional; when supplied, the
+command tries them before asking for a company name. If more than one Account
+matches, it requires an explicit selection. Enter `cancel`, `c`, `q`, or `quit`
+at any prompt to exit without writing to Salesforce. Once an Account is
+resolved, the command posts `Withdrawal in progress: <scenario>.` to that
+Account's Chatter feed. Invoice lookup does not use Salesforce's built-in
+`Invoice` object. Instead, it matches the invoice number against
+`Cert_Invoice__c.Name` and uses that record's `Cert_Account__c` Account lookup.
 
 Create a read-only application-stage count:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,26 +34,33 @@ set.
 
 ## Participant-drop intake
 
-Start a participant withdrawal intake from the terminal:
+Open the participant-drop menu from the terminal:
 
 ```bash
 uv run aisc_salesforce participant-drop
 ```
 
-Select the scenario (Unpaid Invoice, Withdrawal Request, CRG drop, or another
-participant drop). Reference values are optional. An invoice reference is
-matched exactly against `Cert_Invoice__c.Name`, a Withdrawal Request reference
-against `Withdrawal_Request__c.Name`, and a CRG reference against
-`Cert_Audit__c.Name`. Those records supply their Account lookup. The workflow
-does not use Salesforce's built-in `Invoice` object; it uses the custom
-`Cert_Invoice__c` object and its `Cert_Account__c` Account lookup.
+The first menu offers **Start a new withdrawal** and **Complete an existing
+withdrawal**, in that order. Complete currently displays `Complete an existing
+withdrawal is not implemented yet.` and exits successfully. Start continues to
+the scenario menu (Unpaid Invoice, Withdrawal Request, CRG drop, or another
+participant drop). Salesforce configuration is loaded and the connection is
+created only after Start is selected.
+
+Reference values are optional. An invoice reference is matched exactly against
+`Cert_Invoice__c.Name`, a Withdrawal Request reference against
+`Withdrawal_Request__c.Name`, and a CRG reference against `Cert_Audit__c.Name`.
+Those records supply their Account lookup. The workflow does not use
+Salesforce's built-in `Invoice` object; it uses the custom `Cert_Invoice__c`
+object and its `Cert_Account__c` Account lookup.
 
 When a reference does not resolve an Account, the command tries a normalized
 Certification ID and then normalized partial company-name matches. A single
 match proceeds automatically; multiple matches always require an explicit
-choice. Type `cancel` at any prompt to stop. Cancellation makes no Salesforce
-write. A completed intake posts exactly `Withdrawal in progress: <scenario>.`
-to the selected Account's Chatter feed.
+choice. Type `cancel`, `c`, `q`, or `quit` at any prompt to stop. Cancellation
+makes no Salesforce write; cancellation from the initial menu also avoids a
+Salesforce connection. A completed intake posts exactly `Withdrawal in
+progress: <scenario>.` to the selected Account's Chatter feed.
 
 ## Participant user-provisioning Profile check
 

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -18,7 +18,7 @@ from .cli_participant_drop import CLIParticipantDropInteraction
 from .cli_review_ui import CLIReviewUI, ColorMode, print_profile_error
 from .dictionary import DictionaryError, load_export_plan
 from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
-from .participant_drop import ParticipantDropService
+from .participant_drop import ParticipantDropAction, ParticipantDropService
 from .picklist_audit import (
     PicklistAuditError,
     PicklistAuditResult,
@@ -373,14 +373,25 @@ def _run_participant_drop(
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
 ) -> int:
-    """Authenticate and run the interactive participant withdrawal intake."""
+    """Choose an action, then authenticate only when starting a withdrawal."""
+    interaction = CLIParticipantDropInteraction(
+        input_fn=input_fn, output_fn=output_fn
+    )
+    action = interaction.choose_action()
+    if action is None:
+        interaction.show(
+            "Participant drop cancelled; no Salesforce changes were made."
+        )
+        return 0
+    if action is ParticipantDropAction.COMPLETE:
+        interaction.show("Complete an existing withdrawal is not implemented yet.")
+        return 0
+
     _load_dotenv(Path(".env"))
     environment = dict(os.environ)
     credentials = get_credentials(environment)
     auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
-    ParticipantDropService(SalesforceClient(auth)).run(
-        CLIParticipantDropInteraction(input_fn=input_fn, output_fn=output_fn)
-    )
+    ParticipantDropService(SalesforceClient(auth)).run(interaction)
     return 0
 
 

--- a/src/aisc_salesforce/cli_participant_drop.py
+++ b/src/aisc_salesforce/cli_participant_drop.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from .participant_drop import AccountCandidate, ParticipantDropScenario
+from .participant_drop import (
+    AccountCandidate,
+    ParticipantDropAction,
+    ParticipantDropScenario,
+)
 
 
 class CLIParticipantDropInteraction:
@@ -18,6 +22,19 @@ class CLIParticipantDropInteraction:
     ):
         self.input_fn = input_fn
         self.output_fn = output_fn
+
+    def choose_action(self) -> ParticipantDropAction | None:
+        choices = tuple(ParticipantDropAction)
+        self.output_fn("Participant-drop action:")
+        for index, action in enumerate(choices, start=1):
+            self.output_fn(f"  {index}. {action.value}")
+        while True:
+            value = self.input_fn("Choose an action (or 'cancel'): ").strip()
+            if _is_cancel(value):
+                return None
+            if value.isdigit() and 1 <= int(value) <= len(choices):
+                return choices[int(value) - 1]
+            self.output_fn("Enter one of the listed numbers, or 'cancel'.")
 
     def choose_scenario(self) -> ParticipantDropScenario | None:
         choices = tuple(ParticipantDropScenario)

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -8,6 +8,13 @@ from enum import StrEnum
 from typing import Protocol
 
 
+class ParticipantDropAction(StrEnum):
+    """The action selected before starting any Salesforce setup."""
+
+    START = "Start a new withdrawal"
+    COMPLETE = "Complete an existing withdrawal"
+
+
 class ParticipantDropScenario(StrEnum):
     """The reason a participant withdrawal is being started."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,12 +56,45 @@ def test_participant_drop_cli_runs_interactive_workflow(monkeypatch):
 
     monkeypatch.setattr(app, "ParticipantDropService", Service)
 
-    answers = iter(["1", "INV-42"])
+    answers = iter(["1", "1", "INV-42"])
     assert app.main(
         ["participant-drop"], input_fn=lambda prompt: next(answers), output_fn=output.append
     ) == 0
     assert received["scenario"].value == "Unpaid Invoice"
     assert received["reference"] == "INV-42"
+
+
+def test_participant_drop_complete_exits_without_salesforce_setup(monkeypatch):
+    output = []
+    monkeypatch.setattr(
+        app,
+        "_load_dotenv",
+        lambda path: pytest.fail("Salesforce setup must not run for complete"),
+    )
+
+    assert app.main(
+        ["participant-drop"], input_fn=lambda prompt: "2", output_fn=output.append
+    ) == 0
+    assert output[-1] == "Complete an existing withdrawal is not implemented yet."
+
+
+@pytest.mark.parametrize("alias", ["cancel", "c", "q", "quit"])
+def test_participant_drop_initial_cancel_exits_without_salesforce_setup(
+    monkeypatch, alias
+):
+    output = []
+    monkeypatch.setattr(
+        app,
+        "_load_dotenv",
+        lambda path: pytest.fail("Salesforce setup must not run for cancellation"),
+    )
+
+    assert app.main(
+        ["participant-drop"], input_fn=lambda prompt: alias, output_fn=output.append
+    ) == 0
+    assert output[-1] == (
+        "Participant drop cancelled; no Salesforce changes were made."
+    )
 
 
 def test_user_sync_config_command_authenticates_and_validates(monkeypatch, capsys):

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -1,5 +1,9 @@
+import pytest
+
+from aisc_salesforce.cli_participant_drop import CLIParticipantDropInteraction
 from aisc_salesforce.participant_drop import (
     AccountCandidate,
+    ParticipantDropAction,
     ParticipantDropScenario,
     ParticipantDropService,
 )
@@ -45,6 +49,44 @@ class Interaction:
 
     def show(self, message):
         self.messages.append(message)
+
+
+def test_choose_action_displays_choices_in_enum_order():
+    output = []
+    interaction = CLIParticipantDropInteraction(
+        input_fn=lambda prompt: "2", output_fn=output.append
+    )
+
+    assert interaction.choose_action() is ParticipantDropAction.COMPLETE
+    assert output == [
+        "Participant-drop action:",
+        "  1. Start a new withdrawal",
+        "  2. Complete an existing withdrawal",
+    ]
+
+
+def test_choose_action_explains_invalid_input_and_repeats_prompt():
+    answers = iter(["not-a-choice", "1"])
+    prompts = []
+    output = []
+    interaction = CLIParticipantDropInteraction(
+        input_fn=lambda prompt: (prompts.append(prompt), next(answers))[1],
+        output_fn=output.append,
+    )
+
+    assert interaction.choose_action() is ParticipantDropAction.START
+    assert output[-1] == "Enter one of the listed numbers, or 'cancel'."
+    assert prompts == [
+        "Choose an action (or 'cancel'): ",
+        "Choose an action (or 'cancel'): ",
+    ]
+
+
+@pytest.mark.parametrize("alias", ["cancel", "c", "q", "quit"])
+def test_choose_action_accepts_all_cancellation_aliases(alias):
+    interaction = CLIParticipantDropInteraction(input_fn=lambda prompt: alias)
+
+    assert interaction.choose_action() is None
 
 
 def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
@@ -128,10 +170,63 @@ def test_company_no_match_retries_and_multiple_candidates_require_selection():
     assert client.messages == [("001b", "Withdrawal in progress: Other participant drop.")]
 
 
-def test_cancel_never_posts_to_salesforce():
+def test_cancel_at_scenario_never_posts_to_salesforce():
+    client = Client([])
+    interaction = Interaction(None)
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []
+
+
+def test_cancel_at_reference_never_posts_to_salesforce():
+    client = Client([])
+    interaction = Interaction(ParticipantDropScenario.OTHER, reference=None)
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []
+
+
+def test_cancel_at_certification_id_never_posts_to_salesforce():
+    client = Client([])
+    interaction = Interaction(ParticipantDropScenario.OTHER, certification_ids=[None])
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []
+
+
+def test_cancel_at_company_name_never_posts_to_salesforce():
     client = Client([[]])
     interaction = Interaction(
         ParticipantDropScenario.OTHER, certification_ids=["missing"], company_names=[None]
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []
+
+
+def test_cancel_at_multiple_account_selection_never_posts_to_salesforce():
+    client = Client(
+        [
+            [],
+            [
+                {"Id": "001a", "Name": "Acme East", "Certification_ID__c": "A-1"},
+                {"Id": "001b", "Name": "Acme West", "Certification_ID__c": "A-2"},
+            ],
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        certification_ids=["missing"],
+        company_names=["Acme"],
+        choice=None,
     )
 
     result = ParticipantDropService(client).run(interaction)


### PR DESCRIPTION
## Summary
- Add a first-level participant-drop action menu
- Keep Salesforce setup deferred until a new withdrawal is started
- Add cancellation coverage and update usage documentation

Closes #66