### PR TITLE
Record dated withdrawal notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,21 @@ command tries them before asking for a company name. If more than one Account
 matches, it requires an explicit selection.
 
 Each intake also has a withdrawal reason. Unpaid Invoice starts with the
-`#NonPayment` default, which can be replaced by one of these choices: Economy,
-Facility/Main office closure, ROI, New Ownership, or New Business model. CRG
-drop automatically uses `#CRG` and does not show a reason menu. Withdrawal
-Request and Other participant drop require one of the five selectable reasons.
+`#NonPayment` default, which can be replaced by one of these choices:
+`#Economy`, `#Closed`, `#ROI`, `#NewOwner`, or `#BusModel`. CRG drop
+automatically uses `#CRG` and does not show a reason menu. Withdrawal Request
+and Other participant drop require one of the five selectable reasons.
 Enter `cancel`, `c`, `q`, or `quit` at any prompt—including the reason menu—to
 exit without writing to Salesforce. Once an Account and reason are resolved,
 the command posts `Withdrawal in progress: <scenario>.` to that Account's
-Chatter feed. Invoice lookup does not use Salesforce's built-in `Invoice`
-object. Instead, it matches the invoice number against `Cert_Invoice__c.Name`
-and uses that record's `Cert_Account__c` Account lookup. The selected reason is
-kept in the Python intake result for later withdrawal processing; this command
-does not create or update a `Certification_Withdrawal__c` record.
+Chatter feed and appends a Certification Notes entry in the form
+`M/D/YY Withdrawal: <hashtag> <reference>`. The reference is omitted when it
+was left blank, and existing Certification Notes text is preserved. Invoice
+lookup does not use Salesforce's built-in `Invoice` object. Instead, it matches
+the invoice number against `Cert_Invoice__c.Name` and uses that record's
+`Cert_Account__c` Account lookup. The selected reason is kept in the Python
+intake result for later withdrawal processing; this command does not create or
+update a `Certification_Withdrawal__c` record.
 
 Create a read-only application-stage count:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,16 +60,19 @@ match proceeds automatically; multiple matches always require an explicit
 choice.
 
 Each intake has a withdrawal reason before it is recorded. Unpaid Invoice
-starts with `#NonPayment`; press Enter to keep that default or choose Economy,
-Facility/Main office closure, ROI, New Ownership, or New Business model instead.
-CRG drop automatically uses `#CRG`, so no reason menu is shown. Withdrawal
-Request and Other participant drop require one of the five selectable reasons.
+starts with `#NonPayment`; press Enter to keep that default or choose
+`#Economy`, `#Closed`, `#ROI`, `#NewOwner`, or `#BusModel` instead. CRG drop
+automatically uses `#CRG`, so no reason menu is shown. Withdrawal Request and
+Other participant drop require one of the five selectable reasons.
 Type `cancel`, `c`, `q`, or `quit` at any prompt, including the reason menu, to
 stop. Cancellation makes no Salesforce write; cancellation from the initial
 menu also avoids a Salesforce connection. A completed intake posts exactly
-`Withdrawal in progress: <scenario>.` to the selected Account's Chatter feed.
-The selected reason is available in the Python intake result for later work;
-this command does not create or update `Certification_Withdrawal__c` records.
+`Withdrawal in progress: <scenario>.` to the selected Account's Chatter feed
+and appends `M/D/YY Withdrawal: <hashtag> <reference>` to its
+`Cert_Notes__c` Certification Notes field. The reference portion is omitted
+when blank, and the workflow preserves existing note text. The selected reason
+is available in the Python intake result for later work; this command does not
+create or update `Certification_Withdrawal__c` records.
 
 ## Participant user-provisioning Profile check
 

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import date
 from enum import StrEnum
-from typing import Protocol
+from typing import Callable, Protocol
 
 
 class ParticipantDropAction(StrEnum):
@@ -27,21 +28,26 @@ class ParticipantDropScenario(StrEnum):
 class WithdrawalReason(StrEnum):
     """Reasons recorded for a participant withdrawal."""
 
-    ECONOMY = "Economy"
-    FACILITY_MAIN_OFFICE_CLOSURE = "Facility/Main office closure"
-    ROI = "ROI"
-    NEW_OWNERSHIP = "New Ownership"
-    NEW_BUSINESS_MODEL = "New Business model"
+    ECONOMY = "#Economy"
+    CLOSED = "#Closed"
+    ROI = "#ROI"
+    NEW_OWNER = "#NewOwner"
+    BUSINESS_MODEL = "#BusModel"
     CRG = "#CRG"
     NON_PAYMENT = "#NonPayment"
