### PR TITLE
Add deterministic User field policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,22 @@ uv run aisc_salesforce reconcile-user CONTACT_ID --json
 ```
 
 `reconcile-user` never creates, updates, or deletes Salesforce records. It
-uses the Contact's identity and mailing fields as the desired User values and
-uses the Contact email, trimmed and lowercased, as the desired username. The
-command reports blockers—such as a missing email, profile configuration
-problem, username collision, or multiple active linked Users—instead of
-attempting a repair. `--json` provides a stable machine-readable plan.
+uses the Contact's trimmed first name, last name, and normalized email as the
+desired User identity values, and uses that email as the desired username. It
+does not copy or modify User mailing fields. It also generates an Alias from
+five normalized last-name characters, one first-name character, and the
+clock's two-digit year; all generated name characters are casefolded letters
+or digits. When the caller explicitly requires a Community Nickname, it uses
+ten normalized last-name characters, one first-name character, and that same
+clock-based year. The plan sets `en_US` locale and language, `UTF-8` email
+encoding, and maps U.S. state/DC and Canadian province/territory mailing
+addresses to a time zone. Missing or unmapped addresses use `America/Chicago`.
+
+The command reports blockers—such as unusable names, a missing email, profile
+configuration problem, username collision, Alias collision, Community Nickname
+collision, or multiple active linked Users—instead of attempting a repair.
+Generated identifiers are never suffixed to avoid a collision. `--json`
+provides a stable machine-readable plan.
 
 Open the interactive participant-drop menu:
 

--- a/src/aisc_salesforce/user_field_policies.py
+++ b/src/aisc_salesforce/user_field_policies.py
@@ -1,0 +1,229 @@
+"""Pure, deterministic field policies for participant Salesforce Users."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import date
+from typing import Any
+
+from .contact_resolution import normalize_email
+
+DEFAULT_TIME_ZONE = "America/Chicago"
+FIXED_LOCALE = "en_US"
+FIXED_LANGUAGE = "en_US"
+FIXED_EMAIL_ENCODING = "UTF-8"
+
+_US_COUNTRIES = {"united states", "united states of america", "usa", "us"}
+_CANADIAN_COUNTRIES = {"canada", "ca"}
+_US_TIME_ZONES = {
+    "AL": "America/Chicago",
+    "AK": "America/Anchorage",
+    "AZ": "America/Phoenix",
+    "AR": "America/Chicago",
+    "CA": "America/Los_Angeles",
+    "CO": "America/Denver",
+    "CT": "America/New_York",
+    "DE": "America/New_York",
+    "DC": "America/New_York",
+    "FL": "America/New_York",
+    "GA": "America/New_York",
+    "HI": "Pacific/Honolulu",
+    "ID": "America/Boise",
+    "IL": "America/Chicago",
+    "IN": "America/Indiana/Indianapolis",
+    "IA": "America/Chicago",
+    "KS": "America/Chicago",
+    "KY": "America/New_York",
+    "LA": "America/Chicago",
+    "ME": "America/New_York",
+    "MD": "America/New_York",
+    "MA": "America/New_York",
+    "MI": "America/Detroit",
+    "MN": "America/Chicago",
+    "MS": "America/Chicago",
+    "MO": "America/Chicago",
+    "MT": "America/Denver",
+    "NE": "America/Chicago",
+    "NV": "America/Los_Angeles",
+    "NH": "America/New_York",
+    "NJ": "America/New_York",
+    "NM": "America/Denver",
+    "NY": "America/New_York",
+    "NC": "America/New_York",
+    "ND": "America/Chicago",
+    "OH": "America/New_York",
+    "OK": "America/Chicago",
+    "OR": "America/Los_Angeles",
+    "PA": "America/New_York",
+    "RI": "America/New_York",
+    "SC": "America/New_York",
+    "SD": "America/Chicago",
+    "TN": "America/Chicago",
+    "TX": "America/Chicago",
+    "UT": "America/Denver",
+    "VT": "America/New_York",
+    "VA": "America/New_York",
+    "WA": "America/Los_Angeles",
+    "WV": "America/New_York",
+    "WI": "America/Chicago",
+    "WY": "America/Denver",
+}
+_CANADIAN_TIME_ZONES = {
+    "AB": "America/Edmonton",
+    "BC": "America/Vancouver",
+    "MB": "America/Winnipeg",
+    "NB": "America/Moncton",
+    "NL": "America/St_Johns",
+    "NS": "America/Halifax",
+    "NT": "America/Yellowknife",
+    "NU": "America/Iqaluit",
+    "ON": "America/Toronto",
+    "PE": "America/Halifax",
+    "QC": "America/Montreal",
+    "SK": "America/Regina",
+    "YT": "America/Whitehorse",
+}
+_US_STATE_NAMES = {
+    "alabama": "AL",
+    "alaska": "AK",
+    "arizona": "AZ",
+    "arkansas": "AR",
+    "california": "CA",
+    "colorado": "CO",
+    "connecticut": "CT",
+    "delaware": "DE",
+    "district of columbia": "DC",
+    "florida": "FL",
+    "georgia": "GA",
+    "hawaii": "HI",
+    "idaho": "ID",
+    "illinois": "IL",
+    "indiana": "IN",
+    "iowa": "IA",
+    "kansas": "KS",
+    "kentucky": "KY",
+    "louisiana": "LA",
+    "maine": "ME",
+    "maryland": "MD",
+    "massachusetts": "MA",
+    "michigan": "MI",
+    "minnesota": "MN",
+    "mississippi": "MS",
+    "missouri": "MO",
+    "montana": "MT",
+    "nebraska": "NE",
+    "nevada": "NV",
+    "new hampshire": "NH",
+    "new jersey": "NJ",
+    "new mexico": "NM",
+    "new york": "NY",
+    "north carolina": "NC",
+    "north dakota": "ND",
+    "ohio": "OH",
+    "oklahoma": "OK",
+    "oregon": "OR",
+    "pennsylvania": "PA",
+    "rhode island": "RI",
+    "south carolina": "SC",
+    "south dakota": "SD",
+    "tennessee": "TN",
+    "texas": "TX",
+    "utah": "UT",
+    "vermont": "VT",
+    "virginia": "VA",
+    "washington": "WA",
+    "west virginia": "WV",
+    "wisconsin": "WI",
+    "wyoming": "WY",
+}
+_CANADIAN_PROVINCE_NAMES = {
+    "alberta": "AB",
+    "british columbia": "BC",
+    "manitoba": "MB",
+    "new brunswick": "NB",
+    "newfoundland and labrador": "NL",
+    "nova scotia": "NS",
+    "northwest territories": "NT",
+    "nunavut": "NU",
+    "ontario": "ON",
+    "prince edward island": "PE",
+    "quebec": "QC",
+    "saskatchewan": "SK",
+    "yukon": "YT",
+}
+
+
+def contact_first_name(contact: Mapping[str, Any]) -> str:
+    """Return the trimmed Contact first name."""
+    return _text(contact.get("FirstName"))
+
+
+def contact_last_name(contact: Mapping[str, Any]) -> str:
+    """Return the trimmed Contact last name."""
+    return _text(contact.get("LastName"))
+
+
+def contact_email(contact: Mapping[str, Any]) -> tuple[str, str, tuple[str, ...]]:
+    """Return the normalized email, comparison value, and validation warnings."""
+    email, comparison, warnings = normalize_email(contact.get("Email"))
+    return email, comparison, tuple(warnings)
+
+
+def normalized_name_component(value: Any) -> str:
+    """Casefold and retain only Unicode letters and digits for identifiers."""
+    return "".join(
+        character for character in _text(value).casefold() if character.isalnum()
+    )
+
+
+def username_from_email(email: str) -> str:
+    """Use the normalized Contact email as the Salesforce username."""
+    return email
+
+
+def alias(first_name: Any, last_name: Any, clock: Callable[[], date]) -> str:
+    """Build the eight-character Salesforce Alias policy value."""
+    return f"{normalized_name_component(last_name)[:5]}{normalized_name_component(first_name)[:1]}{clock():%y}"[
+        :8
+    ]
+
+
+def community_nickname(
+    first_name: Any,
+    last_name: Any,
+    clock: Callable[[], date],
+    *,
+    required: bool,
+) -> str | None:
+    """Build the optional Community Nickname policy value."""
+    if not required:
+        return None
+    return f"{normalized_name_component(last_name)[:10]}{normalized_name_component(first_name)[:1]}{clock():%y}"
+
+
+def time_zone(contact: Mapping[str, Any]) -> str:
+    """Map a North American mailing address, or use the Chicago fallback."""
+    country = _text(contact.get("MailingCountry")).casefold()
+    state = _text(contact.get("MailingState")).casefold()
+    if country in _US_COUNTRIES:
+        return _US_TIME_ZONES.get(
+            _US_STATE_NAMES.get(state, state.upper()), DEFAULT_TIME_ZONE
+        )
+    if country in _CANADIAN_COUNTRIES:
+        return _CANADIAN_TIME_ZONES.get(
+            _CANADIAN_PROVINCE_NAMES.get(state, state.upper()), DEFAULT_TIME_ZONE
+        )
+    return DEFAULT_TIME_ZONE
+
+
+def fixed_localization_fields() -> dict[str, str]:
+    """Return the fixed Salesforce localization settings for participant Users."""
+    return {
+        "LocaleSidKey": FIXED_LOCALE,
+        "LanguageLocaleKey": FIXED_LANGUAGE,
+        "EmailEncodingKey": FIXED_EMAIL_ENCODING,
+    }
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value).strip()

--- a/src/aisc_salesforce/user_reconciliation.py
+++ b/src/aisc_salesforce/user_reconciliation.py
@@ -8,15 +8,26 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 
 from .account_roles import ACCOUNT_ROLE_DEFINITIONS, AccountRole
-from .contact_resolution import normalize_email
 from .profile_updates import escape_soql_string
 from .required_profile_rules import AccountRoleAssignment, determine_required_profile
 from .salesforce import SalesforceClient
+from .user_field_policies import (
+    alias,
+    community_nickname,
+    contact_email,
+    contact_first_name,
+    contact_last_name,
+    fixed_localization_fields,
+    normalized_name_component,
+    time_zone,
+    username_from_email,
+)
 from .user_sync_config import (
     PROFILE_CONFIGURATION,
     ParticipantProfile,
@@ -42,13 +53,14 @@ USER_FIELDS = [
     "FirstName",
     "LastName",
     "Email",
-    "Street",
-    "City",
-    "State",
-    "PostalCode",
-    "Country",
     "ProfileId",
     "Username",
+    "Alias",
+    "CommunityNickname",
+    "TimeZoneSidKey",
+    "LocaleSidKey",
+    "LanguageLocaleKey",
+    "EmailEncodingKey",
 ]
 ACCOUNT_FIELDS = [
     "Id",
@@ -62,23 +74,18 @@ DESIRED_FIELD_ORDER = (
     "FirstName",
     "LastName",
     "Email",
-    "Street",
-    "City",
-    "State",
-    "PostalCode",
-    "Country",
     "ProfileId",
     "Username",
+    "Alias",
+    "TimeZoneSidKey",
+    "LocaleSidKey",
+    "LanguageLocaleKey",
+    "EmailEncodingKey",
 )
 _CONTACT_TO_USER = {
     "FirstName": "FirstName",
     "LastName": "LastName",
     "Email": "Email",
-    "MailingStreet": "Street",
-    "MailingCity": "City",
-    "MailingState": "State",
-    "MailingPostalCode": "PostalCode",
-    "MailingCountry": "Country",
 }
 
 
@@ -138,6 +145,8 @@ class UserReconciliationPlan:
     proposed_create: tuple[tuple[str, str], ...] | None
     field_changes: tuple[UserFieldChange, ...]
     blockers: tuple[ReconciliationBlocker, ...]
+    alias_collisions: tuple[dict[str, Any], ...] = ()
+    community_nickname_collisions: tuple[dict[str, Any], ...] = ()
 
     @property
     def is_blocked(self) -> bool:
@@ -153,6 +162,10 @@ class UserReconciliationPlan:
             "active_users": [dict(item) for item in self.active_users],
             "inactive_users": [dict(item) for item in self.inactive_users],
             "username_collisions": [dict(item) for item in self.username_collisions],
+            "alias_collisions": [dict(item) for item in self.alias_collisions],
+            "community_nickname_collisions": [
+                dict(item) for item in self.community_nickname_collisions
+            ],
             "proposed_operation": self.proposed_operation,
             "proposed_create": (
                 dict(self.proposed_create) if self.proposed_create is not None else None
@@ -175,6 +188,10 @@ def build_user_reconciliation_plan(
     configured_profiles: Mapping[ParticipantProfile, str] | None,
     username_matches: Iterable[Mapping[str, Any]],
     *,
+    alias_matches: Iterable[Mapping[str, Any]] = (),
+    community_nickname_matches: Iterable[Mapping[str, Any]] = (),
+    community_nickname_required: bool = False,
+    clock: Callable[[], date] = date.today,
     configuration_error: str | None = None,
 ) -> UserReconciliationPlan:
     """Build a plan from already-read Salesforce records, without side effects."""
@@ -193,7 +210,10 @@ def build_user_reconciliation_plan(
             (ReconciliationBlocker("contact_not_found", "Contact was not found."),),
         )
     contact_id = _text(contact.get("Id"))
-    desired, blockers = _desired_user(contact)
+    desired, blockers = _desired_user(
+        contact, clock, community_nickname_required=community_nickname_required
+    )
+    desired_field_order = _desired_field_order(community_nickname_required)
     role_assignments = _role_assignments(accounts, contact_id, family_accounts)
     decision = determine_required_profile(
         [
@@ -256,6 +276,21 @@ def build_user_reconciliation_plan(
                 "username_collision", "Another User already owns the desired username."
             )
         )
+    alias_collisions = _identifier_collisions(alias_matches, linked_ids)
+    if alias_collisions:
+        blockers.append(
+            ReconciliationBlocker(
+                "alias_collision", "Another User already owns the desired Alias."
+            )
+        )
+    nickname_collisions = _identifier_collisions(community_nickname_matches, linked_ids)
+    if nickname_collisions:
+        blockers.append(
+            ReconciliationBlocker(
+                "community_nickname_collision",
+                "Another User already owns the desired Community Nickname.",
+            )
+        )
     if len(active) > 1:
         blockers.append(
             ReconciliationBlocker(
@@ -268,19 +303,19 @@ def build_user_reconciliation_plan(
     create: tuple[tuple[str, str], ...] | None = None
     changes: tuple[UserFieldChange, ...] = ()
     if not blockers:
-        desired_items = tuple((field, desired[field]) for field in DESIRED_FIELD_ORDER)
+        desired_items = tuple((field, desired[field]) for field in desired_field_order)
         if not active:
             operation, create = "create", desired_items
         else:
             changes = tuple(
                 UserFieldChange(field, _text(active[0].get(field)), desired[field])
-                for field in DESIRED_FIELD_ORDER
+                for field in desired_field_order
                 if _text(active[0].get(field)) != desired[field]
             )
             operation = "update" if changes else "none"
     return UserReconciliationPlan(
         contact_id,
-        tuple((field, desired.get(field, "")) for field in DESIRED_FIELD_ORDER),
+        tuple((field, desired.get(field, "")) for field in desired_field_order),
         required_profile,
         tuple(role_assignments),
         tuple(map(_user_snapshot, active)),
@@ -290,17 +325,26 @@ def build_user_reconciliation_plan(
         create,
         changes,
         tuple(blockers),
+        alias_collisions,
+        nickname_collisions,
     )
 
 
 class UserReconciliationService:
     """Orchestrate the focused Salesforce reads used by the reconciliation plan."""
 
-    def __init__(self, client: SalesforceClient):
+    def __init__(
+        self, client: SalesforceClient, *, clock: Callable[[], date] = date.today
+    ):
         self.client = client
+        self.clock = clock
 
     def plan(
-        self, contact_id: str, environment: dict[str, str]
+        self,
+        contact_id: str,
+        environment: dict[str, str],
+        *,
+        community_nickname_required: bool = False,
     ) -> UserReconciliationPlan:
         """Read the smallest useful record sets and return a no-write proposal."""
         contact_id = contact_id.strip()
@@ -330,12 +374,36 @@ class UserReconciliationService:
             )
         except UserSyncConfigError as error:
             configuration_error = str(error)
-        username, comparison, _ = normalize_email(contact.get("Email"))
+        email, comparison, _ = contact_email(contact)
+        username = username_from_email(email)
         username_matches = (
             self.client.query_records(
                 "User", USER_FIELDS, where=_where("Username", username)
             )
             if username and comparison
+            else []
+        )
+        alias_value = alias(
+            contact.get("FirstName"), contact.get("LastName"), self.clock
+        )
+        alias_matches = (
+            self.client.query_records(
+                "User", USER_FIELDS, where=_where("Alias", alias_value)
+            )
+            if alias_value
+            else []
+        )
+        nickname_value = community_nickname(
+            contact.get("FirstName"),
+            contact.get("LastName"),
+            self.clock,
+            required=community_nickname_required,
+        )
+        nickname_matches = (
+            self.client.query_records(
+                "User", USER_FIELDS, where=_where("CommunityNickname", nickname_value)
+            )
+            if nickname_value
             else []
         )
         return build_user_reconciliation_plan(
@@ -346,6 +414,10 @@ class UserReconciliationService:
             profiles,
             configured,
             username_matches,
+            alias_matches=alias_matches,
+            community_nickname_matches=nickname_matches,
+            community_nickname_required=community_nickname_required,
+            clock=self.clock,
             configuration_error=configuration_error,
         )
 
@@ -405,6 +477,9 @@ def render_user_reconciliation_plan(plan: UserReconciliationPlan) -> str:
 
 def _desired_user(
     contact: Mapping[str, Any],
+    clock: Callable[[], date],
+    *,
+    community_nickname_required: bool,
 ) -> tuple[dict[str, str], list[ReconciliationBlocker]]:
     desired = {"ContactId": _text(contact.get("Id"))}
     blockers: list[ReconciliationBlocker] = []
@@ -416,9 +491,30 @@ def _desired_user(
                     "missing_contact_data", f"Contact {source} is required."
                 )
             )
-    username, comparison, warnings = normalize_email(contact.get("Email"))
-    desired["Username"] = username
-    if not username or not comparison:
+    email, comparison, warnings = contact_email(contact)
+    desired["FirstName"] = contact_first_name(contact)
+    desired["LastName"] = contact_last_name(contact)
+    desired["Email"] = email
+    desired["Username"] = username_from_email(email)
+    desired["Alias"] = alias(desired["FirstName"], desired["LastName"], clock)
+    nickname = community_nickname(
+        desired["FirstName"],
+        desired["LastName"],
+        clock,
+        required=community_nickname_required,
+    )
+    if nickname is not None:
+        desired["CommunityNickname"] = nickname
+    desired["TimeZoneSidKey"] = time_zone(contact)
+    desired.update(fixed_localization_fields())
+    for field in ("FirstName", "LastName"):
+        if not normalized_name_component(desired[field]):
+            blockers.append(
+                ReconciliationBlocker(
+                    "invalid_name", f"Contact {field} has no usable letters or digits."
+                )
+            )
+    if not desired["Username"] or not comparison:
         blockers.append(
             ReconciliationBlocker(
                 "invalid_email",
@@ -426,6 +522,27 @@ def _desired_user(
             )
         )
     return desired, blockers
+
+
+def _identifier_collisions(
+    matches: Iterable[Mapping[str, Any]], linked_ids: set[str]
+) -> tuple[dict[str, Any], ...]:
+    return tuple(
+        _user_snapshot(item)
+        for item in matches
+        if _text(item.get("Id")) not in linked_ids
+    )
+
+
+def _desired_field_order(community_nickname_required: bool) -> tuple[str, ...]:
+    if not community_nickname_required:
+        return DESIRED_FIELD_ORDER
+    alias_index = DESIRED_FIELD_ORDER.index("Alias") + 1
+    return (
+        *DESIRED_FIELD_ORDER[:alias_index],
+        "CommunityNickname",
+        *DESIRED_FIELD_ORDER[alias_index:],
+    )
 
 
 def _role_assignments(

--- a/tests/test_user_field_policies.py
+++ b/tests/test_user_field_policies.py
@@ -1,0 +1,49 @@
+"""Focused tests for deterministic participant User field policies."""
+
+from datetime import date
+
+from aisc_salesforce.user_field_policies import (
+    FIXED_EMAIL_ENCODING,
+    FIXED_LANGUAGE,
+    FIXED_LOCALE,
+    alias,
+    community_nickname,
+    fixed_localization_fields,
+    normalized_name_component,
+    time_zone,
+)
+
+
+def test_name_normalization_and_clock_based_identifiers():
+    def clock() -> date:
+        return date(2030, 1, 1)
+
+    assert normalized_name_component("  Élodie!  ") == "élodie"
+    assert alias("Élodie", "O'Neil-Smith", clock) == "oneilé30"
+    assert alias("?", "!", clock) == "30"
+    assert community_nickname("Ada", "Lovelace", clock, required=False) is None
+    assert community_nickname("Ada", "Lovelace", clock, required=True) == "lovelacea30"
+
+
+def test_time_zone_mapping_and_chicago_fallback():
+    assert (
+        time_zone({"MailingCountry": "United States", "MailingState": "CA"})
+        == "America/Los_Angeles"
+    )
+    assert (
+        time_zone({"MailingCountry": "Canada", "MailingState": "Ontario"})
+        == "America/Toronto"
+    )
+    assert (
+        time_zone({"MailingCountry": "Canada", "MailingState": "Unknown"})
+        == "America/Chicago"
+    )
+    assert time_zone({}) == "America/Chicago"
+
+
+def test_fixed_localization_values():
+    assert fixed_localization_fields() == {
+        "LocaleSidKey": FIXED_LOCALE,
+        "LanguageLocaleKey": FIXED_LANGUAGE,
+        "EmailEncodingKey": FIXED_EMAIL_ENCODING,
+    }

--- a/tests/test_user_reconciliation.py
+++ b/tests/test_user_reconciliation.py
@@ -1,6 +1,7 @@
 """Tests for the read-only participant User reconciliation planner."""
 
 from dataclasses import FrozenInstanceError
+from datetime import date
 
 import pytest
 
@@ -45,13 +46,17 @@ def test_no_active_user_produces_create_with_normalized_username():
     )
 
     assert plan.proposed_operation == "create"
-    assert dict(plan.proposed_create or ())["Username"] == "ada@example.com"
+    desired = dict(plan.proposed_create or ())
+    assert desired["Username"] == "ada@example.com"
+    assert desired["Alias"] == "lovela26"
+    assert desired["TimeZoneSidKey"] == "America/Chicago"
+    assert "CommunityNickname" not in desired
     assert plan.required_profile == ParticipantProfile.PARTICIPANT
     assert not plan.blockers
     assert plan.as_dict()["proposed_create"]["ContactId"] == "contact-1"
 
 
-def test_one_active_user_shows_only_differences():
+def test_one_active_user_does_not_copy_contact_mailing_fields():
     user = {
         "Id": "user-1",
         "IsActive": True,
@@ -68,10 +73,36 @@ def test_one_active_user_shows_only_differences():
         CONTACT, [user], [account()], [account()], PROFILES, CONFIG, []
     )
 
-    assert plan.proposed_operation == "update"
-    assert [
-        (change.field, change.current, change.desired) for change in plan.field_changes
-    ] == [("City", "Evanston", "Chicago")]
+    assert plan.proposed_operation == "none"
+    assert not plan.field_changes
+
+
+def test_alias_and_community_nickname_collisions_block_without_suffixes():
+    plan = build_user_reconciliation_plan(
+        CONTACT,
+        [],
+        [account()],
+        [account()],
+        PROFILES,
+        CONFIG,
+        [],
+        alias_matches=[{"Id": "alias-user", "Alias": "lovelaa26"}],
+        community_nickname_matches=[
+            {"Id": "nickname-user", "CommunityNickname": "lovelacea26"}
+        ],
+        community_nickname_required=True,
+        clock=lambda: date(2026, 1, 1),
+    )
+
+    assert dict(plan.desired_user)["CommunityNickname"] == "lovelacea26"
+    assert [item["Id"] for item in plan.alias_collisions] == ["alias-user"]
+    assert [item["Id"] for item in plan.community_nickname_collisions] == [
+        "nickname-user"
+    ]
+    assert {item.code for item in plan.blockers} >= {
+        "alias_collision",
+        "community_nickname_collision",
+    }
 
 
 def test_multiple_active_users_and_inactive_users_are_kept_separate():


### PR DESCRIPTION
## Summary
- add pure, clock-injected User field generation policies
- detect Alias and Community Nickname collisions without suffixing
- keep reconciliation read-only and document the expanded behavior

Closes #76