### PR TITLE
Add withdrawal completion due dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ intake result for later withdrawal processing; this command does not create or
 update a `Certification_Withdrawal__c` record.
 
 For later withdrawal completion-task creation, the due-date policy is based on
-the intake scenario. Withdrawal Request and Unpaid Invoice use the latest
-available certificate expiration date (moving a Saturday or Sunday expiration
-to Monday). CRG drop and Other participant drop instead use the next weekday
-after the current date. If a Withdrawal Request or Unpaid Invoice has no
-available certificate expiration, it also uses that next-weekday fallback.
-Business days exclude weekends only; holidays are not considered.
+the intake scenario. Withdrawal Request and Unpaid Invoice use the next
+business day after the latest available certificate expiration date. CRG drop
+and Other participant drop instead use the next weekday after the current date.
+If a Withdrawal Request or Unpaid Invoice has no available certificate
+expiration, it also uses that next-weekday fallback. Business days exclude
+weekends only; holidays are not considered.
 
 After both Salesforce updates succeed, the terminal displays manual follow-up
 reminders for Data, the Department Head, Invoicing, and Audit Logistics. It

--- a/README.md
+++ b/README.md
@@ -114,11 +114,21 @@ the invoice number against `Cert_Invoice__c.Name` and uses that record's
 intake result for later withdrawal processing; this command does not create or
 update a `Certification_Withdrawal__c` record.
 
+For later withdrawal completion-task creation, the due-date policy is based on
+the intake scenario. Withdrawal Request and Unpaid Invoice use the latest
+available certificate expiration date (moving a Saturday or Sunday expiration
+to Monday). CRG drop and Other participant drop instead use the next weekday
+after the current date. If a Withdrawal Request or Unpaid Invoice has no
+available certificate expiration, it also uses that next-weekday fallback.
+Business days exclude weekends only; holidays are not considered.
+
 After both Salesforce updates succeed, the terminal displays manual follow-up
 reminders for Data, the Department Head, Invoicing, and Audit Logistics. It
 also asks Audit Logistics to remove the Account's Audit Package. The command
 does not send or verify those notifications, and it does not remove or verify
-removal of the Audit Package.
+removal of the Audit Package. Before those reminders, it displays the next
+step's due date, for example: `Due 12/31/26: complete withdrawal for Industrial
+Fabricators (IN-28037)`.
 
 Create a read-only application-stage count:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,6 +74,18 @@ when blank, and the workflow preserves existing note text. The selected reason
 is available in the Python intake result for later work; this command does not
 create or update `Certification_Withdrawal__c` records.
 
+For later withdrawal completion-task creation, Withdrawal Request and Unpaid
+Invoice use the latest available certificate expiration date. A Saturday or
+Sunday expiration advances to Monday. CRG drop and Other participant drop use
+the next weekday after the current date and ignore certificate expirations. A
+Withdrawal Request or Unpaid Invoice with no available certificate expiration
+uses the same next-weekday fallback. Business days exclude weekends only;
+holidays are not considered.
+
+After a withdrawal is recorded, the terminal displays the due date for the
+next step before the manual follow-up reminders, for example: `Due 12/31/26:
+complete withdrawal for Industrial Fabricators (IN-28037)`.
+
 ## Participant user-provisioning Profile check
 
 Run the read-only configuration check before using participant provisioning:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,12 +75,12 @@ is available in the Python intake result for later work; this command does not
 create or update `Certification_Withdrawal__c` records.
 
 For later withdrawal completion-task creation, Withdrawal Request and Unpaid
-Invoice use the latest available certificate expiration date. A Saturday or
-Sunday expiration advances to Monday. CRG drop and Other participant drop use
-the next weekday after the current date and ignore certificate expirations. A
-Withdrawal Request or Unpaid Invoice with no available certificate expiration
-uses the same next-weekday fallback. Business days exclude weekends only;
-holidays are not considered.
+Invoice use the next business day after the latest available certificate
+expiration date. CRG drop and Other participant drop use the next weekday after
+the current date and ignore certificate expirations. A Withdrawal Request or
+Unpaid Invoice with no available certificate expiration uses the same
+next-weekday fallback. Business days exclude weekends only; holidays are not
+considered.
 
 After a withdrawal is recorded, the terminal displays the due date for the
 next step before the manual follow-up reminders, for example: `Due 12/31/26:

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from enum import StrEnum
 from typing import Protocol
 
