### PR TITLE
Scope provisioning eligibility to the calling workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,9 @@ PARTICIPANT_AP_PROFILE_ID=00e5w000000kDqdAAE
 PARTICIPANT_QC_PROFILE_ID=00e5w000000kDqnAAE
 PARTICIPANT_RAS_PROFILE_ID=00e5w000000kDqsAAE
 
-# Organization-specific Experience Cloud User provisioning constraints. Verify
-# these values with the Salesforce administrator before enabling the workflow.
+# Organization-specific Experience Cloud User provisioning constraints. The
+# license is used by all callers; the Account eligibility field/value are
+# required only by process-profile-updates. Verify values with Salesforce.
 EXTERNAL_USER_LICENSE_NAME=
 EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD=
 EXTERNAL_USER_ACCOUNT_ELIGIBILITY_VALUE=

--- a/README.md
+++ b/README.md
@@ -31,15 +31,19 @@ Set these values in `.env`:
   `PARTICIPANT_AP_PROFILE_ID`, `PARTICIPANT_QC_PROFILE_ID`, and
   `PARTICIPANT_RAS_PROFILE_ID`: the fixed Profile IDs used by participant user
   provisioning.
-- `EXTERNAL_USER_LICENSE_NAME`, `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD`, and
-  `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_VALUE`: the exact external license and
-  Account eligibility rule approved for this Salesforce org.
+- `EXTERNAL_USER_LICENSE_NAME`: the external license approved for this
+  Salesforce org.
+- `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD` and
+  `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_VALUE`: the Account eligibility rule used
+  only when `process-profile-updates` creates a missing User. Other provisioning
+  workflows supply their own policy when they need one.
 - `EXTERNAL_USER_ROLE_ID` (optional): the external User role required by that
   license, when applicable.
 
-If a required `EXTERNAL_USER_*` value is missing or blank, the review records
-the configuration error in its audit and keeps the Case and source Profile
-Updates open. Correct the deployment setting, then rerun the review to retry.
+If a required `process-profile-updates` provisioning value is missing or blank,
+the review records the configuration error in its audit and keeps the Case and
+source Profile Updates open. Correct the deployment setting, then rerun the
+review to retry.
 - `SF_LOGIN_URL` (optional): an org URL or complete OAuth token URL. It
   defaults to Salesforce's production login service.
 
@@ -56,8 +60,8 @@ SF_LOGIN_URL=https://aisc.my.salesforce.com/services/oauth2/token
 Before using `process-profile-updates`, verify the license name, Account field
 API name/value, and any role requirement with your Salesforce administrator.
 After every response email is confirmed sent, the workflow checks the Contact,
-participant Profile/license, Account eligibility, Account owner, username, and
-license capacity before creating a missing active external User. If any check
+participant Profile/license, configured Account eligibility, Account owner,
+username, and license capacity before creating a missing active external User. If any check
 or creation fails, it records an actionable audit event, leaves the Case
 Pending and source Profile Updates open, and can be safely retried. A User that
 appears during the final recheck is reused rather than duplicated.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1222,11 +1222,13 @@ or emailed twice.
 
 When every response email is confirmed sent, and before finalizing the Case and
 source Profile Updates, the workflow provisions missing active external Users
-for eligible Contacts. Deployment must set `EXTERNAL_USER_LICENSE_NAME`,
-`EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD`, and
+for eligible Contacts. This profile-update workflow must set
+`EXTERNAL_USER_LICENSE_NAME`, `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD`, and
 `EXTERNAL_USER_ACCOUNT_ELIGIBILITY_VALUE`; set `EXTERNAL_USER_ROLE_ID` only if
-the selected license requires a role. Confirm these organization-specific
-values with the Salesforce administrator.
+the selected license requires a role. The shared provisioning service does not
+apply these Account field/value settings unless its caller explicitly supplies
+that policy, so future workflows can use their own business rule. Confirm these
+organization-specific values with the Salesforce administrator.
 
 The preflight checks Contact/Account relationship, calculated participant
 Profile compatibility with the configured license, the Account eligibility
@@ -1242,8 +1244,9 @@ Profile Updates open for retry. Existing active linked Users are never
 duplicated. User deactivation and username changes are not part of this
 workflow.
 
