### PR TITLE
Add safe external email proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ profile_updates.csv
 review_queue.json
 review_audit.jsonl
 response_emails.txt
+external_email_attempts.jsonl
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,59 @@ appears during the final recheck is reused rather than duplicated.
 
 ## Commands
 
+### External-email proof of concept
+
+`send-external-email-test` is a standalone proof of concept. It is not part of
+User reconciliation or participant messaging. It accepts exactly these test
+addresses: `boyle@aisc.org`, `mauxboyle@gmail.com`, and
+`maureen7780@yahoo.com`.
+
+Preview is the default and does not load Salesforce credentials or contact
+Salesforce:
+
+```bash
+uv run aisc_salesforce send-external-email-test boyle@aisc.org
+```
+
+The preview (and any send) is only for this fixed wording:
+
+> Subject: `[TEST] AISC external-email proof of concept`
+>
+> This is a test of the AISC external-email proof of concept. No action is
+> required. Please do not reply to this email.
+
+To send it, use the separate explicit flag only after reviewing the preview:
+
+```bash
+uv run aisc_salesforce send-external-email-test boyle@aisc.org --send
+```
+
+Each valid preview or send appends one credential-free JSON Lines record to
+`external_email_attempts.jsonl`. It contains only the UTC timestamp,
+recipient, mode, transport, fixed template ID, and safe outcome (`previewed`,
+`sent`, or `failed`); failures also contain a safe error category. It never
+records credentials or raw Salesforce responses. Choose a different local log
+location with `--log-file PATH`. The default log is ignored by Git, but it
+still identifies recipients and should be handled appropriately.
+
+Before using `--send`, deploy the included Apex endpoint and its test to a
+sandbox with the Salesforce CLI, then run its test:
+
+```bash
+sf project deploy start --source-dir force-app/main/default/classes --target-org YOUR_SANDBOX
+sf apex run test --tests AiscExternalEmailTestEndpointTest --target-org YOUR_SANDBOX --wait 10
+```
+
+The Python client sends only the recipient to that endpoint. The endpoint
+separately enforces the same exact allowlist and fixed content before using
+`Messaging.SingleEmailMessage`. Manually preview first, then send once to one
+approved address and confirm the fixed message and credential-free log record.
+
+Coordinate this POC with Experience Cloud's **Send welcome email** setting.
+Do not enable this POC alongside native welcome notifications for participant
+messaging, or recipients can receive duplicate messages. This remains separate
+from User reconciliation. See Salesforce's [external-user creation guidance](https://help.salesforce.com/s/articleView?id=sf.networks_create_external_users.htm&language=en_US&type=5).
+
 Create a read-only snapshot:
 
 ```bash

--- a/force-app/main/default/classes/AiscExternalEmailTestEndpoint.cls
+++ b/force-app/main/default/classes/AiscExternalEmailTestEndpoint.cls
@@ -1,0 +1,71 @@
+/**
+ * A deliberately narrow REST endpoint for the external-email proof of concept.
+ * It owns both the allowlist and message text; API clients provide only recipient.
+ */
+@RestResource(urlMapping='/aisc-external-email-test')
+global with sharing class AiscExternalEmailTestEndpoint {
+    @TestVisible private static final Set<String> APPROVED_RECIPIENTS = new Set<String>{
+        'boyle@aisc.org',
+        'mauxboyle@gmail.com',
+        'maureen7780@yahoo.com'
+    };
+    @TestVisible private static final String SUBJECT =
+        '[TEST] AISC external-email proof of concept';
+    @TestVisible private static final String BODY =
+        'This is a test of the AISC external-email proof of concept. ' +
+        'No action is required. Please do not reply to this email.';
+
+    global static void doPost() {
+        RestResponse response = RestContext.response;
+        String recipient = recipientFromRequest(RestContext.request);
+        if (recipient == null || !APPROVED_RECIPIENTS.contains(recipient)) {
+            respond(response, 400, 'rejected');
+            return;
+        }
+
+        try {
+            Messaging.SingleEmailMessage message = new Messaging.SingleEmailMessage();
+            message.setToAddresses(new String[]{recipient});
+            message.setSubject(SUBJECT);
+            message.setPlainTextBody(BODY);
+            Messaging.SendEmailResult[] results = Messaging.sendEmail(
+                new Messaging.SingleEmailMessage[]{message}
+            );
+            if (results.size() == 1 && results[0].isSuccess()) {
+                respond(response, 200, 'sent');
+            } else {
+                respond(response, 502, 'failed');
+            }
+        } catch (Exception error) {
+            // Do not expose provider details in this intentionally safe endpoint.
+            respond(response, 500, 'failed');
+        }
+    }
+
+    @TestVisible
+    private static String recipientFromRequest(RestRequest request) {
+        if (request == null || request.requestBody == null) {
+            return null;
+        }
+        try {
+            Object decoded = JSON.deserializeUntyped(request.requestBody.toString());
+            if (!(decoded instanceof Map<String, Object>)) {
+                return null;
+            }
+            Map<String, Object> payload = (Map<String, Object>)decoded;
+            if (payload.size() != 1 || !payload.containsKey('recipient')) {
+                return null;
+            }
+            Object value = payload.get('recipient');
+            return value instanceof String ? (String)value : null;
+        } catch (Exception error) {
+            return null;
+        }
+    }
+
+    private static void respond(RestResponse response, Integer statusCode, String outcome) {
+        response.statusCode = statusCode;
+        response.addHeader('Content-Type', 'application/json');
+        response.responseBody = Blob.valueOf('{"outcome":"' + outcome + '"}');
+    }
+}

--- a/force-app/main/default/classes/AiscExternalEmailTestEndpoint.cls-meta.xml
+++ b/force-app/main/default/classes/AiscExternalEmailTestEndpoint.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AiscExternalEmailTestEndpointTest.cls
+++ b/force-app/main/default/classes/AiscExternalEmailTestEndpointTest.cls
@@ -1,0 +1,56 @@
+@IsTest
+private class AiscExternalEmailTestEndpointTest {
+    private static void setRequest(String body) {
+        RestRequest request = new RestRequest();
+        request.requestUri = '/services/apexrest/aisc-external-email-test';
+        request.httpMethod = 'POST';
+        request.requestBody = Blob.valueOf(body);
+        RestContext.request = request;
+        RestContext.response = new RestResponse();
+    }
+
+    @IsTest
+    static void rejects_non_allowlisted_recipient_without_sending() {
+        setRequest('{"recipient":"person@example.com"}');
+
+        Test.startTest();
+        AiscExternalEmailTestEndpoint.doPost();
+        Test.stopTest();
+
+        System.assertEquals(400, RestContext.response.statusCode);
+        System.assertEquals('{"outcome":"rejected"}', RestContext.response.responseBody.toString());
+        System.assertEquals(0, Limits.getEmailInvocations());
+    }
+
+    @IsTest
+    static void rejects_extra_payload_fields() {
+        setRequest('{"recipient":"boyle@aisc.org","subject":"not allowed"}');
+
+        AiscExternalEmailTestEndpoint.doPost();
+
+        System.assertEquals(400, RestContext.response.statusCode);
+        System.assertEquals(0, Limits.getEmailInvocations());
+    }
+
+    @IsTest
+    static void sends_only_the_fixed_message_for_approved_recipient() {
+        setRequest('{"recipient":"boyle@aisc.org"}');
+
+        Test.startTest();
+        AiscExternalEmailTestEndpoint.doPost();
+        Test.stopTest();
+
+        System.assertEquals(1, Limits.getEmailInvocations());
+        System.assertEquals(200, RestContext.response.statusCode);
+        System.assertEquals(
+            '[TEST] AISC external-email proof of concept',
+            AiscExternalEmailTestEndpoint.SUBJECT
+        );
+        System.assertEquals(
+            'This is a test of the AISC external-email proof of concept. ' +
+            'No action is required. Please do not reply to this email.',
+            AiscExternalEmailTestEndpoint.BODY
+        );
+        System.assertEquals('{"outcome":"sent"}', RestContext.response.responseBody.toString());
+    }
+}

--- a/force-app/main/default/classes/AiscExternalEmailTestEndpointTest.cls-meta.xml
+++ b/force-app/main/default/classes/AiscExternalEmailTestEndpointTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,0 +1,12 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "name": "aisc-sf",
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "60.0"
+}

--- a/src/aisc_salesforce/app.py
+++ b/src/aisc_salesforce/app.py
@@ -17,6 +17,12 @@ from .application_snapshot import (
 from .cli_participant_drop import CLIParticipantDropInteraction
 from .cli_review_ui import CLIReviewUI, ColorMode, print_profile_error
 from .dictionary import DictionaryError, load_export_plan
+from .external_email import (
+    ExternalEmailRecipientError,
+    ExternalEmailService,
+    SalesforceExternalEmailSender,
+    append_attempt_log,
+)
 from .imis_contacts import ContactConsolidationError, consolidate_contactbasic
 from .participant_drop import ParticipantDropAction, ParticipantDropService
 from .participant_user_provisioning import ParticipantUserProvisioningService
@@ -183,6 +189,22 @@ def main(
         "participant-drop",
         help="Interactively record that a participant withdrawal is in progress.",
     )
+    external_email_parser = subparsers.add_parser(
+        "send-external-email-test",
+        help="Preview or explicitly send the fixed external-email test.",
+    )
+    external_email_parser.add_argument("recipient", help="One approved test address.")
+    external_email_parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Send the fixed test email instead of previewing it.",
+    )
+    external_email_parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=Path("external_email_attempts.jsonl"),
+        help="Credential-free JSON Lines attempt log (default: external_email_attempts.jsonl).",
+    )
     args = parser.parse_args(argv)
     if args.command == "snapshot":
         try:
@@ -315,6 +337,52 @@ def main(
         except (SalesforceError, ValueError) as error:
             print(f"Participant drop failed: {error}", file=sys.stderr)
             return 1
+    if args.command == "send-external-email-test":
+        try:
+            return _run_external_email_test(
+                args.recipient,
+                send=args.send,
+                log_file=args.log_file,
+                output_fn=output_fn,
+            )
+        except (ExternalEmailRecipientError, SalesforceError, OSError) as error:
+            print(f"External-email test failed: {error}", file=sys.stderr)
+            return 1
+    return 1
+
+
+def _run_external_email_test(
+    recipient: str,
+    *,
+    send: bool,
+    log_file: Path,
+    output_fn: Callable[[str], None],
+) -> int:
+    """Run the deliberately separate fixed-message email proof of concept."""
+    # Validate before configuration is read or a client can be constructed.
+    ExternalEmailService().attempt(recipient, send=False)
+    if not send:
+        attempt = ExternalEmailService().attempt(recipient, send=False)
+        append_attempt_log(log_file, attempt)
+        output_fn(f"Previewed the fixed test email for {recipient}; no email was sent.")
+        output_fn(f"Subject: {attempt.message.subject}")
+        output_fn(f"Body: {attempt.message.body}")
+        return 0
+
+    _load_dotenv(Path(".env"))
+    environment = dict(os.environ)
+    credentials = get_credentials(environment)
+    auth = request_access_token(credentials, oauth_url=get_oauth_url(environment))
+    sender = SalesforceExternalEmailSender(SalesforceClient(auth))
+    attempt = ExternalEmailService(sender).attempt(recipient, send=True)
+    append_attempt_log(log_file, attempt)
+    if attempt.outcome == "sent":
+        output_fn(f"Sent the fixed test email to {recipient}.")
+        return 0
+    print(
+        "External-email test failed safely; see the credential-free attempt log.",
+        file=sys.stderr,
+    )
     return 1
 
 

--- a/src/aisc_salesforce/external_email.py
+++ b/src/aisc_salesforce/external_email.py
@@ -1,0 +1,137 @@
+"""Safe, fixed-content external-email proof-of-concept support."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from .salesforce import SalesforceError
+
+APPROVED_RECIPIENTS = frozenset(
+    {"boyle@aisc.org", "mauxboyle@gmail.com", "maureen7780@yahoo.com"}
+)
+
+
+@dataclass(frozen=True)
+class FixedTestEmailMessage:
+    """The only email content this proof of concept is permitted to send."""
+
+    template_id: str
+    subject: str
+    body: str
+
+
+FIXED_TEST_MESSAGE = FixedTestEmailMessage(
+    template_id="aisc-external-email-poc-v1",
+    subject="[TEST] AISC external-email proof of concept",
+    body=(
+        "This is a test of the AISC external-email proof of concept. "
+        "No action is required. Please do not reply to this email."
+    ),
+)
+
+
+class EmailSender(Protocol):
+    """A transport that can deliver the one permitted test message."""
+
+    def send(self, recipient: str, message: FixedTestEmailMessage) -> None:
+        """Send the approved fixed message to an approved recipient."""
+
+
+class ExternalEmailRecipientError(ValueError):
+    """The supplied recipient is not one of the explicitly approved addresses."""
+
+
+@dataclass(frozen=True)
+class ExternalEmailAttempt:
+    """A safe summary of a preview or send attempt."""
+
+    recipient: str
+    mode: str
+    transport: str
+    template_id: str
+    outcome: str
+    message: FixedTestEmailMessage
+    error_category: str | None = None
+
+
+class ExternalEmailService:
+    """Validate recipient addresses before previewing or sending anything."""
+
+    def __init__(self, sender: EmailSender | None = None):
+        self.sender = sender
+
+    def attempt(self, recipient: str, *, send: bool) -> ExternalEmailAttempt:
+        """Preview, or explicitly send, the single fixed test email."""
+        if recipient not in APPROVED_RECIPIENTS:
+            raise ExternalEmailRecipientError(
+                "Recipient is not on the approved external-email test allowlist."
+            )
+        if not send:
+            return ExternalEmailAttempt(
+                recipient=recipient,
+                mode="preview",
+                transport="none",
+                template_id=FIXED_TEST_MESSAGE.template_id,
+                outcome="previewed",
+                message=FIXED_TEST_MESSAGE,
+            )
+        if self.sender is None:
+            raise RuntimeError("A sender is required when --send is used.")
+        try:
+            self.sender.send(recipient, FIXED_TEST_MESSAGE)
+        except SalesforceError:
+            return self._failed_attempt(recipient, "salesforce_error")
+        except Exception:
+            return self._failed_attempt(recipient, "sender_error")
+        return ExternalEmailAttempt(
+            recipient=recipient,
+            mode="send",
+            transport="salesforce_apex",
+            template_id=FIXED_TEST_MESSAGE.template_id,
+            outcome="sent",
+            message=FIXED_TEST_MESSAGE,
+        )
+
+    @staticmethod
+    def _failed_attempt(recipient: str, error_category: str) -> ExternalEmailAttempt:
+        return ExternalEmailAttempt(
+            recipient=recipient,
+            mode="send",
+            transport="salesforce_apex",
+            template_id=FIXED_TEST_MESSAGE.template_id,
+            outcome="failed",
+            message=FIXED_TEST_MESSAGE,
+            error_category=error_category,
+        )
+
+
+class SalesforceExternalEmailSender:
+    """Send through Apex, which independently enforces the same limits."""
+
+    def __init__(self, client: object):
+        self.client = client
+
+    def send(self, recipient: str, message: FixedTestEmailMessage) -> None:
+        if message != FIXED_TEST_MESSAGE:
+            raise ValueError("Only the fixed external-email test message is allowed.")
+        self.client.send_external_email_test(recipient)  # type: ignore[attr-defined]
+
+
+def append_attempt_log(path: Path, attempt: ExternalEmailAttempt) -> None:
+    """Append a credential-free JSON Lines record for an approved attempt."""
+    record: dict[str, str] = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "recipient": attempt.recipient,
+        "mode": attempt.mode,
+        "transport": attempt.transport,
+        "template_id": attempt.template_id,
+        "outcome": attempt.outcome,
+    }
+    if attempt.error_category is not None:
+        record["error_category"] = attempt.error_category
+    with path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(record, sort_keys=True) + "\n")

--- a/src/aisc_salesforce/salesforce.py
+++ b/src/aisc_salesforce/salesforce.py
@@ -293,6 +293,24 @@ class SalesforceClient:
             json=payload,
         )
 
+    def send_external_email_test(self, recipient: str) -> None:
+        """Ask the restricted Apex endpoint to send its fixed test email.
+
+        The request deliberately contains only a recipient. Apex owns the
+        allowlist and all email content, so this client cannot supply arbitrary
+        external-email text.
+        """
+        url = (
+            f"{self.auth.instance_url}/services/apexrest/"
+            "aisc-external-email-test"
+        )
+        self._request(
+            "post",
+            url,
+            action="send external-email proof-of-concept test",
+            json={"recipient": recipient},
+        )
+
     def _request(
         self,
         method: str,

--- a/tests/test_external_email.py
+++ b/tests/test_external_email.py
@@ -1,0 +1,127 @@
+import json
+
+import pytest
+
+from aisc_salesforce.external_email import (
+    FIXED_TEST_MESSAGE,
+    ExternalEmailRecipientError,
+    ExternalEmailService,
+    SalesforceExternalEmailSender,
+    append_attempt_log,
+)
+from aisc_salesforce.salesforce import (
+    SalesforceClient,
+    SalesforceError,
+    SalesforceSession,
+)
+
+
+class RecordingSender:
+    def __init__(self):
+        self.calls = []
+
+    def send(self, recipient, message):
+        self.calls.append((recipient, message))
+
+
+def test_preview_uses_fixed_template_without_invoking_sender():
+    sender = RecordingSender()
+
+    result = ExternalEmailService(sender).attempt("boyle@aisc.org", send=False)
+
+    assert result.outcome == "previewed"
+    assert result.message is FIXED_TEST_MESSAGE
+    assert sender.calls == []
+
+
+@pytest.mark.parametrize("recipient", ["BOYLE@AISC.ORG", " boyle@aisc.org ", "person@example.com"])
+def test_only_exact_approved_recipients_are_accepted(recipient):
+    with pytest.raises(ExternalEmailRecipientError):
+        ExternalEmailService().attempt(recipient, send=False)
+
+
+def test_explicit_send_invokes_sender_with_only_fixed_template():
+    sender = RecordingSender()
+
+    result = ExternalEmailService(sender).attempt("mauxboyle@gmail.com", send=True)
+
+    assert result.outcome == "sent"
+    assert sender.calls == [("mauxboyle@gmail.com", FIXED_TEST_MESSAGE)]
+    assert FIXED_TEST_MESSAGE.subject == "[TEST] AISC external-email proof of concept"
+    assert "no action is required" in FIXED_TEST_MESSAGE.body.casefold()
+    assert "do not reply" in FIXED_TEST_MESSAGE.body.casefold()
+
+
+def test_failed_send_has_safe_error_category():
+    class FailingSender:
+        def send(self, recipient, message):
+            raise SalesforceError("access token secret-value was rejected")
+
+    result = ExternalEmailService(FailingSender()).attempt("maureen7780@yahoo.com", send=True)
+
+    assert result.outcome == "failed"
+    assert result.error_category == "salesforce_error"
+
+
+def test_json_lines_log_contains_only_safe_fields(tmp_path):
+    log_file = tmp_path / "attempts.jsonl"
+    result = ExternalEmailService().attempt("boyle@aisc.org", send=False)
+
+    append_attempt_log(log_file, result)
+
+    record = json.loads(log_file.read_text())
+    assert set(record) == {
+        "timestamp",
+        "recipient",
+        "mode",
+        "transport",
+        "template_id",
+        "outcome",
+    }
+    serialized = log_file.read_text().lower()
+    assert "token" not in serialized
+    assert "password" not in serialized
+    assert "api_key" not in serialized
+
+
+def test_salesforce_sender_posts_only_recipient_to_fixed_endpoint():
+    class Client:
+        def __init__(self):
+            self.recipient = None
+
+        def send_external_email_test(self, recipient):
+            self.recipient = recipient
+
+    client = Client()
+    SalesforceExternalEmailSender(client).send("boyle@aisc.org", FIXED_TEST_MESSAGE)
+
+    assert client.recipient == "boyle@aisc.org"
+
+
+def test_salesforce_client_posts_recipient_to_apex_endpoint():
+    calls = []
+
+    class Response:
+        ok = True
+
+    class Session:
+        def post(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return Response()
+
+    client = SalesforceClient(SalesforceSession("https://example.test", "token"), Session())
+    client.send_external_email_test("boyle@aisc.org")
+
+    assert calls == [
+        (
+            "https://example.test/services/apexrest/aisc-external-email-test",
+            {
+                "headers": {
+                    "Authorization": "Bearer token",
+                    "Content-Type": "application/json",
+                },
+                "timeout": 30,
+                "json": {"recipient": "boyle@aisc.org"},
+            },
+        )
+    ]

--- a/tests/test_external_email_cli.py
+++ b/tests/test_external_email_cli.py
@@ -1,0 +1,73 @@
+import json
+
+from aisc_salesforce import app
+
+
+def test_email_command_previews_without_salesforce_setup(monkeypatch, tmp_path):
+    output = []
+    monkeypatch.setattr(
+        app,
+        "_load_dotenv",
+        lambda path: (_ for _ in ()).throw(AssertionError("must not authenticate")),
+    )
+    log_file = tmp_path / "attempts.jsonl"
+
+    assert app.main(["send-external-email-test", "boyle@aisc.org", "--log-file", str(log_file)], output_fn=output.append) == 0
+
+    assert output == [
+        "Previewed the fixed test email for boyle@aisc.org; no email was sent.",
+        "Subject: [TEST] AISC external-email proof of concept",
+        "Body: This is a test of the AISC external-email proof of concept. "
+        "No action is required. Please do not reply to this email.",
+    ]
+    assert json.loads(log_file.read_text())["outcome"] == "previewed"
+
+
+def test_email_command_send_authenticates_and_uses_sender(monkeypatch, tmp_path):
+    output = []
+    calls = []
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app.os, "environ", {"SF_CLIENT_ID": "id", "SF_CLIENT_SECRET": "secret"})
+    monkeypatch.setattr(app, "get_credentials", lambda values: values)
+    monkeypatch.setattr(app, "get_oauth_url", lambda values: "token-url")
+    monkeypatch.setattr(app, "request_access_token", lambda credentials, oauth_url: "auth")
+
+    class Client:
+        def __init__(self, auth):
+            assert auth == "auth"
+
+        def send_external_email_test(self, recipient):
+            calls.append(recipient)
+
+    monkeypatch.setattr(app, "SalesforceClient", Client)
+    log_file = tmp_path / "attempts.jsonl"
+
+    assert app.main(["send-external-email-test", "boyle@aisc.org", "--send", "--log-file", str(log_file)], output_fn=output.append) == 0
+
+    assert calls == ["boyle@aisc.org"]
+    assert output == ["Sent the fixed test email to boyle@aisc.org."]
+    assert json.loads(log_file.read_text())["outcome"] == "sent"
+
+
+def test_email_command_logs_safe_failed_send(monkeypatch, tmp_path):
+    monkeypatch.setattr(app, "_load_dotenv", lambda path: None)
+    monkeypatch.setattr(app.os, "environ", {"SF_CLIENT_ID": "id", "SF_CLIENT_SECRET": "secret"})
+    monkeypatch.setattr(app, "get_credentials", lambda values: values)
+    monkeypatch.setattr(app, "get_oauth_url", lambda values: "token-url")
+    monkeypatch.setattr(app, "request_access_token", lambda credentials, oauth_url: "auth")
+
+    class Client:
+        def __init__(self, auth):
+            pass
+
+        def send_external_email_test(self, recipient):
+            raise app.SalesforceError("provider response with token")
+
+    monkeypatch.setattr(app, "SalesforceClient", Client)
+    log_file = tmp_path / "attempts.jsonl"
+
+    assert app.main(["send-external-email-test", "boyle@aisc.org", "--send", "--log-file", str(log_file)]) == 1
+    record = json.loads(log_file.read_text())
+    assert record["outcome"] == "failed"
+    assert record["error_category"] == "salesforce_error"
+    assert "token" not in log_file.read_text().lower()


### PR DESCRIPTION
## Summary

- Add a deliberately separate `send-external-email-test` proof of concept.
- Restrict the Python client and Apex REST endpoint to three exact test addresses.
- Keep the subject/body fixed in both layers; the API caller supplies only `recipient`.
- Add credential-free JSON Lines attempt logging and focused Python/Apex tests.
- Add the Salesforce DX project configuration needed for CLI deployment.

Closes #84

## Important status: unfinished and not org-tested

This is intentionally a proof of concept, not a production participant-messaging feature.

The Python implementation and tests are complete locally: `uv run pytest` passes all 563 tests. However, the Apex endpoint has **not** been successfully deployed or exercised in the AISC org. The first deployment attempt reached `boyle@aisc.org` but Salesforce rejected both classes with `Not available for deploy for this organization` before compilation or tests ran. The org is Unlimited Edition, so the likely remaining issue is the deployment user’s permissions or an org-specific restriction; this still needs confirmation by the main administrator.

Do not use `--send` until the Apex endpoint is deployed and the administrator has reviewed it. Preview remains local and does not contact Salesforce.

## Administrator review / next steps

1. Review `AiscExternalEmailTestEndpoint.cls` and `AiscExternalEmailTestEndpointTest.cls`.
2. Confirm the deployment user has the required Metadata API permissions, especially `Author Apex` or `Modify Metadata Through Metadata API Functions`, plus the permissions required to deploy Apex.
3. Prefer deployment by the administrator (or a time-limited permission set) to a sandbox first; do not grant permanent broad access solely for this POC.
4. Deploy with Salesforce CLI and run `AiscExternalEmailTestEndpointTest`.
5. Verify that one approved recipient receives exactly the fixed test message and that invalid recipients/extra request fields are rejected.
6. Review Setup Audit Trail and the local `external_email_attempts.jsonl` record.
7. Use a dedicated, least-privileged OAuth integration user for endpoint calls.
8. Coordinate with Experience Cloud’s **Send welcome email** setting to avoid duplicate participant notifications.
9. Decide separately whether this should ever move beyond the POC; it currently has no production rollout, monitoring, rate limiting, or participant-messaging integration.

## Commands after administrator approval

```bash
sf project deploy start --source-dir force-app --target-org aisc-org
sf apex run test --tests AiscExternalEmailTestEndpointTest --target-org aisc-org --wait 10
uv run aisc_salesforce send-external-email-test boyle@aisc.org
uv run aisc_salesforce send-external-email-test boyle@aisc.org --send
```

The final command must not be run until the preview, deployment, test, and administrator review are complete.