+
+    # Keep these older Python member names available for existing callers.
+    FACILITY_MAIN_OFFICE_CLOSURE = CLOSED
+    NEW_OWNERSHIP = NEW_OWNER
+    NEW_BUSINESS_MODEL = BUSINESS_MODEL
 
 
 SELECTABLE_REASONS = (
     WithdrawalReason.ECONOMY,
-    WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE,
+    WithdrawalReason.CLOSED,
     WithdrawalReason.ROI,
-    WithdrawalReason.NEW_OWNERSHIP,
-    WithdrawalReason.NEW_BUSINESS_MODEL,
+    WithdrawalReason.NEW_OWNER,
+    WithdrawalReason.BUSINESS_MODEL,
 )
 """Reasons a person can select in withdrawal intake."""
 
@@ -59,6 +65,7 @@ class AccountCandidate:
     id: str
     name: str
     certification_id: str | None
+    certification_notes: str | None = None
 
 
 @dataclass(frozen=True)
@@ -109,10 +116,13 @@ _NORMALIZED_SEARCH = re.compile(r"[^a-z0-9]+")
 
 
 class ParticipantDropService:
-    """Find one Account and record the start of its withdrawal in Chatter."""
+    """Find one Account and record the start of its withdrawal."""
 
-    def __init__(self, client: object):
+    def __init__(
+        self, client: object, *, date_provider: Callable[[], date] = date.today
+    ):
         self.client = client
+        self.date_provider = date_provider
 
     def run(self, interaction: ParticipantDropInteraction) -> ParticipantDropResult:
         """Run intake, posting only after one Account has been resolved."""
@@ -165,6 +175,12 @@ class ParticipantDropService:
         if withdrawal_reason is None:
             return self._cancel(interaction)
 
+        note_text = _append_withdrawal_note(
+            account.certification_notes,
+            _format_withdrawal_note(self.date_provider(), withdrawal_reason, reference),
+        )
+        self.client.update_record("Account", account.id, {"Cert_Notes__c": note_text})
+
         message = f"Withdrawal in progress: {scenario.value}."
         self.client.post_feed_message(account.id, message)
         interaction.show(f"Withdrawal intake recorded for {account.name}.")
@@ -215,7 +231,7 @@ class ParticipantDropService:
     def _find_account_by_id(self, account_id: str) -> AccountCandidate | None:
         records = self.client.query_records(
             "Account",
-            ["Id", "Name", "Certification_ID__c"],
+            ["Id", "Name", "Certification_ID__c", "Cert_Notes__c"],
             where=f"Id = '{_soql_literal(account_id)}'",
         )
         candidates = _account_candidates(records)
