### PR TITLE
Apply reconciled user updates safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,28 @@ uv run aisc_salesforce reconcile-user CONTACT_ID
 uv run aisc_salesforce reconcile-user CONTACT_ID --json
 ```
 
-`reconcile-user` never creates, updates, or deletes Salesforce records. It
+The commands above are read-only. Save and review the JSON plan before using
+the separate, explicit apply path:
+
+```bash
+uv run aisc_salesforce reconcile-user CONTACT_ID --json > reviewed-plan.json
+uv run aisc_salesforce reconcile-user CONTACT_ID --plan reviewed-plan.json --apply
+uv run aisc_salesforce reconcile-user CONTACT_ID --plan reviewed-plan.json --apply --json
+```
+
+Before writing, the apply command fetches the records again and rejects a
+stale plan, a different Contact/User, blockers, creates, and no-op plans. It
+updates only differing `ProfileId`, `FirstName`, `LastName`, `Email`, and
+`Username` fields on exactly one active linked User; email/username comparisons
+ignore surrounding whitespace and casing. Alias, Community Nickname,
+localization, inactive Users, and every other field remain out of scope. JSON
+apply output reports each allowed field as `applied` or `skipped`, plus a
+console-only `login_identity_changed` event when Email or Username changes.
+Salesforce may send its own identity-change notifications; this application
+neither suppresses nor duplicates them, consistent with [Salesforce's editing
+User guidance](https://help.salesforce.com/s/articleView?id=sf.users_edit_considerations.htm&language=en_US&release=236.19.0&type=5).
+
+The read-only planner
 uses the Contact's trimmed first name, last name, and normalized email as the
 desired User identity values, and uses that email as the desired username. It
 does not copy or modify User mailing fields. It also generates an Alias from

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,8 +117,25 @@ uv run aisc_salesforce reconcile-user CONTACT_ID --json
 This is a read-only command: it authenticates and performs focused Salesforce
 queries, but never creates, updates, or deletes a record. The regular output
 is a short review summary. `--json` prints a stable, automation-friendly plan
-with desired values, role assignments, linked Users, proposed changes, and
-blockers.
+with desired values, role assignments, linked Users, proposed changes,
+blockers, and the active User's expected values for safe review.
+
+To apply a reviewed update, save that JSON and use both `--plan` and `--apply`:
+
+```bash
+uv run aisc_salesforce reconcile-user CONTACT_ID --json > reviewed-plan.json
+uv run aisc_salesforce reconcile-user CONTACT_ID --plan reviewed-plan.json --apply
+```
+
+Apply fetches Salesforce again and refuses stale, blocked, create, no-op, or
+wrong-target plans. It only updates changed `ProfileId`, `FirstName`,
+`LastName`, `Email`, and `Username` values for one active User. Every allowed
+field is reported as `applied` or `skipped` in `--json` output. Alias,
+Community Nickname, localization, and inactive Users are never changed. When
+Email or Username changes, the console report includes a
+`login_identity_changed` event. The application does not suppress or duplicate
+Salesforce's own User identity emails; see [Salesforce's editing User
+guidance](https://help.salesforce.com/s/articleView?id=sf.users_edit_considerations.htm&language=en_US&release=236.19.0&type=5).
 
 The Contact is the source of the desired `ContactId`, name, email, and mailing
 address values. Its trimmed, lowercased Email is also the desired `Username`.

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -47,7 +47,9 @@ from .stage_profile_updates import (
     write_staged_profile_updates,
 )
 from .user_reconciliation import (
+    ReconciliationPlanError,
     UserReconciliationService,
+    load_user_reconciliation_plan,
     render_user_reconciliation_plan,
 )
 from .user_sync_config import UserSyncConfigError, UserSyncConfigValidator
@@ -170,6 +172,12 @@ def main(
     reconcile_user_parser.add_argument(
         "--json", action="store_true", help="Print the stable JSON plan contract."
     )
+    reconcile_user_parser.add_argument(
+        "--plan", type=Path, help="Reviewed JSON plan file to verify before applying."
+    )
+    reconcile_user_parser.add_argument(
+        "--apply", action="store_true", help="Apply a still-current reviewed update plan."
+    )
     subparsers.add_parser(
         "participant-drop",
         help="Interactively record that a participant withdrawal is in progress.",
@@ -283,11 +291,21 @@ def main(
             print(f"User sync configuration check failed: {error}", file=sys.stderr)
             return 1
     if args.command == "reconcile-user":
+        if args.plan is not None and not args.apply:
+            print("User reconciliation apply requires --apply; no Salesforce records were changed.", file=sys.stderr)
+            return 1
+        if args.apply and args.plan is None:
+            print("User reconciliation apply requires --plan PATH; no Salesforce records were changed.", file=sys.stderr)
+            return 1
         try:
+            if args.apply:
+                return _run_apply_reconcile_user(
+                    args.contact_id, args.plan, as_json=args.json, output_fn=output_fn
+                )
             return _run_reconcile_user(
                 args.contact_id, as_json=args.json, output_fn=output_fn
             )
-        except (SalesforceError, UserSyncConfigError) as error:
+        except (SalesforceError, UserSyncConfigError, ReconciliationPlanError, OSError) as error:
             print(f"User reconciliation failed: {error}", file=sys.stderr)
             return 1
     if args.command == "participant-drop":
@@ -366,6 +384,36 @@ def _run_reconcile_user(
     return (
         1 if any(item.code == "profile_configuration" for item in plan.blockers) else 0
     )
+
+
+def _run_apply_reconcile_user(
+    contact_id: str,
+    plan_path: Path,
+    *,
+    as_json: bool,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Apply one reviewed plan only after a fresh Salesforce safety check."""
+    reviewed = load_user_reconciliation_plan(plan_path)
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    result = UserReconciliationService(SalesforceClient(auth)).apply(
+        reviewed, contact_id, environment
+    )
+    if as_json:
+        output_fn(result.to_json())
+    else:
+        output_fn(f"Updated User {result.user_id} for Contact {result.contact_id}.")
+        for item in result.fields:
+            output_fn(f"  - {item['field']}: {item['status']}")
+        for event in result.events:
+            output_fn(
+                "login_identity_changed: "
+                f"User {event['user_id']} changed {', '.join(event['fields'])}."
+            )
+    return 0
 
 
 def _run_participant_drop(

--- a/src/aisc_salesforce/user_reconciliation.py
+++ b/src/aisc_salesforce/user_reconciliation.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import date
+from pathlib import Path
 from typing import Any
 
 from .account_roles import ACCOUNT_ROLE_DEFINITIONS, AccountRole
@@ -82,6 +83,7 @@ DESIRED_FIELD_ORDER = (
     "LanguageLocaleKey",
     "EmailEncodingKey",
 )
+APPLY_FIELD_ORDER = ("ProfileId", "FirstName", "LastName", "Email", "Username")
 _CONTACT_TO_USER = {
     "FirstName": "FirstName",
     "LastName": "LastName",
@@ -147,6 +149,9 @@ class UserReconciliationPlan:
     blockers: tuple[ReconciliationBlocker, ...]
     alias_collisions: tuple[dict[str, Any], ...] = ()
     community_nickname_collisions: tuple[dict[str, Any], ...] = ()
+    # This deliberately excludes Alias, CommunityNickname, and localization.
+    # It is the small optimistic-lock snapshot used by a reviewed apply plan.
+    expected_current_user: tuple[tuple[str, str], ...] | None = None
 
     @property
     def is_blocked(self) -> bool:
@@ -172,6 +177,11 @@ class UserReconciliationPlan:
             ),
             "field_changes": [item.as_dict() for item in self.field_changes],
             "blockers": [item.as_dict() for item in self.blockers],
+            "expected_current_user": (
+                dict(self.expected_current_user)
+                if self.expected_current_user is not None
+                else None
+            ),
         }
 
     def to_json(self) -> str:
@@ -310,7 +320,7 @@ def build_user_reconciliation_plan(
             changes = tuple(
                 UserFieldChange(field, _text(active[0].get(field)), desired[field])
                 for field in desired_field_order
-                if _text(active[0].get(field)) != desired[field]
+                if not _field_values_equal(field, active[0].get(field), desired[field])
             )
             operation = "update" if changes else "none"
     return UserReconciliationPlan(
@@ -327,6 +337,76 @@ def build_user_reconciliation_plan(
         tuple(blockers),
         alias_collisions,
         nickname_collisions,
+        (
+            tuple((field, _text(active[0].get(field))) for field in APPLY_FIELD_ORDER)
+            if len(active) == 1
+            else None
+        ),
+    )
+
+
+class ReconciliationPlanError(ValueError):
+    """A saved reconciliation plan is not safe to use."""
+
+
+@dataclass(frozen=True)
+class UserReconciliationApplyResult:
+    """The machine-readable outcome of an allowed User update."""
+
+    contact_id: str
+    user_id: str
+    fields: tuple[dict[str, str], ...]
+    events: tuple[dict[str, Any], ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "contact_id": self.contact_id,
+            "user_id": self.user_id,
+            "fields": [dict(item) for item in self.fields],
+            "events": [dict(item) for item in self.events],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), indent=2, sort_keys=True)
+
+
+def load_user_reconciliation_plan(path: Path) -> UserReconciliationPlan:
+    """Load a reviewed JSON plan, rejecting incomplete or hand-shaped input."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReconciliationPlanError(f"Could not read reconciliation plan: {error}") from error
+    if not isinstance(raw, dict):
+        raise ReconciliationPlanError("Reconciliation plan must be a JSON object.")
+    required = {"contact_id", "desired_user", "active_users", "blockers", "expected_current_user"}
+    if not required.issubset(raw):
+        raise ReconciliationPlanError("Reconciliation plan is missing required review data.")
+    if not isinstance(raw["contact_id"], str) or not raw["contact_id"].strip():
+        raise ReconciliationPlanError("Reconciliation plan has no Contact ID.")
+    desired = raw["desired_user"]
+    expected = raw["expected_current_user"]
+    active = raw["active_users"]
+    if not isinstance(desired, dict) or not isinstance(expected, dict) or not isinstance(active, list):
+        raise ReconciliationPlanError("Reconciliation plan has invalid User review data.")
+    if (
+        len(active) != 1
+        or not isinstance(active[0], dict)
+        or active[0].get("IsActive") is not True
+        or not _text(active[0].get("Id"))
+    ):
+        raise ReconciliationPlanError("Reconciliation plan must target exactly one active User.")
+    for field in APPLY_FIELD_ORDER:
+        if not isinstance(desired.get(field), str) or not isinstance(expected.get(field), str):
+            raise ReconciliationPlanError(f"Reconciliation plan is missing {field} review values.")
+    if _text(desired.get("ContactId")) != raw["contact_id"].strip():
+        raise ReconciliationPlanError("Reconciliation plan Contact IDs do not match.")
+    # Reconstructing every descriptive field is unnecessary for apply safety;
+    # the fresh plan is the authority for all Salesforce-derived context.
+    return UserReconciliationPlan(
+        raw["contact_id"].strip(), tuple(desired.items()), raw.get("required_profile"), (),
+        (dict(active[0]),), (), (), raw.get("proposed_operation"), None, (),
+        tuple(ReconciliationBlocker(str(item.get("code", "")), str(item.get("message", ""))) for item in raw["blockers"] if isinstance(item, dict)),
+        expected_current_user=tuple((field, expected[field]) for field in APPLY_FIELD_ORDER),
     )
 
 
@@ -420,6 +500,50 @@ class UserReconciliationService:
             clock=self.clock,
             configuration_error=configuration_error,
         )
+
+    def apply(
+        self,
+        reviewed_plan: UserReconciliationPlan,
+        contact_id: str,
+        environment: dict[str, str],
+    ) -> UserReconciliationApplyResult:
+        """Re-read Salesforce, then apply only a still-current reviewed update."""
+        if reviewed_plan.contact_id != contact_id.strip():
+            raise ReconciliationPlanError("Contact ID does not match the reviewed plan.")
+        fresh = self.plan(contact_id, environment)
+        _validate_apply_plan(reviewed_plan, fresh)
+        user_id = _text(fresh.active_users[0].get("Id"))
+        desired = dict(fresh.desired_user)
+        current = dict(fresh.expected_current_user or ())
+        values = {
+            field: desired[field]
+            for field in APPLY_FIELD_ORDER
+            if not _field_values_equal(field, current.get(field), desired[field])
+        }
+        # A single PATCH keeps the five related identity fields together.  No
+        # User fields outside this explicit allow-list can reach Salesforce.
+        if values:
+            self.client.update_record("User", user_id, values)
+        fields = tuple(
+            {
+                "field": field,
+                "status": "applied" if field in values else "skipped",
+                "current": current.get(field, ""),
+                "desired": desired[field],
+            }
+            for field in APPLY_FIELD_ORDER
+        )
+        identity_fields = [field for field in ("Email", "Username") if field in values]
+        events: tuple[dict[str, Any], ...] = ()
+        if identity_fields:
+            events = (
+                {
+                    "type": "login_identity_changed",
+                    "user_id": user_id,
+                    "fields": identity_fields,
+                },
+            )
+        return UserReconciliationApplyResult(fresh.contact_id, user_id, fields, events)
 
     def _read_family_accounts(
         self, accounts: Iterable[Mapping[str, Any]]
@@ -609,6 +733,38 @@ def _user_snapshot(user: Mapping[str, Any]) -> dict[str, Any]:
 
 def _text(value: Any) -> str:
     return "" if value is None else str(value).strip()
+
+
+def _field_values_equal(field: str, current: Any, desired: Any) -> bool:
+    """Compare login email values without treating cosmetic casing as a change."""
+    if field in {"Email", "Username"}:
+        return _text(current).casefold() == _text(desired).casefold()
+    return _text(current) == _text(desired)
+
+
+def _validate_apply_plan(
+    reviewed: UserReconciliationPlan, fresh: UserReconciliationPlan
+) -> None:
+    """Reject stale, blocked, create, and no-op plans before any PATCH."""
+    if reviewed.blockers:
+        raise ReconciliationPlanError("Reviewed reconciliation plan is blocked; no User was updated.")
+    if reviewed.proposed_operation != "update":
+        raise ReconciliationPlanError("Reviewed reconciliation plan is not an active-User update.")
+    if fresh.blockers:
+        raise ReconciliationPlanError("Fresh reconciliation plan is blocked; no User was updated.")
+    if fresh.proposed_operation != "update" or len(fresh.active_users) != 1:
+        raise ReconciliationPlanError("Fresh reconciliation plan is not an active-User update.")
+    reviewed_expected = dict(reviewed.expected_current_user or ())
+    fresh_expected = dict(fresh.expected_current_user or ())
+    reviewed_user_id = _text(reviewed.active_users[0].get("Id")) if len(reviewed.active_users) == 1 else ""
+    fresh_user_id = _text(fresh.active_users[0].get("Id"))
+    if (
+        reviewed.contact_id != fresh.contact_id
+        or reviewed_user_id != fresh_user_id
+        or reviewed_expected != fresh_expected
+        or dict(reviewed.desired_user) != dict(fresh.desired_user)
+    ):
+        raise ReconciliationPlanError("Reviewed reconciliation plan is stale or no longer safe to apply.")
 
 
 def _where(field: str, value: str) -> str:

--- a/tests/test_user_reconciliation.py
+++ b/tests/test_user_reconciliation.py
@@ -6,8 +6,10 @@ from datetime import date
 import pytest
 
 from aisc_salesforce.user_reconciliation import (
+    ReconciliationPlanError,
     UserReconciliationService,
     build_user_reconciliation_plan,
+    load_user_reconciliation_plan,
     render_user_reconciliation_plan,
 )
 from aisc_salesforce.user_sync_config import PROFILE_CONFIGURATION, ParticipantProfile
@@ -196,3 +198,66 @@ def test_service_uses_only_filtered_queries():
     assert plan.proposed_operation == "create"
     assert all(where for _, _, where in client.calls)
     assert client.calls[0][2] == "Id = 'contact-1'"
+
+
+def test_apply_updates_only_allowed_changed_fields_and_reports_login_event():
+    current_user = {
+        "Id": "user-1", "IsActive": True, "ProfileId": "old-profile",
+        "FirstName": "Ada", "LastName": "Byron", "Email": "ada@old.example",
+        "Username": "ada@old.example", "Alias": "leave-me-alone",
+    }
+    reviewed = build_user_reconciliation_plan(
+        CONTACT, [current_user], [account()], [account()], PROFILES, CONFIG, []
+    )
+
+    class Client:
+        def update_record(self, object_name, record_id, values):
+            self.updated = (object_name, record_id, values)
+
+    client = Client()
+    service = UserReconciliationService(client)
+    service.plan = lambda contact_id, environment: reviewed  # type: ignore[method-assign]
+
+    result = service.apply(reviewed, "contact-1", {})
+
+    assert client.updated == (
+        "User", "user-1",
+        {
+            "ProfileId": ParticipantProfile.PARTICIPANT.value,
+            "LastName": "Lovelace",
+            "Email": "ada@example.com",
+            "Username": "ada@example.com",
+        },
+    )
+    assert {item["field"]: item["status"] for item in result.fields} == {
+        "ProfileId": "applied", "FirstName": "skipped", "LastName": "applied",
+        "Email": "applied", "Username": "applied",
+    }
+    assert result.events[0]["type"] == "login_identity_changed"
+
+
+def test_apply_rejects_stale_plan_before_writing():
+    user = {"Id": "user-1", "IsActive": True, "Email": "old@example.com"}
+    reviewed = build_user_reconciliation_plan(
+        CONTACT, [user], [account()], [account()], PROFILES, CONFIG, []
+    )
+    stale = build_user_reconciliation_plan(
+        CONTACT, [{**user, "Email": "newer@example.com"}], [account()], [account()], PROFILES, CONFIG, []
+    )
+
+    class Client:
+        def update_record(self, *args):
+            raise AssertionError("stale plan attempted a write")
+
+    service = UserReconciliationService(Client())
+    service.plan = lambda contact_id, environment: stale  # type: ignore[method-assign]
+    with pytest.raises(ReconciliationPlanError, match="stale"):
+        service.apply(reviewed, "contact-1", {})
+
+
+def test_load_plan_requires_expected_active_user_values(tmp_path):
+    path = tmp_path / "plan.json"
+    path.write_text('{"contact_id": "contact-1"}', encoding="utf-8")
+
+    with pytest.raises(ReconciliationPlanError, match="missing required"):
+        load_user_reconciliation_plan(path)


### PR DESCRIPTION
## Summary
- Add an explicit reviewed-plan apply path for reconciled Salesforce User updates.
- Re-read and validate the plan before updating only allowed fields.
- Document the workflow and report identity-change events.

Closes #78