@@ -59,6 +59,30 @@ ALL_REASONS = (*SELECTABLE_REASONS, *ASSIGNED_REASONS)
 """Every supported withdrawal reason, in its workflow display order."""
 
 
+def calculate_withdrawal_completion_due_date(
+    scenario: ParticipantDropScenario,
+    certificate_expirations: Iterable[date],
+    current_date: date,
+) -> date:
+    """Calculate the due date for a withdrawal completion task.
+
+    Withdrawal Request and Unpaid Invoice use the latest certificate expiration.
+    When no expiration is available, and for CRG and Other scenarios, the due
+    date is the next Monday-through-Friday business day after ``current_date``.
+    """
+    latest_expiration = max(certificate_expirations, default=None)
+    if (
+        scenario
+        in (
+            ParticipantDropScenario.WITHDRAWAL_REQUEST,
+            ParticipantDropScenario.UNPAID_INVOICE,
+        )
+        and latest_expiration is not None
+    ):
+        return _next_or_same_business_day(latest_expiration)
+    return _next_business_day(current_date)
+
+
 @dataclass(frozen=True)
 class AccountCandidate:
     """The small amount of Account information needed for human selection."""
@@ -67,6 +91,7 @@ class AccountCandidate:
     name: str
     certification_id: str | None
     certification_notes: str | None = None
+    certificate_expiration: date | None = None
 
 
 @dataclass(frozen=True)
@@ -184,15 +209,24 @@ class ParticipantDropService:
         if withdrawal_reason is None:
             return self._cancel(interaction)
 
+        current_date = self.date_provider()
         note_text = _append_withdrawal_note(
             account.certification_notes,
-            _format_withdrawal_note(self.date_provider(), withdrawal_reason, reference),
+            _format_withdrawal_note(current_date, withdrawal_reason, reference),
         )
         self.client.update_record("Account", account.id, {"Cert_Notes__c": note_text})
 
         message = f"Withdrawal in progress: {scenario.value}."
         self.client.post_feed_message(account.id, message)
         interaction.show(f"Withdrawal intake recorded for {account.name}.")
+        due_date = calculate_withdrawal_completion_due_date(
+            scenario,
+            (account.certificate_expiration,)
+            if account.certificate_expiration is not None
+            else (),
+            current_date,
+        )
+        interaction.show(_format_withdrawal_due_notice(due_date, account.name, reference))
         for reminder in _manual_follow_up_reminders():
             interaction.show(reminder)
         return ParticipantDropResult(account, withdrawal_reason)
@@ -242,7 +276,13 @@ class ParticipantDropService:
     def _find_account_by_id(self, account_id: str) -> AccountCandidate | None:
         records = self.client.query_records(
             "Account",
-            ["Id", "Name", "Certification_ID__c", "Cert_Notes__c"],
+            [
+                "Id",
+                "Name",
+                "Certification_ID__c",
+                "Cert_Notes__c",
+                "Cert_Scheduling_2_0_Cert_Month__c",
+            ],
             where=f"Id = '{_soql_literal(account_id)}'",
         )
         candidates = _account_candidates(records)