-Missing or blank required `EXTERNAL_USER_*` settings follow the same audited,
-retryable path. Correct the deployment configuration and rerun the review.
+Missing or blank settings required by this profile-update workflow follow the
+same audited, retryable path. Correct the deployment configuration and rerun
+the review.
 
 `Q` or `Quit` is different from an error or keyboard interruption. It writes a
 `stopped early` audit event, keeps the current Case Pending, leaves that Case's

--- a/src/aisc_salesforce/participant_user_provisioning.py
+++ b/src/aisc_salesforce/participant_user_provisioning.py
@@ -26,8 +26,6 @@ class ExternalUserProvisioningConfig:
     """The organization-specific constraints for an external User license."""
 
     license_name: str
-    account_eligibility_field: str
-    account_eligibility_value: str
     role_id: str | None = None
 
     @classmethod
@@ -38,6 +36,29 @@ class ExternalUserProvisioningConfig:
             "EXTERNAL_USER_LICENSE_NAME": environment.get(
                 "EXTERNAL_USER_LICENSE_NAME", ""
             ).strip(),
+        }
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            raise ProvisioningConfigurationError(
+                "Missing external User provisioning configuration: "
+                + ", ".join(missing)
+            )
+        role_id = environment.get("EXTERNAL_USER_ROLE_ID", "").strip() or None
+        return cls(values["EXTERNAL_USER_LICENSE_NAME"], role_id)
+
+
+@dataclass(frozen=True)
+class AccountEligibilityPolicy:
+    """A caller-owned Account field/value rule for external User creation."""
+
+    field: str
+    value: str
+
+    @classmethod
+    def from_environment(
+        cls, environment: dict[str, str]
+    ) -> AccountEligibilityPolicy:
+        values = {
             "EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD": environment.get(
                 "EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD", ""
             ).strip(),
@@ -51,12 +72,9 @@ class ExternalUserProvisioningConfig:
                 "Missing external User provisioning configuration: "
                 + ", ".join(missing)
             )
-        role_id = environment.get("EXTERNAL_USER_ROLE_ID", "").strip() or None
         return cls(
-            values["EXTERNAL_USER_LICENSE_NAME"],
             values["EXTERNAL_USER_ACCOUNT_ELIGIBILITY_FIELD"],
             values["EXTERNAL_USER_ACCOUNT_ELIGIBILITY_VALUE"],
-            role_id,
         )
 
 
@@ -91,12 +109,17 @@ class ParticipantUserProvisioningService:
         self._planner = UserReconciliationService(client, clock=clock)
 
     def provision(
-        self, contact_ids: set[str], environment: dict[str, str]
+        self,
+        contact_ids: set[str],
+        environment: dict[str, str],
+        *,
+        account_eligibility_policy: AccountEligibilityPolicy | None = None,
     ) -> tuple[ProvisioningOutcome, ...]:
         """Create each eligible missing User, or raise with an actionable blocker.
 
-        A linked active User is a successful no-op.  An ineligible Contact is
-        skipped; it is not an error because it does not require an external User.
+        A linked active User is a successful no-op. A supplied Account policy is
+        applied only to this call; without one, no Account eligibility field is
+        read or enforced.
         """
         try:
             config = ExternalUserProvisioningConfig.from_environment(environment)
@@ -147,7 +170,9 @@ class ParticipantUserProvisioningService:
                     )
                 )
             payload = dict(plan.proposed_create)
-            warning = self._validate_external_requirements(contact_id, payload, config)
+            warning = self._validate_external_requirements(
+                contact_id, payload, config, account_eligibility_policy
+            )
 
             # A concurrent workflow may have created the User while preflight ran.
             active = self.client.query_records(
@@ -182,7 +207,11 @@ class ParticipantUserProvisioningService:
                 ) from error
             outcomes.append(
                 ProvisioningOutcome(
-                    contact_id, "created", user_id=user_id, warning=warning
+                    contact_id,
+                    "created",
+                    f"User {payload['Email']} created",
+                    user_id=user_id,
+                    warning=warning,
                 )
             )
         return tuple(outcomes)
@@ -192,6 +221,7 @@ class ParticipantUserProvisioningService:
         contact_id: str,
         payload: dict[str, Any],
         config: ExternalUserProvisioningConfig,
