### PR TITLE
Add withdrawal reasons to participant drop intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,21 @@ connect to Salesforce until you choose Start.
 
 The related reference and Certification ID are optional; when supplied, the
 command tries them before asking for a company name. If more than one Account
-matches, it requires an explicit selection. Enter `cancel`, `c`, `q`, or `quit`
-at any prompt to exit without writing to Salesforce. Once an Account is
-resolved, the command posts `Withdrawal in progress: <scenario>.` to that
-Account's Chatter feed. Invoice lookup does not use Salesforce's built-in
-`Invoice` object. Instead, it matches the invoice number against
-`Cert_Invoice__c.Name` and uses that record's `Cert_Account__c` Account lookup.
+matches, it requires an explicit selection.
+
+Each intake also has a withdrawal reason. Unpaid Invoice starts with the
+`#NonPayment` default, which can be replaced by one of these choices: Economy,
+Facility/Main office closure, ROI, New Ownership, or New Business model. CRG
+drop automatically uses `#CRG` and does not show a reason menu. Withdrawal
+Request and Other participant drop require one of the five selectable reasons.
+Enter `cancel`, `c`, `q`, or `quit` at any prompt—including the reason menu—to
+exit without writing to Salesforce. Once an Account and reason are resolved,
+the command posts `Withdrawal in progress: <scenario>.` to that Account's
+Chatter feed. Invoice lookup does not use Salesforce's built-in `Invoice`
+object. Instead, it matches the invoice number against `Cert_Invoice__c.Name`
+and uses that record's `Cert_Account__c` Account lookup. The selected reason is
+kept in the Python intake result for later withdrawal processing; this command
+does not create or update a `Certification_Withdrawal__c` record.
 
 Create a read-only application-stage count:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,10 +57,19 @@ object and its `Cert_Account__c` Account lookup.
 When a reference does not resolve an Account, the command tries a normalized
 Certification ID and then normalized partial company-name matches. A single
 match proceeds automatically; multiple matches always require an explicit
-choice. Type `cancel`, `c`, `q`, or `quit` at any prompt to stop. Cancellation
-makes no Salesforce write; cancellation from the initial menu also avoids a
-Salesforce connection. A completed intake posts exactly `Withdrawal in
-progress: <scenario>.` to the selected Account's Chatter feed.
+choice.
+
+Each intake has a withdrawal reason before it is recorded. Unpaid Invoice
+starts with `#NonPayment`; press Enter to keep that default or choose Economy,
+Facility/Main office closure, ROI, New Ownership, or New Business model instead.
+CRG drop automatically uses `#CRG`, so no reason menu is shown. Withdrawal
+Request and Other participant drop require one of the five selectable reasons.
+Type `cancel`, `c`, `q`, or `quit` at any prompt, including the reason menu, to
+stop. Cancellation makes no Salesforce write; cancellation from the initial
+menu also avoids a Salesforce connection. A completed intake posts exactly
+`Withdrawal in progress: <scenario>.` to the selected Account's Chatter feed.
+The selected reason is available in the Python intake result for later work;
+this command does not create or update `Certification_Withdrawal__c` records.
 
 ## Participant user-provisioning Profile check
 

--- a/src/aisc_salesforce/cli_participant_drop.py
+++ b/src/aisc_salesforce/cli_participant_drop.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from .participant_drop import (
+    SELECTABLE_REASONS,
     AccountCandidate,
     ParticipantDropAction,
     ParticipantDropScenario,
+    WithdrawalReason,
 )
 
 
@@ -84,6 +86,32 @@ class CLIParticipantDropInteraction:
                 return None
             if value.isdigit() and 1 <= int(value) <= len(candidates):
                 return candidates[int(value) - 1]