@@ -256,7 +296,13 @@ class ParticipantDropService:
             return None
         records = self.client.query_records(
             "Account",
-            ["Id", "Name", "Certification_ID__c", "Cert_Notes__c"],
+            [
+                "Id",
+                "Name",
+                "Certification_ID__c",
+                "Cert_Notes__c",
+                "Cert_Scheduling_2_0_Cert_Month__c",
+            ],
             where="Certification_ID__c != NULL",
         )
         candidates = [
@@ -298,6 +344,9 @@ def _account_candidates(
         name = record.get("Name")
         certification_id = record.get("Certification_ID__c")
         certification_notes = record.get("Cert_Notes__c")
+        certificate_expiration = _parse_certificate_expiration(
+            record.get("Cert_Scheduling_2_0_Cert_Month__c")
+        )
         if (
             not isinstance(account_id, str)
             or not isinstance(name, str)
@@ -310,6 +359,7 @@ def _account_candidates(
                 name,
                 certification_id if isinstance(certification_id, str) else None,
                 certification_notes if isinstance(certification_notes, str) else None,
+                certificate_expiration,
             )
         )
         known_ids.add(account_id)
@@ -318,6 +368,30 @@ def _account_candidates(
 
 def _normalize_search(value: str | None) -> str:
     return _NORMALIZED_SEARCH.sub("", (value or "").casefold())
+
+
+def _parse_certificate_expiration(value: object) -> date | None:
+    """Return the date portion of a Salesforce certificate-expiration value."""
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _next_or_same_business_day(value: date) -> date:
+    """Move a weekend date forward to Monday, leaving weekdays unchanged."""
+    while value.weekday() >= 5:
+        value += timedelta(days=1)
+    return value
+
+
+def _next_business_day(value: date) -> date:
+    """Return the first Monday-through-Friday date strictly after ``value``."""
+    return _next_or_same_business_day(value + timedelta(days=1))
 
 
 def _soql_literal(value: str) -> str:
@@ -332,6 +406,17 @@ def _format_withdrawal_note(
     formatted_date = f"{withdrawal_date.month}/{withdrawal_date.day}/{withdrawal_date.year % 100:02d}"
     entry = f"{formatted_date} Withdrawal: {reason.value}"
     return f"{entry} {reference.strip()}" if reference.strip() else entry
+
+
+def _format_withdrawal_due_notice(
+    due_date: date, account_name: str, reference: str
+) -> str:
+    """Create the terminal reminder for the next withdrawal step."""
+    reference_text = f" ({reference.strip()})" if reference.strip() else ""
+    return (
+        f"Due {due_date:%m/%d/%y}: complete withdrawal for "
+        f"{account_name}{reference_text}"
+    )
 
 
 def _manual_follow_up_reminders() -> tuple[str, ...]:

--- a/src/aisc_salesforce/participant_drop.py
+++ b/src/aisc_salesforce/participant_drop.py
@@ -66,9 +66,10 @@ def calculate_withdrawal_completion_due_date(
 ) -> date:
     """Calculate the due date for a withdrawal completion task.
 
-    Withdrawal Request and Unpaid Invoice use the latest certificate expiration.
-    When no expiration is available, and for CRG and Other scenarios, the due
-    date is the next Monday-through-Friday business day after ``current_date``.
+    Withdrawal Request and Unpaid Invoice use the next Monday-through-Friday
+    business day after the latest certificate expiration. When no expiration is
+    available, and for CRG and Other scenarios, the due date is the next
+    Monday-through-Friday business day after ``current_date``.
     """
     latest_expiration = max(certificate_expirations, default=None)
     if (
@@ -79,7 +80,7 @@ def calculate_withdrawal_completion_due_date(
         )
         and latest_expiration is not None
     ):
-        return _next_or_same_business_day(latest_expiration)
+        return _next_business_day(latest_expiration)
     return _next_business_day(current_date)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,8 +119,11 @@ def test_participant_drop_cli_displays_manual_follow_up_reminders(monkeypatch):
         == 0
     )
 
-    assert output[-8:] == [
-        "Withdrawal intake recorded for Invoice Steel.",
+    assert output[-9] == "Withdrawal intake recorded for Invoice Steel."
+    assert output[-8].startswith("Due ") and output[-8].endswith(
+        "complete withdrawal for Invoice Steel (INV-42)"
+    )
+    assert output[-7:] == [
         "Manual follow-up required:",
         "  - Notify Data: Maureen Boyle.",
         "  - Notify Department Head: Lisa Patel.",

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -81,13 +81,13 @@ class Interaction:
             ParticipantDropScenario.WITHDRAWAL_REQUEST,
             (date(2026, 9, 3), date(2026, 9, 4)),
             date(2026, 9, 1),
-            date(2026, 9, 4),
+            date(2026, 9, 7),
         ),
         (
             ParticipantDropScenario.UNPAID_INVOICE,
             (date(2026, 9, 4),),
             date(2026, 9, 1),
-            date(2026, 9, 4),
+            date(2026, 9, 7),
         ),
         (
             ParticipantDropScenario.WITHDRAWAL_REQUEST,
@@ -256,7 +256,7 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
     ]
     assert interaction.messages == [
         "Withdrawal intake recorded for Invoice Steel.",
-        "Due 09/30/26: complete withdrawal for Invoice Steel (INV-42)",
+        "Due 10/01/26: complete withdrawal for Invoice Steel (INV-42)",
         "Manual follow-up required:",
         "  - Notify Data: Maureen Boyle.",
         "  - Notify Department Head: Lisa Patel.",

--- a/tests/test_participant_drop.py
+++ b/tests/test_participant_drop.py
@@ -12,6 +12,7 @@ from aisc_salesforce.participant_drop import (
     ParticipantDropScenario,
     ParticipantDropService,
     WithdrawalReason,
+    calculate_withdrawal_completion_due_date,
 )
 
 
@@ -71,6 +72,64 @@ class Interaction:
 
     def show(self, message):
         self.messages.append(message)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expirations", "current_date", "expected_due_date"),
+    [
+        (
+            ParticipantDropScenario.WITHDRAWAL_REQUEST,
+            (date(2026, 9, 3), date(2026, 9, 4)),
+            date(2026, 9, 1),
+            date(2026, 9, 4),
+        ),
+        (
+            ParticipantDropScenario.UNPAID_INVOICE,
+            (date(2026, 9, 4),),
+            date(2026, 9, 1),
+            date(2026, 9, 4),
+        ),
+        (
+            ParticipantDropScenario.WITHDRAWAL_REQUEST,
+            (date(2026, 9, 5),),
+            date(2026, 9, 1),
+            date(2026, 9, 7),
+        ),
+        (
+            ParticipantDropScenario.UNPAID_INVOICE,
+            (date(2026, 9, 6),),
+            date(2026, 9, 1),
+            date(2026, 9, 7),
+        ),
+        (
+            ParticipantDropScenario.CRG_DROP,
+            (date(2026, 9, 30),),
+            date(2026, 9, 4),
+            date(2026, 9, 7),
+        ),
+        (
+            ParticipantDropScenario.OTHER,
+            (date(2026, 9, 30),),
+            date(2026, 9, 5),
+            date(2026, 9, 7),
+        ),
+        (
+            ParticipantDropScenario.WITHDRAWAL_REQUEST,
+            (),
+            date(2026, 9, 4),
+            date(2026, 9, 7),
+        ),
+    ],
+)
+def test_calculate_withdrawal_completion_due_date(
+    scenario, expirations, current_date, expected_due_date
+):
+    assert (
+        calculate_withdrawal_completion_due_date(
+            scenario, expirations, current_date
+        )
+        == expected_due_date
+    )
 
 
 def test_withdrawal_reason_collections_match_the_workflow_contract():
@@ -165,6 +224,7 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
                     "Name": "Invoice Steel",
                     "Certification_ID__c": "C-1",
                     "Cert_Notes__c": "Prior note",
+                    "Cert_Scheduling_2_0_Cert_Month__c": "2026-09-30T00:00:00.000+0000",
                 }
             ],
         ]
@@ -176,7 +236,7 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
     )
 
     assert result.account == AccountCandidate(
-        "001invoice", "Invoice Steel", "C-1", "Prior note"
+        "001invoice", "Invoice Steel", "C-1", "Prior note", date(2026, 9, 30)
     )
     assert result.withdrawal_reason is WithdrawalReason.NON_PAYMENT
     assert client.queries[0] == (
@@ -196,6 +256,7 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
     ]
     assert interaction.messages == [
         "Withdrawal intake recorded for Invoice Steel.",
+        "Due 09/30/26: complete withdrawal for Invoice Steel (INV-42)",
         "Manual follow-up required:",
         "  - Notify Data: Maureen Boyle.",
         "  - Notify Department Head: Lisa Patel.",
@@ -204,6 +265,35 @@ def test_unpaid_invoice_records_dated_note_and_posts_exact_message():
         "  - Ask Audit Logistics (Kim Swiss) to remove the Account's Audit Package.",
         "These notifications and Audit Package removal are not performed or verified by the script.",
     ]
+
+
+def test_due_notice_uses_the_next_business_day_when_expiration_is_unavailable():
+    client = Client(
+        [
+            [
+                {
+                    "Id": "001a",
+                    "Name": "Industrial Fabricators",
+                    "Certification_ID__c": "C-1",
+                }
+            ]
+        ]
+    )
+    interaction = Interaction(
+        ParticipantDropScenario.OTHER,
+        "IN-28037",
+        certification_ids=["C-1"],
+        withdrawal_reasons=[WithdrawalReason.ECONOMY],
+    )
+
+    ParticipantDropService(client, date_provider=lambda: date(2026, 9, 4)).run(
+        interaction
+    )
+
+    assert (
+        "Due 09/07/26: complete withdrawal for Industrial Fabricators (IN-28037)"
+        in interaction.messages
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- calculate completion due dates by withdrawal scenario
- display the due date before manual follow-up reminders
- document the due-date policy and add tests

Closes #74