@@ -229,7 +245,7 @@ class ParticipantDropService:
             return None
         records = self.client.query_records(
             "Account",
-            ["Id", "Name", "Certification_ID__c"],
+            ["Id", "Name", "Certification_ID__c", "Cert_Notes__c"],
             where="Certification_ID__c != NULL",
         )
         candidates = [
@@ -245,7 +261,7 @@ class ParticipantDropService:
             return ()
         records = self.client.query_records(
             "Account",
-            ["Id", "Name", "Certification_ID__c"],
+            ["Id", "Name", "Certification_ID__c", "Cert_Notes__c"],
             where="Name != NULL",
         )
         return tuple(
@@ -270,6 +286,7 @@ def _account_candidates(
         account_id = record.get("Id")
         name = record.get("Name")
         certification_id = record.get("Certification_ID__c")
+        certification_notes = record.get("Cert_Notes__c")
         if (
             not isinstance(account_id, str)
             or not isinstance(name, str)
@@ -281,6 +298,7 @@ def _account_candidates(
                 account_id,
                 name,
                 certification_id if isinstance(certification_id, str) else None,
+                certification_notes if isinstance(certification_notes, str) else None,
             )
         )
         known_ids.add(account_id)
@@ -294,3 +312,22 @@ def _normalize_search(value: str | None) -> str:
 def _soql_literal(value: str) -> str:
     """Escape user text placed inside one quoted SOQL literal."""
     return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _format_withdrawal_note(
+    withdrawal_date: date, reason: WithdrawalReason, reference: str
+) -> str:
+    """Create the dated Certification Notes entry for one withdrawal."""
+    formatted_date = (
+        f"{withdrawal_date.month}/{withdrawal_date.day}/{withdrawal_date.year % 100:02d}"
+    )
+    entry = f"{formatted_date} Withdrawal: {reason.value}"
+    return f"{entry} {reference.strip()}" if reference.strip() else entry
+
+
+def _append_withdrawal_note(existing_note: str | None, entry: str) -> str:
+    """Append an entry while preserving all existing Certification Notes text."""
+    if not existing_note:
+        return entry
+    separator = "" if existing_note.endswith("\n") else "\n"
+    return f"{existing_note}{separator}{entry}"

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from aisc_salesforce.cli_participant_drop import CLIParticipantDropInteraction
@@ -18,6 +20,7 @@ class Client:
         self.responses = iter(responses)
         self.queries = []
         self.messages = []
+        self.updates = []
 
     def query_records(self, object_name, fields, *, where=None, order_by=None):
         self.queries.append((object_name, fields, where))
@@ -25,6 +28,9 @@ class Client:
 
     def post_feed_message(self, account_id, message):
         self.messages.append((account_id, message))
+
+    def update_record(self, object_name, record_id, values):
+        self.updates.append((object_name, record_id, values))
 
 
 class Interaction:
@@ -70,10 +76,10 @@ class Interaction:
 def test_withdrawal_reason_collections_match_the_workflow_contract():
     assert SELECTABLE_REASONS == (
         WithdrawalReason.ECONOMY,
-        WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE,
+        WithdrawalReason.CLOSED,
         WithdrawalReason.ROI,
-        WithdrawalReason.NEW_OWNERSHIP,
-        WithdrawalReason.NEW_BUSINESS_MODEL,
+        WithdrawalReason.NEW_OWNER,
+        WithdrawalReason.BUSINESS_MODEL,
     )
     assert ASSIGNED_REASONS == (WithdrawalReason.CRG, WithdrawalReason.NON_PAYMENT)
     assert ALL_REASONS == (*SELECTABLE_REASONS, *ASSIGNED_REASONS)
@@ -88,15 +94,15 @@ def test_cli_reason_menu_uses_the_unpaid_default_and_allows_replacement():
 
     reason = interaction.choose_withdrawal_reason(WithdrawalReason.NON_PAYMENT)
 
-    assert reason is WithdrawalReason.FACILITY_MAIN_OFFICE_CLOSURE
+    assert reason is WithdrawalReason.CLOSED
     assert output == [
         "Withdrawal reason:",
         "  1. #NonPayment (default)",
-        "  2. Economy",
-        "  3. Facility/Main office closure",
-        "  4. ROI",
-        "  5. New Ownership",
-        "  6. New Business model",
+        "  2. #Economy",
+        "  3. #Closed",
+        "  4. #ROI",
+        "  5. #NewOwner",
+        "  6. #BusModel",
     ]
 
 
@@ -149,7 +155,7 @@ def test_choose_action_accepts_all_cancellation_aliases(alias):
     assert interaction.choose_action() is None
 
 
-def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
+def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
     client = Client(
         [
             [{"Cert_Account__c": "001invoice"}],
@@ -158,15 +164,20 @@ def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
                     "Id": "001invoice",
                     "Name": "Invoice Steel",
                     "Certification_ID__c": "C-1",
+                    "Cert_Notes__c": "Prior note",
                 }
             ],
         ]
     )
     interaction = Interaction(ParticipantDropScenario.UNPAID_INVOICE, "INV-42")
 
-    result = ParticipantDropService(client).run(interaction)
+    result = ParticipantDropService(client, date_provider=lambda: date(2026, 9, 1)).run(
+        interaction
+    )
 
-    assert result.account == AccountCandidate("001invoice", "Invoice Steel", "C-1")
+    assert result.account == AccountCandidate(
+        "001invoice", "Invoice Steel", "C-1", "Prior note"
+    )
     assert result.withdrawal_reason is WithdrawalReason.NON_PAYMENT
     assert client.queries[0] == (
         "Cert_Invoice__c",
@@ -175,6 +186,107 @@ def test_unpaid_invoice_uses_cert_invoice_name_and_posts_exact_message():
     )
     assert client.messages == [
         ("001invoice", "Withdrawal in progress: Unpaid Invoice.")
+    ]
+    assert client.updates == [
+        (
+            "Account",
+            "001invoice",
+            {"Cert_Notes__c": "Prior note\n9/1/26 Withdrawal: #NonPayment INV-42"},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("reference", "reason", "expected_note"),
+    [
+        ("", WithdrawalReason.ECONOMY, "9/1/26 Withdrawal: #Economy"),
+        (" REF-7 ", WithdrawalReason.CLOSED, "9/1/26 Withdrawal: #Closed REF-7"),
+        ("REF-7", WithdrawalReason.ROI, "9/1/26 Withdrawal: #ROI REF-7"),
+        ("REF-7", WithdrawalReason.NEW_OWNER, "9/1/26 Withdrawal: #NewOwner REF-7"),
+        ("REF-7", WithdrawalReason.BUSINESS_MODEL, "9/1/26 Withdrawal: #BusModel REF-7"),
+    ],
+)
+def test_withdrawal_note_uses_each_reason_and_optional_reference(
+    reference, reason, expected_note
+):
+    client = Client(
+        [[{"Id": "001a", "Name": "Steel", "Certification_ID__c": "C-1"}]]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        reference,
+        certification_ids=["C-1"],
+        withdrawal_reasons=[reason],
+    )
+
+    ParticipantDropService(client, date_provider=lambda: date(2026, 9, 1)).run(
+        interaction
+    )
+
+    assert client.updates == [("Account", "001a", {"Cert_Notes__c": expected_note})]
+    assert client.messages == [
+        ("001a", "Withdrawal in progress: Other participant drop.")
+    ]
+
+
+@pytest.mark.parametrize("existing_note", [None, ""])
+def test_withdrawal_note_writes_only_new_entry_for_empty_notes(existing_note):
+    client = Client(
+        [
+            [
+                {
+                    "Id": "001a",
+                    "Name": "Steel",
+                    "Certification_ID__c": "C-1",
+                    "Cert_Notes__c": existing_note,
+                }
+            ]
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        certification_ids=["C-1"],
+        withdrawal_reasons=[WithdrawalReason.ECONOMY],
+    )
+
+    ParticipantDropService(client, date_provider=lambda: date(2026, 9, 1)).run(
+        interaction
+    )
+
+    assert client.updates == [
+        ("Account", "001a", {"Cert_Notes__c": "9/1/26 Withdrawal: #Economy"})
+    ]
+
+
+def test_withdrawal_note_preserves_a_trailing_newline():
+    client = Client(
+        [
+            [
+                {
+                    "Id": "001a",
+                    "Name": "Steel",
+                    "Certification_ID__c": "C-1",
+                    "Cert_Notes__c": "Prior note\n",
+                }
+            ]
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        certification_ids=["C-1"],
+        withdrawal_reasons=[WithdrawalReason.ECONOMY],
+    )
+
+    ParticipantDropService(client, date_provider=lambda: date(2026, 9, 1)).run(
+        interaction
+    )
+
+    assert client.updates == [
+        (
+            "Account",
+            "001a",
+            {"Cert_Notes__c": "Prior note\n9/1/26 Withdrawal: #Economy"},
+        )
     ]
 
 
@@ -243,7 +355,7 @@ def test_unpaid_invoice_default_can_be_replaced_with_a_selectable_reason():
     ("scenario", "reason"),
     [
         (ParticipantDropScenario.WITHDRAWAL_REQUEST, WithdrawalReason.ECONOMY),
-        (ParticipantDropScenario.OTHER, WithdrawalReason.NEW_BUSINESS_MODEL),
+        (ParticipantDropScenario.OTHER, WithdrawalReason.BUSINESS_MODEL),
     ],
 )
 def test_selectable_reason_is_required_for_manual_drop_scenarios(scenario, reason):
@@ -265,11 +377,14 @@ def test_crg_drop_assigns_its_reason_without_prompting_for_a_reason():
         ]
     )
 
-    result = ParticipantDropService(client).run(
+    result = ParticipantDropService(client, date_provider=lambda: date(2026, 9, 1)).run(
         Interaction(ParticipantDropScenario.CRG_DROP, "AUD-1")
     )
 
     assert result.withdrawal_reason is WithdrawalReason.CRG
+    assert client.updates == [
+        ("Account", "001crg", {"Cert_Notes__c": "9/1/26 Withdrawal: #CRG AUD-1"})
+    ]
 
 
 def test_cancel_at_reason_never_posts_to_salesforce():
@@ -293,6 +408,7 @@ def test_cancel_at_reason_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []
 
 
 def test_falls_back_to_normalized_certification_id_then_company_name():
@@ -371,6 +487,7 @@ def test_cancel_at_scenario_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []
 
 
 def test_cancel_at_reference_never_posts_to_salesforce():
@@ -381,6 +498,7 @@ def test_cancel_at_reference_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []
 
 
 def test_cancel_at_certification_id_never_posts_to_salesforce():
@@ -391,6 +509,7 @@ def test_cancel_at_certification_id_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []
 
 
 def test_cancel_at_company_name_never_posts_to_salesforce():
@@ -405,6 +524,7 @@ def test_cancel_at_company_name_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []
 
 
 def test_cancel_at_multiple_account_selection_never_posts_to_salesforce():
@@ -428,3 +548,4 @@ def test_cancel_at_multiple_account_selection_never_posts_to_salesforce():
 
     assert result.cancelled is True
     assert client.messages == []
+    assert client.updates == []


### PR DESCRIPTION
## Summary
- record dated withdrawal notes with withdrawal reason and optional reference
- preserve existing Certification Notes text while continuing Chatter updates
- update documentation and add coverage for note formatting and cancellation behavior

Fixes #70