+            self.output_fn("Enter one of the listed numbers, or 'cancel'.")
+
+    def choose_withdrawal_reason(
+        self, default_reason: WithdrawalReason | None
+    ) -> WithdrawalReason | None:
+        """Prompt for an allowed withdrawal reason, with an optional process default."""
+        choices = (
+            (default_reason,) if default_reason is not None else ()
+        ) + SELECTABLE_REASONS
+        self.output_fn("Withdrawal reason:")
+        for index, reason in enumerate(choices, start=1):
+            default_marker = " (default)" if reason is default_reason else ""
+            self.output_fn(f"  {index}. {reason.value}{default_marker}")
+
+        prompt = "Choose a withdrawal reason (or 'cancel')"
+        if default_reason is not None:
+            prompt += f"; press Enter for {default_reason.value}"
+        prompt += ": "
+        while True:
+            value = self.input_fn(prompt).strip()
+            if _is_cancel(value):
+                return None
+            if not value and default_reason is not None:
+                return default_reason
+            if value.isdigit() and 1 <= int(value) <= len(choices):
+                return choices[int(value) - 1]
             self.output_fn("Enter one of the listed numbers, or 'cancel'.")
 
     def show(self, message: str) -> None:

--- a/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
+++ b/src/aisc_salesforce/data/salesforce_schema_dictionary.csv
@@ -76,6 +76,7 @@ Cert_Invoice__c,cert_invoice_account,Cert_Account__c,Lookup (Account),Account us
 Withdrawal_Request__c,withdrawal_request_id,Id,Id,Withdrawal request record ID,TRUE
 Withdrawal_Request__c,withdrawal_request_name,Name,string,Withdrawal request reference used for participant-drop lookup,TRUE
 Withdrawal_Request__c,withdrawal_request_account,Account__c,Lookup (Account),Account used for participant-drop lookup,TRUE
+Certification_Withdrawal__c,certification_withdrawal_cancellation_reason,Certification_Cancellation_Reason__c,picklist,Withdrawal reason available for future withdrawal processing,TRUE
 Case,case_acctid,AccountId,,,TRUE
 Case,case_additional_audit,Additional_Audit__c,,,FALSE
 Case,case_adhere_to_aisc_cosp_2_1,Adhere_to_AISC_CoSP_2_1__c,,,FALSE

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -24,6 +24,34 @@ class ParticipantDropScenario(StrEnum):
     OTHER = "Other participant drop"
 
 
+class WithdrawalReason(StrEnum):
+    """Reasons recorded for a participant withdrawal."""
+
+    ECONOMY = "Economy"
+    FACILITY_MAIN_OFFICE_CLOSURE = "Facility/Main office closure"
+    ROI = "ROI"
+    NEW_OWNERSHIP = "New Ownership"
+    NEW_BUSINESS_MODEL = "New Business model"
+    CRG = "#CRG"
+    NON_PAYMENT = "#NonPayment"
+
+
+SELECTABLE_REASONS = (
+    WithdrawalReason.ECONOMY,
+    WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE,
+    WithdrawalReason.ROI,
+    WithdrawalReason.NEW_OWNERSHIP,
+    WithdrawalReason.NEW_BUSINESS_MODEL,
+)
+"""Reasons a person can select in withdrawal intake."""
+
+ASSIGNED_REASONS = (WithdrawalReason.CRG, WithdrawalReason.NON_PAYMENT)
+"""Process reasons assigned by the workflow instead of selected from Salesforce values."""
+
+ALL_REASONS = (*SELECTABLE_REASONS, *ASSIGNED_REASONS)
+"""Every supported withdrawal reason, in its workflow display order."""
+
+
 @dataclass(frozen=True)
 class AccountCandidate:
     """The small amount of Account information needed for human selection."""
@@ -38,6 +66,7 @@ class ParticipantDropResult:
     """The outcome of one intake run."""
 
     account: AccountCandidate | None
+    withdrawal_reason: WithdrawalReason | None = None
     cancelled: bool = False
 
 
@@ -56,11 +85,19 @@ class ParticipantDropInteraction(Protocol):
         self, candidates: tuple[AccountCandidate, ...]
     ) -> AccountCandidate | None: ...
 
