### PR TITLE
Add issue-72 withdrawal follow-up reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ the invoice number against `Cert_Invoice__c.Name` and uses that record's
 intake result for later withdrawal processing; this command does not create or
 update a `Certification_Withdrawal__c` record.
 
+After both Salesforce updates succeed, the terminal displays manual follow-up
+reminders for Data, the Department Head, Invoicing, and Audit Logistics. It
+also asks Audit Logistics to remove the Account's Audit Package. The command
+does not send or verify those notifications, and it does not remove or verify
+removal of the Audit Package.
+
 Create a read-only application-stage count:
 
 ```bash

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
 from enum import StrEnum
-from typing import Callable, Protocol
+from typing import Protocol
 
 
 class ParticipantDropAction(StrEnum):
@@ -112,6 +113,14 @@ _REFERENCE_LOOKUPS = {
     ),
     ParticipantDropScenario.CRG_DROP: ("Cert_Audit__c", "Name", "Cert_Account__c"),
 }
+WITHDRAWAL_FOLLOW_UP_CONTACTS = (
+    ("Data", "Maureen Boyle"),
+    ("Department Head", "Lisa Patel"),
+    ("Invoicing", "Karla Ruiz"),
+    ("Audit Logistics", "Kim Swiss"),
+)
+"""Manual notification contacts, in the order shown after a withdrawal starts."""
+
 _NORMALIZED_SEARCH = re.compile(r"[^a-z0-9]+")
 
 
@@ -184,6 +193,8 @@ class ParticipantDropService:
         message = f"Withdrawal in progress: {scenario.value}."
         self.client.post_feed_message(account.id, message)
         interaction.show(f"Withdrawal intake recorded for {account.name}.")
+        for reminder in _manual_follow_up_reminders():
+            interaction.show(reminder)
         return ParticipantDropResult(account, withdrawal_reason)
 
     @staticmethod
@@ -318,11 +329,29 @@ def _format_withdrawal_note(
     withdrawal_date: date, reason: WithdrawalReason, reference: str
 ) -> str:
     """Create the dated Certification Notes entry for one withdrawal."""
-    formatted_date = (
-        f"{withdrawal_date.month}/{withdrawal_date.day}/{withdrawal_date.year % 100:02d}"
-    )
+    formatted_date = f"{withdrawal_date.month}/{withdrawal_date.day}/{withdrawal_date.year % 100:02d}"
     entry = f"{formatted_date} Withdrawal: {reason.value}"
     return f"{entry} {reference.strip()}" if reference.strip() else entry
+
+
+def _manual_follow_up_reminders() -> tuple[str, ...]:
+    """Return the terminal-only tasks required after both Salesforce writes."""
+    audit_logistics_name = dict(WITHDRAWAL_FOLLOW_UP_CONTACTS)["Audit Logistics"]
+    notifications = tuple(
+        f"  - Notify {role}: {name}." for role, name in WITHDRAWAL_FOLLOW_UP_CONTACTS
+    )
+    return (
+        "Manual follow-up required:",
+        *notifications,
+        (
+            "  - Ask Audit Logistics "
+            f"({audit_logistics_name}) to remove the Account's Audit Package."
+        ),
+        (
+            "These notifications and Audit Package removal are not performed or "
+            "verified by the script."
+        ),
+    )
 
 
 def _append_withdrawal_note(existing_note: str | None, entry: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,11 +57,78 @@ def test_participant_drop_cli_runs_interactive_workflow(monkeypatch):
     monkeypatch.setattr(app, "ParticipantDropService", Service)
 
     answers = iter(["1", "1", "INV-42"])
-    assert app.main(
-        ["participant-drop"], input_fn=lambda prompt: next(answers), output_fn=output.append
-    ) == 0
+    assert (
+        app.main(
+            ["participant-drop"],
+            input_fn=lambda prompt: next(answers),
+            output_fn=output.append,
+        )
+        == 0
+    )
     assert received["scenario"].value == "Unpaid Invoice"
     assert received["reference"] == "INV-42"
+
+
+def test_participant_drop_cli_displays_manual_follow_up_reminders(monkeypatch):
+    output = []
+
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(
+        app.os, "environ", {"SF_CLIENT_ID": "id", "SF_CLIENT_SECRET": "secret"}
+    )
+    monkeypatch.setattr(app, "get_credentials", lambda values: values)
+    monkeypatch.setattr(app, "get_oauth_url", lambda values: "token-url")
+    monkeypatch.setattr(
+        app, "request_access_token", lambda credentials, oauth_url: "auth"
+    )
+
+    class Client:
+        def __init__(self, auth):
+            assert auth == "auth"
+
+        def query_records(self, object_name, fields, *, where=None, order_by=None):
+            if object_name == "Cert_Invoice__c":
+                return [{"Cert_Account__c": "001invoice"}]
+            return [
+                {
+                    "Id": "001invoice",
+                    "Name": "Invoice Steel",
+                    "Certification_ID__c": "C-1",
+                    "Cert_Notes__c": None,
+                }
+            ]
+
+        def update_record(self, object_name, record_id, values):
+            assert (object_name, record_id) == ("Account", "001invoice")
+
+        def post_feed_message(self, account_id, message):
+            assert (account_id, message) == (
+                "001invoice",
+                "Withdrawal in progress: Unpaid Invoice.",
+            )
+
+    monkeypatch.setattr(app, "SalesforceClient", Client)
+
+    answers = iter(["1", "1", "INV-42", ""])
+    assert (
+        app.main(
+            ["participant-drop"],
+            input_fn=lambda prompt: next(answers),
+            output_fn=output.append,
+        )
+        == 0
+    )
+
+    assert output[-8:] == [
+        "Withdrawal intake recorded for Invoice Steel.",
+        "Manual follow-up required:",
+        "  - Notify Data: Maureen Boyle.",
+        "  - Notify Department Head: Lisa Patel.",
+        "  - Notify Invoicing: Karla Ruiz.",
+        "  - Notify Audit Logistics: Kim Swiss.",
+        "  - Ask Audit Logistics (Kim Swiss) to remove the Account's Audit Package.",
+        "These notifications and Audit Package removal are not performed or verified by the script.",
+    ]
 
 
 def test_participant_drop_complete_exits_without_salesforce_setup(monkeypatch):
@@ -72,10 +139,14 @@ def test_participant_drop_complete_exits_without_salesforce_setup(monkeypatch):
         lambda path: pytest.fail("Salesforce setup must not run for complete"),
     )
 
-    assert app.main(
-        ["participant-drop"], input_fn=lambda prompt: "2", output_fn=output.append
-    ) == 0
+    assert (
+        app.main(
+            ["participant-drop"], input_fn=lambda prompt: "2", output_fn=output.append
+        )
+        == 0
+    )
     assert output[-1] == "Complete an existing withdrawal is not implemented yet."
+    assert "Manual follow-up required:" not in output
 
 
 @pytest.mark.parametrize("alias", ["cancel", "c", "q", "quit"])
@@ -89,12 +160,16 @@ def test_participant_drop_initial_cancel_exits_without_salesforce_setup(
         lambda path: pytest.fail("Salesforce setup must not run for cancellation"),
     )
 
-    assert app.main(
-        ["participant-drop"], input_fn=lambda prompt: alias, output_fn=output.append
-    ) == 0
+    assert (
+        app.main(
+            ["participant-drop"], input_fn=lambda prompt: alias, output_fn=output.append
+        )
+        == 0
+    )
     assert output[-1] == (
         "Participant drop cancelled; no Salesforce changes were made."
     )
+    assert "Manual follow-up required:" not in output
 
 
 def test_user_sync_config_command_authenticates_and_validates(monkeypatch, capsys):

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -194,6 +194,16 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
             {"Cert_Notes__c": "Prior note\n9/1/26 Withdrawal: #NonPayment INV-42"},
         )
     ]
+    assert interaction.messages == [
+        "Withdrawal intake recorded for Invoice Steel.",
+        "Manual follow-up required:",
+        "  - Notify Data: Maureen Boyle.",
+        "  - Notify Department Head: Lisa Patel.",
+        "  - Notify Invoicing: Karla Ruiz.",
+        "  - Notify Audit Logistics: Kim Swiss.",
+        "  - Ask Audit Logistics (Kim Swiss) to remove the Account's Audit Package.",
+        "These notifications and Audit Package removal are not performed or verified by the script.",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -203,15 +213,17 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
         (" REF-7 ", WithdrawalReason.CLOSED, "9/1/26 Withdrawal: #Closed REF-7"),
         ("REF-7", WithdrawalReason.ROI, "9/1/26 Withdrawal: #ROI REF-7"),
         ("REF-7", WithdrawalReason.NEW_OWNER, "9/1/26 Withdrawal: #NewOwner REF-7"),
-        ("REF-7", WithdrawalReason.BUSINESS_MODEL, "9/1/26 Withdrawal: #BusModel REF-7"),
+        (
+            "REF-7",
+            WithdrawalReason.BUSINESS_MODEL,
+            "9/1/26 Withdrawal: #BusModel REF-7",
+        ),
     ],
 )
 def test_withdrawal_note_uses_each_reason_and_optional_reference(
     reference, reason, expected_note
 ):
-    client = Client(
-        [[{"Id": "001a", "Name": "Steel", "Certification_ID__c": "C-1"}]]
-    )
+    client = Client([[{"Id": "001a", "Name": "Steel", "Certification_ID__c": "C-1"}]])
     interaction = Interaction(
         ParticipantDropScenario.OTHER,
         reference,
@@ -409,6 +421,9 @@ def test_cancel_at_reason_never_posts_to_salesforce():
     assert result.cancelled is True
     assert client.messages == []
     assert client.updates == []
+    assert interaction.messages == [
+        "Participant drop cancelled; no Salesforce changes were made."
+    ]
 
 
 def test_falls_back_to_normalized_certification_id_then_company_name():


### PR DESCRIPTION
## Summary
- Display manual follow-up reminders after withdrawal intake succeeds.
- Document that notifications and Audit Package removal remain manual and unverified.
- Add coverage for reminder output and no-reminder cancellation paths.

Closes #72