+        account_eligibility_policy: AccountEligibilityPolicy | None,
     ) -> str:
         contact_rows = self.client.query_records(
             "Contact",
@@ -210,7 +240,15 @@ class ParticipantUserProvisioningService:
             )
         account_rows = self.client.query_records(
             "Account",
-            ["Id", "OwnerId", config.account_eligibility_field],
+            [
+                "Id",
+                "OwnerId",
+                *(
+                    [account_eligibility_policy.field]
+                    if account_eligibility_policy is not None
+                    else []
+                ),
+            ],
             where=f"Id = '{escape_soql_string(account_id)}'",
         )
         account = next(
@@ -220,14 +258,14 @@ class ParticipantUserProvisioningService:
             self._fail(
                 contact_id, "account_not_found", "Contact Account could not be read."
             )
-        if (
-            str(account.get(config.account_eligibility_field) or "").strip()
-            != config.account_eligibility_value
+        if account_eligibility_policy is not None and (
+            str(account.get(account_eligibility_policy.field) or "").strip()
+            != account_eligibility_policy.value
         ):
             self._fail(
                 contact_id,
                 "account_not_eligible",
-                f"Account {config.account_eligibility_field} must be {config.account_eligibility_value!r}.",
+                f"Account {account_eligibility_policy.field} must be {account_eligibility_policy.value!r}.",
             )
         owner_id = str(account.get("OwnerId") or "").strip()
         owners = (

--- a/src/aisc_salesforce/process_profile_updates.py
+++ b/src/aisc_salesforce/process_profile_updates.py
@@ -34,8 +34,10 @@ from .contact_resolution import (
 )
 from .filesystem import sync_directory
 from .participant_user_provisioning import (
+    AccountEligibilityPolicy,
     ParticipantUserProvisioningError,
     ParticipantUserProvisioningService,
+    ProvisioningConfigurationError,
     ProvisioningOutcome,
 )
 from .profile_updates import AutomationCounts, escape_soql_string
@@ -3353,9 +3355,27 @@ class InteractiveProfileUpdateProcessor:
                 "External User provisioning configuration was not provided."
             )
         try:
-            outcomes = self.participant_user_provisioning.provision(
-                contact_ids, self.provisioning_environment
+            account_eligibility_policy = AccountEligibilityPolicy.from_environment(
+                self.provisioning_environment
             )
+            outcomes = self.participant_user_provisioning.provision(
+                contact_ids,
+                self.provisioning_environment,
+                account_eligibility_policy=account_eligibility_policy,
+            )
+        except ProvisioningConfigurationError as error:
+            error = ParticipantUserProvisioningError(
+                ProvisioningOutcome(
+                    "",
+                    "failed",
+                    str(error),
+                    "provisioning_configuration_invalid",
+                )
+            )
+            self._append_provisioning_audit(batch, error.outcome, ActionStatus.FAILED)
+            raise ProcessingError(
+                f"External User provisioning failed: {error.outcome.message}"
+            ) from error
         except ParticipantUserProvisioningError as error:
             self._append_provisioning_audit(batch, error.outcome, ActionStatus.FAILED)
             subject = (
@@ -3373,6 +3393,8 @@ class InteractiveProfileUpdateProcessor:
                 if outcome.action == "created"
                 else ActionStatus.NOOP
             )
+            if outcome.action == "created":
+                self._display_event(Notice(styled(outcome.message)))
             self._append_provisioning_audit(batch, outcome, status)
 
     def _append_provisioning_audit(

--- a/tests/test_participant_user_provisioning.py
+++ b/tests/test_participant_user_provisioning.py
@@ -5,6 +5,7 @@ from datetime import date
 import pytest
 
 from aisc_salesforce.participant_user_provisioning import (
+    AccountEligibilityPolicy,
     ParticipantUserProvisioningError,
     ParticipantUserProvisioningService,
 )
@@ -57,8 +58,10 @@ class Client:
         self.rows = rows or {}
         self.license_error = license_error
         self.created = []
+        self.queries = []
 
     def query_records(self, object_name, fields, *, where=None, order_by=None):
+        self.queries.append((object_name, fields, where))
         if object_name == "UserLicense" and self.license_error:
             raise SalesforceError("not permitted")
         if object_name == "User" and where and not where.startswith("Id ="):
@@ -99,9 +102,14 @@ def service(client):
 
 def test_creates_valid_external_user_payload():
     client = Client(rows=valid_rows())
-    outcomes = service(client).provision({"contact-1"}, ENVIRONMENT)
+    outcomes = service(client).provision(
+        {"contact-1"},
+        ENVIRONMENT,
+        account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
+    )
 
     assert outcomes[0].action == "created"
+    assert outcomes[0].message == "User ada@example.com created"
     assert client.created == [
         ("User", {**dict(planned_create().proposed_create or ()), "IsActive": True})
     ]
@@ -132,7 +140,11 @@ def test_preflight_blockers_are_actionable(object_name, replacement, code):
     rows = valid_rows()
     rows[object_name] = replacement
     with pytest.raises(ParticipantUserProvisioningError, match=".") as error:
-        service(Client(rows=rows)).provision({"contact-1"}, ENVIRONMENT)
+        service(Client(rows=rows)).provision(
+            {"contact-1"},
+            ENVIRONMENT,
+            account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
+        )
     assert error.value.outcome.code == code
 
 
@@ -140,7 +152,11 @@ def test_exhausted_license_blocks_creation():
     rows = valid_rows()
     rows["UserLicense"][0].update(TotalLicenses=2, UsedLicenses=2)
     with pytest.raises(ParticipantUserProvisioningError) as error:
-        service(Client(rows=rows)).provision({"contact-1"}, ENVIRONMENT)
+        service(Client(rows=rows)).provision(
+            {"contact-1"},
+            ENVIRONMENT,
+            account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
+        )
     assert error.value.outcome.code == "license_capacity_exhausted"
 
 
@@ -155,14 +171,20 @@ def test_duplicate_username_blocks_creation():
 
     with pytest.raises(ParticipantUserProvisioningError) as error:
         service(DuplicateClient(rows=valid_rows())).provision(
-            {"contact-1"}, ENVIRONMENT
+            {"contact-1"},
+            ENVIRONMENT,
+            account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
         )
     assert error.value.outcome.code == "username_collision"
 
 
 def test_unqueryable_license_capacity_is_a_warning_not_a_blocker():
     client = Client(rows=valid_rows(), license_error=True)
-    outcome = service(client).provision({"contact-1"}, ENVIRONMENT)[0]
+    outcome = service(client).provision(
+        {"contact-1"},
+        ENVIRONMENT,
+        account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
+    )[0]
     assert outcome.action == "created"
     assert "could not be queried" in outcome.warning
 
@@ -192,6 +214,46 @@ def test_race_recheck_reuses_active_linked_user():
             )
 
     client = RaceClient()
-    outcome = service(client).provision({"contact-1"}, ENVIRONMENT)[0]
+    outcome = service(client).provision(
+        {"contact-1"},
+        ENVIRONMENT,
+        account_eligibility_policy=AccountEligibilityPolicy("Portal_Eligible__c", "Yes"),
+    )[0]
     assert outcome.action == "reused"
     assert client.created == []
+
+
+def test_provisioning_without_a_policy_does_not_read_or_enforce_eligibility():
+    rows = valid_rows()
+    rows["Account"][0]["Portal_Eligible__c"] = "No"
+    client = Client(rows=rows)
+
+    environment = {
+        key: value
+        for key, value in ENVIRONMENT.items()
+        if "ACCOUNT_ELIGIBILITY" not in key
+    }
+    outcome = service(client).provision({"contact-1"}, environment)[0]
+
+    assert outcome.action == "created"
+    account_query = next(
+        fields for object_name, fields, _ in client.queries if object_name == "Account"
+    )
+    assert "Portal_Eligible__c" not in account_query
+
+
+def test_a_caller_supplied_policy_applies_only_to_that_call():
+    rows = valid_rows()
+    rows["Account"][0]["Portal_Eligible__c"] = "No"
+    client = Client(rows=rows)
+    provisioning = service(client)
+    policy = AccountEligibilityPolicy("Portal_Eligible__c", "Yes")
+
+    with pytest.raises(ParticipantUserProvisioningError) as error:
+        provisioning.provision(
+            {"contact-1"}, ENVIRONMENT, account_eligibility_policy=policy
+        )
+    assert error.value.outcome.code == "account_not_eligible"
+
+    outcome = provisioning.provision({"contact-1"}, ENVIRONMENT)[0]
+    assert outcome.action == "created"


### PR DESCRIPTION
## Summary
- Make Account eligibility an optional, caller-supplied provisioning policy.
- Keep Account eligibility configuration required for process-profile-updates.
- Add created-user messaging and tests/documentation for the scoped behavior.

Closes #82