+    def choose_withdrawal_reason(
+        self, default_reason: WithdrawalReason | None
+    ) -> WithdrawalReason | None: ...
+
     def show(self, message: str) -> None: ...
 
 
 _REFERENCE_LOOKUPS = {
-    ParticipantDropScenario.UNPAID_INVOICE: ("Cert_Invoice__c", "Name", "Cert_Account__c"),
+    ParticipantDropScenario.UNPAID_INVOICE: (
+        "Cert_Invoice__c",
+        "Name",
+        "Cert_Account__c",
+    ),
     ParticipantDropScenario.WITHDRAWAL_REQUEST: (
         "Withdrawal_Request__c",
         "Name",
@@ -88,7 +125,9 @@ class ParticipantDropService:
             return self._cancel(interaction)
         account = self._find_by_reference(scenario, reference)
         if account is None and reference.strip():
-            interaction.show("No Account matched that reference; using fallback search.")
+            interaction.show(
+                "No Account matched that reference; using fallback search."
+            )
 
         if account is None:
             certification_id = interaction.request_certification_id()
@@ -106,7 +145,9 @@ class ParticipantDropService:
                 return self._cancel(interaction)
             candidates = self._find_by_company_name(company_name)
             if not candidates:
-                interaction.show("No Accounts matched that company name; try again or cancel.")
+                interaction.show(
+                    "No Accounts matched that company name; try again or cancel."
+                )
                 continue
             if len(candidates) == 1:
                 account = candidates[0]
@@ -115,13 +156,41 @@ class ParticipantDropService:
             if selected is None:
                 return self._cancel(interaction)
             if selected not in candidates:
-                raise ValueError("Selected Account was not one of the presented candidates.")
+                raise ValueError(
+                    "Selected Account was not one of the presented candidates."
+                )
             account = selected
+
+        withdrawal_reason = self._choose_withdrawal_reason(interaction, scenario)
+        if withdrawal_reason is None:
+            return self._cancel(interaction)
 
         message = f"Withdrawal in progress: {scenario.value}."
         self.client.post_feed_message(account.id, message)
         interaction.show(f"Withdrawal intake recorded for {account.name}.")
-        return ParticipantDropResult(account)
+        return ParticipantDropResult(account, withdrawal_reason)
+
+    @staticmethod
+    def _choose_withdrawal_reason(
+        interaction: ParticipantDropInteraction, scenario: ParticipantDropScenario
+    ) -> WithdrawalReason | None:
+        if scenario is ParticipantDropScenario.CRG_DROP:
+            return WithdrawalReason.CRG
+
+        default_reason = (
+            WithdrawalReason.NON_PAYMENT
+            if scenario is ParticipantDropScenario.UNPAID_INVOICE
+            else None
+        )
+        reason = interaction.choose_withdrawal_reason(default_reason)
+        allowed_reasons = SELECTABLE_REASONS + (
+            (default_reason,) if default_reason is not None else ()
+        )
+        if reason is not None and reason not in allowed_reasons:
+            raise ValueError(
+                "Selected withdrawal reason is not allowed for this scenario."
+            )
+        return reason
 
     def _find_by_reference(
         self, scenario: ParticipantDropScenario, reference: str
@@ -152,7 +221,9 @@ class ParticipantDropService:
         candidates = _account_candidates(records)
         return candidates[0] if len(candidates) == 1 else None
 
-    def _find_by_certification_id(self, certification_id: str) -> AccountCandidate | None:
+    def _find_by_certification_id(
+        self, certification_id: str
+    ) -> AccountCandidate | None:
         normalized = _normalize_search(certification_id)
         if not normalized:
             return None
@@ -189,7 +260,9 @@ class ParticipantDropService:
         return ParticipantDropResult(None, cancelled=True)
 
 
-def _account_candidates(records: list[dict[str, object]]) -> tuple[AccountCandidate, ...]:
+def _account_candidates(
+    records: list[dict[str, object]],
+) -> tuple[AccountCandidate, ...]:
     """Turn valid Account query rows into unique candidates in Salesforce order."""
     candidates: list[AccountCandidate] = []
     known_ids: set[str] = set()
@@ -197,7 +270,11 @@ def _account_candidates(records: list[dict[str, object]]) -> tuple[AccountCandid
         account_id = record.get("Id")
         name = record.get("Name")
         certification_id = record.get("Certification_ID__c")
-        if not isinstance(account_id, str) or not isinstance(name, str) or account_id in known_ids:
+        if (
+            not isinstance(account_id, str)
+            or not isinstance(name, str)
+            or account_id in known_ids
+        ):
             continue
         candidates.append(
             AccountCandidate(

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -117,3 +117,6 @@ def test_schema_dictionary_includes_participant_drop_withdrawal_fields():
         "Name",
         "Cert_Account__c",
     ]
+    assert [field.api_name for field in plan["Certification_Withdrawal__c"]] == [
+        "Certification_Cancellation_Reason__c",
+    ]

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -2,10 +2,14 @@ import pytest
 
 from aisc_salesforce.cli_participant_drop import CLIParticipantDropInteraction
 from aisc_salesforce.participant_drop import (
+    ALL_REASONS,
+    ASSIGNED_REASONS,
+    SELECTABLE_REASONS,
     AccountCandidate,
     ParticipantDropAction,
     ParticipantDropScenario,
     ParticipantDropService,
+    WithdrawalReason,
 )
 
 
@@ -24,12 +28,21 @@ class Client:
 
 
 class Interaction:
-    def __init__(self, scenario, reference="", certification_ids=(), company_names=(), choice=None):
+    def __init__(
+        self,
+        scenario,
+        reference="",
+        certification_ids=(),
+        company_names=(),
+        choice=None,
+        withdrawal_reasons=(),
+    ):
         self.scenario = scenario
         self.reference = reference
         self.certification_ids = iter(certification_ids)
         self.company_names = iter(company_names)
         self.choice = choice
+        self.withdrawal_reasons = iter(withdrawal_reasons)
         self.messages = []
 
     def choose_scenario(self):
@@ -47,8 +60,55 @@ class Interaction:
     def select_account(self, candidates):
         return self.choice
 
+    def choose_withdrawal_reason(self, default_reason):
+        return next(self.withdrawal_reasons, default_reason)
+
     def show(self, message):
         self.messages.append(message)
+
+
+def test_withdrawal_reason_collections_match_the_workflow_contract():
+    assert SELECTABLE_REASONS == (
+        WithdrawalReason.ECONOMY,
+        WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE,
+        WithdrawalReason.ROI,
+        WithdrawalReason.NEW_OWNERSHIP,
+        WithdrawalReason.NEW_BUSINESS_MODEL,
+    )
+    assert ASSIGNED_REASONS == (WithdrawalReason.CRG, WithdrawalReason.NON_PAYMENT)
+    assert ALL_REASONS == (*SELECTABLE_REASONS, *ASSIGNED_REASONS)
+
+
+def test_cli_reason_menu_uses_the_unpaid_default_and_allows_replacement():
+    answers = iter(["3"])
+    output = []
+    interaction = CLIParticipantDropInteraction(
+        input_fn=lambda prompt: next(answers), output_fn=output.append
+    )
+
+    reason = interaction.choose_withdrawal_reason(WithdrawalReason.NON_PAYMENT)
+
+    assert reason is WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE
+    assert output == [
+        "Withdrawal reason:",
+        "  1. #NonPayment (default)",
+        "  2. Economy",
+        "  3. Facility/Main office closure",
+        "  4. ROI",
+        "  5. New Ownership",
+        "  6. New Business model",
+    ]
+
+
+def test_cli_reason_menu_requires_a_number_or_cancellation_without_a_default():
+    answers = iter(["invalid", "cancel"])
+    output = []
+    interaction = CLIParticipantDropInteraction(
+        input_fn=lambda prompt: next(answers), output_fn=output.append
+    )
+
+    assert interaction.choose_withdrawal_reason(None) is None
+    assert output[-1] == "Enter one of the listed numbers, or 'cancel'."
 
 
 def test_choose_action_displays_choices_in_enum_order():
@@ -93,7 +153,13 @@ def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
     client = Client(
         [
             [{"Cert_Account__c": "001invoice"}],
-            [{"Id": "001invoice", "Name": "Invoice Steel", "Certification_ID__c": "C-1"}],
+            [
+                {
+                    "Id": "001invoice",
+                    "Name": "Invoice Steel",
+                    "Certification_ID__c": "C-1",
+                }
+            ],
         ]
     )
     interaction = Interaction(ParticipantDropScenario.UNPAID_INVOICE, "INV-42")
@@ -101,8 +167,11 @@ def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
     result = ParticipantDropService(client).run(interaction)
 
     assert result.account == AccountCandidate("001invoice", "Invoice Steel", "C-1")
+    assert result.withdrawal_reason is WithdrawalReason.NON_PAYMENT
     assert client.queries[0] == (
-        "Cert_Invoice__c", ["Name", "Cert_Account__c"], "Name = 'INV-42'"
+        "Cert_Invoice__c",
+        ["Name", "Cert_Account__c"],
+        "Name = 'INV-42'",
     )
     assert client.messages == [
         ("001invoice", "Withdrawal in progress: Unpaid Invoice.")
@@ -111,23 +180,130 @@ def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
 
 def test_withdrawal_request_uses_name_and_crg_drop_uses_audit_name():
     for scenario, object_name, field, account_id in (
-        (ParticipantDropScenario.WITHDRAWAL_REQUEST, "Withdrawal_Request__c", "Account__c", "001withdrawal"),
-        (ParticipantDropScenario.CRG_DROP, "Cert_Audit__c", "Cert_Account__c", "001crg"),
+        (
+            ParticipantDropScenario.WITHDRAWAL_REQUEST,
+            "Withdrawal_Request__c",
+            "Account__c",
+            "001withdrawal",
+        ),
+        (
+            ParticipantDropScenario.CRG_DROP,
+            "Cert_Audit__c",
+            "Cert_Account__c",
+            "001crg",
+        ),
     ):
         client = Client(
-            [[{field: account_id}], [{"Id": account_id, "Name": "Steel", "Certification_ID__c": None}]]
+            [
+                [{field: account_id}],
+                [{"Id": account_id, "Name": "Steel", "Certification_ID__c": None}],
+            ]
         )
-        result = ParticipantDropService(client).run(Interaction(scenario, "REF-1"))
+        withdrawal_reasons = (
+            [WithdrawalReason.ECONOMY]
+            if scenario is ParticipantDropScenario.WITHDRAWAL_REQUEST
+            else []
+        )
+        result = ParticipantDropService(client).run(
+            Interaction(scenario, "REF-1", withdrawal_reasons=withdrawal_reasons)
+        )
 
         assert result.account.id == account_id
         assert client.queries[0] == (object_name, ["Name", field], "Name = 'REF-1'")
+
+
+def test_unpaid_invoice_default_can_be_replaced_with_a_selectable_reason():
+    client = Client(
+        [
+            [{"Cert_Account__c": "001invoice"}],
+            [
+                {
+                    "Id": "001invoice",
+                    "Name": "Invoice Steel",
+                    "Certification_ID__c": "C-1",
+                }
+            ],
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.UNPAID_INVOICE,
+        "INV-42",
+        withdrawal_reasons=[WithdrawalReason.ROI],
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.withdrawal_reason is WithdrawalReason.ROI
+    assert client.messages == [
+        ("001invoice", "Withdrawal in progress: Unpaid Invoice.")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "reason"),
+    [
+        (ParticipantDropScenario.WITHDRAWAL_REQUEST, WithdrawalReason.ECONOMY),
+        (ParticipantDropScenario.OTHER, WithdrawalReason.NEW_BUSINESS_MODEL),
+    ],
+)
+def test_selectable_reason_is_required_for_manual_drop_scenarios(scenario, reason):
+    client = Client([[{"Id": "001a", "Name": "Steel", "Certification_ID__c": "C-1"}]])
+    interaction = Interaction(
+        scenario, certification_ids=["C-1"], withdrawal_reasons=[reason]
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.withdrawal_reason is reason
+
+
+def test_crg_drop_assigns_its_reason_without_prompting_for_a_reason():
+    client = Client(
+        [
+            [{"Cert_Account__c": "001crg"}],
+            [{"Id": "001crg", "Name": "Steel", "Certification_ID__c": None}],
+        ]
+    )
+
+    result = ParticipantDropService(client).run(
+        Interaction(ParticipantDropScenario.CRG_DROP, "AUD-1")
+    )
+
+    assert result.withdrawal_reason is WithdrawalReason.CRG
+
+
+def test_cancel_at_reason_never_posts_to_salesforce():
+    client = Client(
+        [
+            [{"Cert_Account__c": "001invoice"}],
+            [
+                {
+                    "Id": "001invoice",
+                    "Name": "Invoice Steel",
+                    "Certification_ID__c": "C-1",
+                }
+            ],
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.UNPAID_INVOICE, "INV-42", withdrawal_reasons=[None]
+    )
+
+    result = ParticipantDropService(client).run(interaction)
+
+    assert result.cancelled is True
+    assert client.messages == []
 
 
 def test_falls_back_to_normalized_certification_id_then_company_name():
     client = Client(
         [
             [
-                {"Id": "001b", "Name": "AISC Steel, Inc.", "Certification_ID__c": "abc 123"},
+                {
+                    "Id": "001b",
+                    "Name": "AISC Steel, Inc.",
+                    "Certification_ID__c": "abc 123",
+                },
                 {"Id": "001c", "Name": "Unrelated", "Certification_ID__c": "other"},
             ],
         ]
@@ -135,12 +311,15 @@ def test_falls_back_to_normalized_certification_id_then_company_name():
     interaction = Interaction(
         ParticipantDropScenario.OTHER,
         certification_ids=["ABC-123"],
+        withdrawal_reasons=[WithdrawalReason.ECONOMY],
     )
 
     result = ParticipantDropService(client).run(interaction)
 
     assert result.account.id == "001b"
-    assert client.messages == [("001b", "Withdrawal in progress: Other participant drop.")]
+    assert client.messages == [
+        ("001b", "Withdrawal in progress: Other participant drop.")
+    ]
 
 
 def test_company_no_match_retries_and_multiple_candidates_require_selection():
@@ -151,8 +330,16 @@ def test_company_no_match_retries_and_multiple_candidates_require_selection():
             [],
             [],
             [
-                {"Id": first.id, "Name": first.name, "Certification_ID__c": first.certification_id},
-                {"Id": selected.id, "Name": selected.name, "Certification_ID__c": selected.certification_id},
+                {
+                    "Id": first.id,
+                    "Name": first.name,
+                    "Certification_ID__c": first.certification_id,
+                },
+                {
+                    "Id": selected.id,
+                    "Name": selected.name,
+                    "Certification_ID__c": selected.certification_id,
+                },
             ],
         ]
     )
@@ -161,13 +348,19 @@ def test_company_no_match_retries_and_multiple_candidates_require_selection():
         certification_ids=["missing"],
         company_names=["No company", "Acme"],
         choice=selected,
+        withdrawal_reasons=[WithdrawalReason.ECONOMY],
     )
 
     result = ParticipantDropService(client).run(interaction)
 
     assert result.account == selected
-    assert "No Accounts matched that company name; try again or cancel." in interaction.messages
-    assert client.messages == [("001b", "Withdrawal in progress: Other participant drop.")]
+    assert (
+        "No Accounts matched that company name; try again or cancel."
+        in interaction.messages
+    )
+    assert client.messages == [
+        ("001b", "Withdrawal in progress: Other participant drop.")
+    ]
 
 
 def test_cancel_at_scenario_never_posts_to_salesforce():
@@ -203,7 +396,9 @@ def test_cancel_at_certification_id_never_posts_to_salesforce():
 def test_cancel_at_company_name_never_posts_to_salesforce():
     client = Client([[]])
     interaction = Interaction(
-        ParticipantDropScenario.OTHER, certification_ids=["missing"], company_names=[None]
+        ParticipantDropScenario.OTHER,
+        certification_ids=["missing"],
+        company_names=[None],
     )
 
     result = ParticipantDropService(client).run(interaction)


### PR DESCRIPTION
## Summary
- add scenario-specific withdrawal reason selection and defaults
- preserve the selected reason in the intake result
- document the workflow and expand test coverage

Closes #68